### PR TITLE
Edit machine-learning-walkthrough-4-train-and-evaluate-models.md

### DIFF
--- a/articles/machine-learning-walkthrough-4-train-and-evaluate-models.md
+++ b/articles/machine-learning-walkthrough-4-train-and-evaluate-models.md
@@ -51,10 +51,10 @@ First, let's set up the boosted decision tree model:
 2.	Find the **Train Model** module, drag it onto the canvas, and then connect the output of the boosted decision tree module to the left input port ("Untrained model") of the **Train Model** module.
 3.	Connect the output of the left **Execute R Script** module to the right input port ("Dataset") of the **Train Model** module.
 
-	>Tip - We don't need two of the inputs and one of the outputs of the **Execute R Script** module for this experiment, so we'll just leave them unattached. This is not uncommon for some modules.
+	>**Tip**: We don't need two of the inputs and one of the outputs of the **Execute R Script** module for this experiment, so we'll just leave them unattached. This is not uncommon for some modules.
 
 
-4.	Select the **Train Model** module. In the **Properties** pane, click **Launch column selector**, select "Include" in the first dropdown, select "column indices" in the second dropdown, and enter "21" in the text field (you can also select "Column name" and enter "Credit risk"). This identifies column 21, the credit risk value, as the column for the model to predict.
+4.	Select the **Train Model** module. In the **Properties** pane, click **Launch column selector**, select **Include** in the first dropdown, select **column indices** in the second dropdown, and enter "21" in the text field (you can also select **Column name** and enter "Credit Risk"). This identifies column 21, the credit risk value, as the column for the model to predict.
 
 
 This portion of the experiment now looks something like this:  
@@ -63,21 +63,21 @@ This portion of the experiment now looks something like this:
  
 Next, we'll set up the SVM model.  
 
-Boosted Decision Trees work well with features of any type. However, since the SVM module generates a linear classifier, the model that it generates has the best test error when all numeric features have the same scale. To convert all numeric features to the same scale we use the **Normalize Data** module with a Tanh transformation, which transforms features into the [0,1] range. Note that string features are converted by the SVM module to categorical features and then to binary 0/1 features, so we don't need to manually transform string features. Also, we don't want to transform the Credit Risk column (column 21) - it's numeric, but it's the value we're training the model to predict so we need to leave it alone.  
+Boosted decision trees work well with features of any type. However, since the SVM module generates a linear classifier, the model that it generates has the best test error when all numeric features have the same scale. To convert all numeric features to the same scale, we use the **Normalize Data** module with a Tanh transformation, which transforms features into the [0,1] range. Note that string features are converted by the SVM module to categorical features and then to binary 0/1 features, so we don't need to manually transform string features. Also, we don't want to transform the Credit Risk column (column 21) - it's numeric, but it's the value we're training the model to predict, so we need to leave it alone.  
 
 1.	Find the **Two-Class Support Vector Machine** module in the module palette and drag it onto the canvas.
-2.	Right-click the **Train Model** module, select **Copy**, then right-click the canvas and select **Paste**. Note that the copy of the **Train Model** module has the same column selection as the original.
+2.	Right-click the **Train Model** module, select **Copy**, and then right-click the canvas and select **Paste**. Note that the copy of the **Train Model** module has the same column selection as the original.
 3.	Connect the output of the SVM module to the left input port ("Untrained model") of the **Train Model** module.
 4.	Find the **Normalize Data** module and drag it onto the canvas.
 5.	Connect the input of this transform module to the output of the left **Execute R Script** module.
 6.	Connect the left output port ("Transformed Dataset") of the transform module to the right input port ("Dataset") of the **Train Model** module.
-7.	In the **Properties** pane for the transform module, select "Tanh" for the **Transformation method** parameter.
-8.	Click **Launch column selector**, select "Include" in the first dropdown, select "column type" in the second dropdown, and select "Numeric" in the third dropdown. This specifies that all the numeric columns (and only numeric) will be transformed.
-9.	Click the plus sign (+), which creates a new row of dropdowns. Select "Exclude" in the first dropdown, select "column indices" in the second dropdown, and enter "21" in the text field. This specifies that column 21 (the "Credit risk" column) will be ignored.
+7.	In the **Properties** pane for the transform module, select **Tanh** for the **Transformation method** parameter.
+8.	Click **Launch column selector**, select **Include** in the first dropdown, select **column type** in the second dropdown, and select **Numeric** in the third dropdown. This specifies that all the numeric columns (and only numeric) will be transformed.
+9.	Click the plus sign (+), which creates a new row of dropdowns. Select **Exclude** in the first dropdown, select **column indices** in the second dropdown, and enter "21" in the text field. This specifies that column 21 (the Credit Risk column) will be ignored.
 10.	Click **OK**.  
 
 
