### PR TITLE
Update grep target file for broader compatibility

### DIFF
--- a/articles/virtual-machines-linux-how-to-attach-disk.md
+++ b/articles/virtual-machines-linux-how-to-attach-disk.md
@@ -25,7 +25,7 @@ You can attach both empty disks and disks that contain data. In both cases, the 
 
 2. In the SSH window, type the following command, and then enter the password for the account that you created to manage the virtual machine:
 
-		# sudo grep SCSI /var/log/messages
+		# sudo grep SCSI /var/log/syslog
 
 	You can find the identifier of the last data disk that was added in the messages that are displayed.
 

--- a/articles/virtual-machines-linux-how-to-attach-disk.md
+++ b/articles/virtual-machines-linux-how-to-attach-disk.md
@@ -25,7 +25,10 @@ You can attach both empty disks and disks that contain data. In both cases, the 
 
 2. In the SSH window, type the following command, and then enter the password for the account that you created to manage the virtual machine:
 
-		# sudo grep SCSI /var/log/syslog
+		# sudo grep SCSI /var/log/messages
+
+	>[AZURE.NOTE] For recent Ubuntu distributions you may need to use `sudo grep SCSI /var/log/syslog` as logging to `/var/log/messages` may be disabled by default. 
+
 
 	You can find the identifier of the last data disk that was added in the messages that are displayed.
 


### PR DESCRIPTION
By default all messages logged to `/var/log/messages` are also logged to `/var/log/syslog`. Recent versions of Ubuntu no longer log by default to `/var/log/messages.` By changing the target of the grep search to `/var/log/syslog` the instructions achieve broader compatibility, including vanilla installations of Ubuntu on Azure.