### PR TITLE
Delete link to section that no longer exists

### DIFF
--- a/articles/storage-python-how-to-use-blob-storage.md
+++ b/articles/storage-python-how-to-use-blob-storage.md
@@ -19,7 +19,6 @@ see the [Next Steps][] section.
  [How To: List the Blobs in a Container][]   
  [How To: Download Blobs][]   
  [How To: Delete a Blob][]   
- [How To: Upload and Download Large Blobs][]   
  [Next Steps][]
 
 [WACOM.INCLUDE [howto-blob-storage](../includes/howto-blob-storage.md)]


### PR DESCRIPTION
The section was removed in commit 132a37e00896da4dbeca7dba3775414ca709ef04, but the link to that section wasn't.