-The **Normalize Data** module is now set to perform a tanh transform on all numeric columns except for the Credit Risk column.  
+The **Normalize Data** module is now set to perform a Tanh transformation on all numeric columns except for the Credit Risk column.  
 
 This portion of our experiment should now look something like this:  
 
@@ -91,7 +91,7 @@ We'll use the scoring data that was separated out by the **Split** module to sco
 3.	Connect the right input port of the **Score Model** module to the output of the right **Execute R Script** module. Note that it's okay to have the output of a module go to multiple places.
 4.	Copy and paste the **Score Model** module to create a second copy, or drag a new module onto the canvas.
 5.	Connect the left input port of this module to the SVM model (that is, connect to the output port of the **Train Model** module that's connected to the **Two-Class Support Vector Machine** module).
-6.	For the SVM model, we have to do the same transform to the test data as we did to the training data. So copy and paste the **Normalize Data** module to create a second copy and connect it to the output of the right **Execute R Script** module.
+6.	For the SVM model, we have to do the same transformation to the test data as we did to the training data. So copy and paste the **Normalize Data** module to create a second copy and connect it to the output of the right **Execute R Script** module.
 7.	Connect the right input port of the **Score Model** module to the output of the **Normalize Data** module.  
 
 To evaluate the two scoring results we'll use the **Evaluate Model** module.  
@@ -108,15 +108,15 @@ Click the **RUN** button below the canvas to run the experiment. It may take a f
 
 When all the modules have a check mark, the experiment has finished running. To check the results, right-click the output port of the **Evaluate Model** module and select **Visualize**.  
 
-The **Evaluate Model** module produces a pair of curves and metrics that allow you to compare the results of the two scored models. You can view the results as Receiver Operator Characteristic (ROC) curves, Precision/Recall curves, or Lift curves. Additional data displayed includes a confusion matrix, cumulative AUC values, and other metrics. You can change the threshold value by moving the slider left or right and see how it affects the set of metrics.  
+The **Evaluate Model** module produces a pair of curves and metrics that allow you to compare the results of the two scored models. You can view the results as Receiver Operator Characteristic (ROC) curves, Precision/Recall curves, or Lift curves. Additional data displayed includes a confusion matrix, cumulative values for the area under the curve (AUC), and other metrics. You can change the threshold value by moving the slider left or right and see how it affects the set of metrics.  
 
-Click "Scored dataset" or "Scored dataset to compare" to highlight the associated curve and to display the associated metrics below. In the legend for the curves, "Scored dataset" corresponds to the left input port of the **Evaluate Model** module - in our case, this is the boosted decision tree model. The "Scored dataset to compare" corresponds to the right input port - the SVM model in our case. When you click one of these labels you will highlight the curve for that model and display the corresponding metrics below.  
+Click **Scored dataset** or **Scored dataset to compare** to highlight the associated curve and to display the associated metrics below. In the legend for the curves, "Scored dataset" corresponds to the left input port of the **Evaluate Model** module - in our case, this is the boosted decision tree model. "Scored dataset to compare" corresponds to the right input port - the SVM model in our case. When you click one of these labels you will highlight the curve for that model and display the corresponding metrics below.  
 
 ![ROC curves for models][4]
  
 By examining these values you can decide which model is closest to giving you the results you're looking for. You can go back and iterate on your experiment by changing values in the different models.  
 
->Tip - Each time you run the experiment a record of that iteration is kept in the Run History. You can view these iterations, and return to any of them, by clicking **VIEW RUN HISTORY** below the canvas. You can also click **Prior Run** in the **Properties** pane to return to the iteration immediately preceding the one you have open.  
+>Tip: Each time you run the experiment a record of that iteration is kept in the Run History. You can view these iterations, and return to any of them, by clicking **VIEW RUN HISTORY** below the canvas. You can also click **Prior Run** in the **Properties** pane to return to the iteration immediately preceding the one you have open.  
 
 You can also make a copy of any iteration of your experiment by clicking **SAVE AS** below the canvas. This makes a duplicate of the experiment, creating a new Run History to track your iterations of this version. The new copy is displayed in the **EXPERIMENTS** list alongside the original. This can be helpful if you want to start a new branch of experiment iterations.  
 


### PR DESCRIPTION
Edit complete.

Line 45 in this topic includes this sentence: "For the purposes of this experiment, we'll select the Support Vector Machine (SVM) and the Two-Class Boosted Decision Trees." The term "boosted decision tree" is lowercase everywhere else in the topic, so if "Two-Class Boosted Decision Trees" is meant to be a generic term, it should be lowercase as well. If it's a specific name, title case is fine--but this is the only mention, so please make sure that this sentence is clear and accurate exactly as is.