### PR TITLE
Edit machine-learning-walkthrough-6-access-web-service.md

### DIFF
--- a/articles/machine-learning-walkthrough-6-access-web-service.md
+++ b/articles/machine-learning-walkthrough-6-access-web-service.md
@@ -40,12 +40,12 @@ This is the last step of the walkthrough, [Developing a Predictive Solution with
 
 # Step 6: Access the Azure Machine Learning web service
 
-To be useful as a web service, users need to be able to send data to the service and receive results. The web service is an Azure web service which can receive and return data in one of two ways:  
+For a web service to be useful, users need to be able to send data to it and receive results. The web service is an Azure web service that can receive and return data in one of two ways:  
 
--	**Request/Response** - The user sends a single set of credit data to the service using an HTTP protocol, and the service responds with a single set of results.
--	**Batch Execution** - The user sends to the service the URL of an Azure BLOB which contains one or more rows of credit data. The service stores the results in another BLOB and returns the URL of that container.  
+-	**Request/Response** - The user sends a single set of credit data to the service by using an HTTP protocol, and the service responds with a single set of results.
+-	**Batch Execution** - The user sends to the service the URL of an Azure blob that contains one or more rows of credit data. The service stores the results in another blob and returns the URL of that container.  
 
-On the **DASHBOARD** tab for the web service, there are two links to information that will help a developer write code to access this service. Click the **API help page** link on the **REQUEST/RESPONSE** row and a page opens that contains sample code to use the service's request/response protocol. Similarly, the link on the **BATCH EXECUTION** row provides example code for making a batch request to the service.  
+On the **DASHBOARD** tab for the web service, there are two links to information that will help a developer write code to access this service. Click the **API help page** link on the **REQUEST/RESPONSE** row, and a page opens that contains sample code to use the service's request/response protocol. Similarly, the link on the **BATCH EXECUTION** row provides example code for making a batch request to the service.  
 
 The API help page includes samples for R, C#, and Python programming languages. For example, here is the R code that you could use to access the web service we published (the actual service URL would be displayed in your sample code):  
 


### PR DESCRIPTION
In the sentence "The user sends a single set of credit data to the service by using an HTTP protocol" (line 45), it looks like "using an HTTP protocol" should be changed to "using HTTP"--or maybe the word "protocol" should be changed to something else. The reason is that the "P" in HTTP stands for "Protocol," so "HTTP protocol" might be redundant unless there's a technical reason for using it.

Also, this topic uses both "sample" and "example" to refer to code. It's better to use one term consistently, unless there's a reason for using both (that is, there's a distinction that depends on the context).
