### PR TITLE
Update web-sites-java-custom-upload.md

### DIFF
--- a/articles/web-sites-java-custom-upload.md
+++ b/articles/web-sites-java-custom-upload.md
@@ -17,7 +17,7 @@ The following describes the settings expected for custom Java websites on Azure.
 - All listen ports other than the single HTTP listener should be disabled.  In Tomcat, that includes the shutdown, HTTPS, and AJP ports.
 - The container needs to be configured for IPv4 traffic only.
 - The **startup** command for the application needs to be set in the configuration.
-- Applications that require directories with write permission need to be located in the Azure website's content directory,  which is **D:\home**.
+- Applications that require directories with write permission need to be located in the Azure website's content directory,  which is **D:\home**.  The environmental variable `HOME` refers to D:\home.  
 
 You can set environment variables as required in the web.config file.
 
@@ -29,11 +29,11 @@ The following information describes the **httpPlatform** format within web.confi
 
 Examples (shown with **processPath** included):
 
-    processPath="d:\home\site\wwwroot\bin\tomcat\bin\catalina.bat"
+    processPath="%HOME%\site\wwwroot\bin\tomcat\bin\catalina.bat"
     arguments="start"
     
     processPath="%JAVA_HOME\bin\java.exe"
-    arguments="-Djava.net.preferIPv4Stack=true -Djetty.port=%HTTP\_PLATFORM\_PORT% -Djetty.base=&quot;d:\home\site\wwwroot\bin\jetty-distribution-9.1.0.v20131115&quot; -jar &quot;d:\home\site\wwwroot\bin\jetty-distribution-9.1.0.v20131115\start.jar&quot;"
+    arguments="-Djava.net.preferIPv4Stack=true -Djetty.port=%HTTP\_PLATFORM\_PORT% -Djetty.base=&quot;%HOME%\site\wwwroot\bin\jetty-distribution-9.1.0.v20131115&quot; -jar &quot;%HOME%\site\wwwroot\bin\jetty-distribution-9.1.0.v20131115\start.jar&quot;"
 
 
 **processPath** - Path to the executable or script that will launch a process listening for HTTP requests.
@@ -44,9 +44,9 @@ Examples:
 
     processPath="%JAVA_HOME%\bin\java.exe"
 
-    processPath="d:\home\site\wwwroot\bin\tomcat\bin\startup.bat"
+    processPath="%HOME%\site\wwwroot\bin\tomcat\bin\startup.bat"
 
-    processPath="d:\home\site\wwwroot\bin\tomcat\bin\catalina.bat"
+    processPath="%HOME%\site\wwwroot\bin\tomcat\bin\catalina.bat"
                                                                                        
 **rapidFailsPerMinute** (Default=10.) Number of times the process specified in **processPath** is allowed to crash per minute. If this limit is exceeded, **HttpPlatformHandler** will stop launching the process for the remainder of the minute.
                                     
@@ -79,12 +79,12 @@ While there are two variations on Tomcat that are supplied with Azure Websites, 
 	    <handlers>
 	      <add name="httpPlatformHandler" path="*" verb="*" modules="httpPlatformHandler" resourceType="Unspecified" />
 	    </handlers>
-	    <httpPlatform processPath="d:\home\site\wwwroot\bin\tomcat\bin\startup.bat" 
+	    <httpPlatform processPath="%HOME%\site\wwwroot\bin\tomcat\bin\startup.bat" 
 	        arguments="">
 	      <environmentVariables>
 	        <environmentVariable name="CATALINA_OPTS" value="-Dport.http=%HTTP_PLATFORM_PORT%" />
-	        <environmentVariable name="CATALINA_HOME" value="d:\home\site\wwwroot\bin\tomcat" />
-	        <environmentVariable name="JRE_HOME" value="d:\home\site\wwwroot\bin\java" /> <!-- optional, if not specified, this will default to %programfiles%\Java -->
+	        <environmentVariable name="CATALINA_HOME" value="%HOME%\site\wwwroot\bin\tomcat" />
+	        <environmentVariable name="JRE_HOME" value="%HOME%\site\wwwroot\bin\java" /> <!-- optional, if not specified, this will default to %programfiles%\Java -->
 	        <environmentVariable name="JAVA_OPTS" value="-Djava.net.preferIPv4Stack=true" />
 	      </environmentVariables>
 	    </httpPlatform>
