### PR TITLE
Removed manifest editing section for ADAL SSO Auth

### DIFF
--- a/articles/mobile-services-dotnet-backend-ios-adal-sso-authentication.md
+++ b/articles/mobile-services-dotnet-backend-ios-adal-sso-authentication.md
@@ -28,8 +28,6 @@ This tutorial requires the following:
 * Microsoft Azure Mobile Services SDK
 * The [Active Directory Authentication Library for iOS]
 
-[WACOM.INCLUDE [mobile-services-dotnet-adal-register-service](../includes/mobile-services-dotnet-adal-register-service.md)]
-
 [WACOM.INCLUDE [mobile-services-dotnet-adal-register-client](../includes/mobile-services-dotnet-adal-register-client.md)]
 
 ## <a name="require-authentication"></a>Configure the mobile service to require authentication


### PR DESCRIPTION
I noticed now in the Azure portal, the manifest is created automatically with the requirements as listed in this step when you create a web app/api. Thus no download-edit-upload is required to allow access from the client app.