### PR TITLE
Update virtual-machines-linux-how-to-log-on.md

### DIFF
--- a/articles/virtual-machines-linux-how-to-log-on.md
+++ b/articles/virtual-machines-linux-how-to-log-on.md
@@ -28,7 +28,7 @@ This procedure shows you how to use the PuTTY program to access the virtual mach
 
 	![Open PuTTY](./media/virtual-machines-linux-how-to-log-on/putty.png)
 
-4. Log on to the virtual machine using the account that you specified when the machine was created. The user name is azureuser by default.
+4. Log on to the virtual machine using the account that you specified when the machine was created. For more details on how to create a virtual machine with user name and password, see [Create a Virtual Machine Running Linux](http://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-tutorial/). 
 
 	![Log on to the virtual machine](./media/virtual-machines-linux-how-to-log-on/sshlogin.png)
 


### PR DESCRIPTION
Removing the reference to azureuser, no longer the default on the new preview portal. Also, the steps to create a new Linux VM doesn't talk about azureuser. Adding a link to the create VM page.