### PR TITLE
Added note re: partitioned queues and AMQP

### DIFF
--- a/articles/service-bus-java-how-to-use-jms-api-amqp.md
+++ b/articles/service-bus-java-how-to-use-jms-api-amqp.md
@@ -19,7 +19,7 @@ This how-to guide explains how to use the Service Bus brokered messaging feature
 
 This guide assumes that you already have a Service Bus namespace containing a queue named "queue1." If you do not, then you can create the namespace and queue using the [Azure Management Portal](http://manage.windowsazure.com). For more information about how to create Service Bus namespaces and queues, see the How-To Guide titled [How to Use Service Bus Queues](https://www.windowsazure.com/en-us/develop/net/how-to-guides/service-bus-queues/).
 
-**Note**: You must create the queue with partitioning disabled as partitioned queues and topics do not yet have AMQP support. For additional information, see [Partitioning Messaging Entities](https://msdn.microsoft.com/en-us/library/azure/dn520246.aspx).
+**Note**: You must create the queue with partitioning disabled as partitioned queues and topics do not yet have AMQP support. For additional information, see [Partitioning Messaging Entities](http://msdn.microsoft.com/library/azure/dn520246.aspx).
 
 ##Downloading the AMQP 1.0 JMS client library
 

--- a/articles/service-bus-java-how-to-use-jms-api-amqp.md
+++ b/articles/service-bus-java-how-to-use-jms-api-amqp.md
@@ -19,6 +19,8 @@ This how-to guide explains how to use the Service Bus brokered messaging feature
 
 This guide assumes that you already have a Service Bus namespace containing a queue named "queue1." If you do not, then you can create the namespace and queue using the [Azure Management Portal](http://manage.windowsazure.com). For more information about how to create Service Bus namespaces and queues, see the How-To Guide titled [How to Use Service Bus Queues](https://www.windowsazure.com/en-us/develop/net/how-to-guides/service-bus-queues/).
 
+**Note**: You must create the queue with partitioning disabled as partitioned queues and topics do not yet have AMQP support. For additional information, see [Partitioning Messaging Entities](https://msdn.microsoft.com/en-us/library/azure/dn520246.aspx).
+
 ##Downloading the AMQP 1.0 JMS client library
 
 For information about where to download the latest version of the Apache Qpid JMS AMQP 1.0 client library, visit [http://people.apache.org/~rgodfrey/qpid-java-amqp-1-0-client-jms.html](http://people.apache.org/~rgodfrey/qpid-java-amqp-1-0-client-jms.html).


### PR DESCRIPTION
Since queues are created with partitioning enabled by default now and partitioned queues are not supported with AMQP, this is a common source of errors for people following this tutorial.