@@ -112,7 +112,7 @@ As is the case for Tomcat, customers can upload their own instances for Jetty. I
 	      <add name="httppPlatformHandler" path="*" verb="*" modules="httpPlatformHandler" resourceType="Unspecified" />
 	    </handlers>
 	    <httpPlatform processPath="%JAVA_HOME%\bin\java.exe" 
-	         arguments="-Djava.net.preferIPv4Stack=true -Djetty.port=%HTTP_PLATFORM_PORT% -Djetty.base=&quot;d:\home\site\wwwroot\bin\jetty-distribution-9.1.0.v20131115&quot; -jar &quot;d:\home\site\wwwroot\bin\jetty-distribution-9.1.0.v20131115\start.jar&quot;"
+	         arguments="-Djava.net.preferIPv4Stack=true -Djetty.port=%HTTP_PLATFORM_PORT% -Djetty.base=&quot;%HOME%\site\wwwroot\bin\jetty-distribution-9.1.0.v20131115&quot; -jar &quot;%HOME%\site\wwwroot\bin\jetty-distribution-9.1.0.v20131115\start.jar&quot;"
 	        startupTimeLimit="20"
 		  startupRetryCount="10"
 		  stdoutLogEnabled="true">
@@ -142,9 +142,9 @@ Our test used the Hudson 3.1.2 war and the default Tomcat 7.0.50 instance but wi
 		startupRetryCount="10">
 		<environmentVariables>
 		  <environmentVariable name="HUDSON_HOME" 
-		value="d:\home\site\wwwroot\hudson_home" />
+		value="%HOME%\site\wwwroot\hudson_home" />
 		  <environmentVariable name="JAVA_OPTS" 
-		value="-Djava.net.preferIPv4Stack=true -Duser.home=d:/home/site/wwwroot/user_home -Dhudson.DNSMultiCast.disabled=true" />
+		value="-Djava.net.preferIPv4Stack=true -Duser.home=%HOME%/site/wwwroot/user_home -Dhudson.DNSMultiCast.disabled=true" />
 		</environmentVariables>            
 		    </httpPlatform>
 		  </system.webServer>
@@ -184,7 +184,7 @@ Using Liferay 6.1.2 Community Edition GA3 bundled with Tomcat, the following fil
 
 In the **liferay\tomcat-7.0.40\webapps\ROOT\WEB-INF\classes** folder, create a file named **portal-ext.properties**. This file needs to contain one line, as shown here:
 
-    liferay.home=d:/home/site/wwwroot/liferay
+    liferay.home=%HOME%/site/wwwroot/liferay
 
 At the same directory level as the tomcat-7.0.40 folder, create a file named **web.config** with the following content:
 
@@ -195,14 +195,14 @@ At the same directory level as the tomcat-7.0.40 folder, create a file named **w
 	<add name="httpPlatformHandler" path="*" verb="*"
 	     modules="httpPlatformHandler" resourceType="Unspecified" />
 	    </handlers>
-	    <httpPlatform processPath="d:\home\site\wwwroot\tomcat-7.0.40\bin\catalina.bat" 
+	    <httpPlatform processPath="%HOME%\site\wwwroot\tomcat-7.0.40\bin\catalina.bat" 
 	                  arguments="run" 
 	                  startupTimeLimit="10" 
 	                  requestTimeout="00:10:00" 
 	                  stdoutLogEnabled="true">
 	      <environmentVariables>
 	  <environmentVariable name="CATALINA_OPTS" value="-Dport.http=%HTTP_PLATFORM_PORT%" />
-	  <environmentVariable name="CATALINA_HOME" value="d:\home\site\wwwroot\tomcat-7.0.40" />
+	  <environmentVariable name="CATALINA_HOME" value="%HOME%\site\wwwroot\tomcat-7.0.40" />
 	        <environmentVariable name="JRE_HOME" value="D:\Program Files\Java\jdk1.7.0_51" /> 
 	        <environmentVariable name="JAVA_OPTS" value="-Djava.net.preferIPv4Stack=true" />
 	      </environmentVariables>


### PR DESCRIPTION
In an attempt to improve documentation/examples such that they will work with Azure Pack websites as well we need to change the references to D:\home to %HOME%.  In Azure Pack the drive location is C:\home.  In the event there is a need to find the feature owner to approve, I'm the PM for both the Java feature and Azure Pack Websites and I approve of myself making these changes. :-)
Chris Compy