### PR TITLE
Edit machine-learning-recommendation-api-quick-start-guide.md

### DIFF
--- a/articles/machine-learning-recommendation-api-quick-start-guide.md
+++ b/articles/machine-learning-recommendation-api-quick-start-guide.md
@@ -18,63 +18,63 @@
 
 # Quick start guide for the Machine Learning Recommendations API
 
-This document depicts how to onboard your service or application to use Azure ML Recommendations. 
+This document depicts how to onboard your service or application to use Microsoft Azure Machine Learning Recommendations. 
 
 ##Contents
 
-- [General Overview](#general-overview)
+- [General overview](#general-overview)
 - [Limitations](#limitations)
 - [Integration](#integration)
 	- [Authentication](#authentication)
 	- [Service URI](#service-uri)
-	- [API Version](#api-version)
+	- [API version](#api-version)
 	- [Create a model](#create-a-model)
 	- [Import catalog data](#import-catalog-data)
 	- [Import usage data](#import-usage-data)
 		- [Uploading file](#uploading-file)
 		- [Using data acquisition](#using-data-acquisition)
 	- [Build a recommendation model](#build-a-recommendation-model)
-	- [Get Builds Status of a Model](#get-builds-status-of-a-model)
-	- [Get Recommendations](#get-recommendations)
-	- [Update Model](#update-model)
+	- [Get build status of a model](#get-builds-status-of-a-model)
+	- [Get recommendations](#get-recommendations)
+	- [Update model](#update-model)
 - [Legal](#legal)
 
 
-##General Overview
+##General overview
 
-To use Azure ML Recommendations you need to do the following steps:
+To use Azure Machine Learning Recommendations, you need to take the following steps:
 
-* Create a Model - A model is a container of your usage data, catalog data and the recommendation model.
-* Import catalog data - This is an optional step. A catalog contains meta-data information on the items. If you do not upload catalog data, the recommendations services will learn about your catalog implicitly from the usage data.
+* Create a model - A model is a container of your usage data, catalog data and the recommendation model.
+* Import catalog data - This is an optional step. A catalog contains metadata information on the items. If you do not upload catalog data, the recommendation's services will learn about your catalog implicitly from the usage data.
 * Import usage data - Usage data can be uploaded in one of 2 ways (or both):
 	* By uploading a file that contains the usage data.
-	* By sending Data Acquisition events.
-	Usually you upload a usage file in order to be able to create an initial recommendation model (bootstrap) and use it until the system gathers enough data using the data acquisition format.
-* Build a recommendation model - this is an asynchronous operation in which the recommendation system takes all the usage data and creates a recommendation model. This operation can take several minutes or several hours depending on the size of the data and the build configuration parameters. When triggering the build you will get a build id, use it to check when the build process has ended before starting to consume recommendations.
-* Recommendations consumption - get recommendations for a specific item or list of items.
+	* By sending data acquisition events.
+	Usually you upload a usage file in order to be able to create an initial recommendation model (bootstrap) and use it until the system gathers enough data by using the data acquisition format.
+* Build a recommendation model - This is an asynchronous operation in which the recommendation system takes all the usage data and creates a recommendation model. This operation can take several minutes or several hours depending on the size of the data and the build configuration parameters. When triggering the build, you will get a build ID. Use it to check when the build process has ended before starting to consume recommendations.
+* Consume recommendations - Get recommendations for a specific item or list of items.
 
-All the steps above are done through Azure ML Recommendations API.
+All the steps above are done through the Azure Machine Learning Recommendations API.
 
 ##Limitations
 
-* Maximum number of models per subscription: 10
-* Maximum number of items that a catalog can hold: 100,000
-* The maximum amount of usage points that are kept is ~5,000,000. The oldest will be deleted if new ones will be uploaded or reported.
-* Maximum size of data can be sent in POST (e.g. Import catalog data, import usage data) is 200MB.
-* The number of transactions per second for a recommendation model build that is not active is ~2TPS, only recommendation model build that is active can hold up to 20TPS.
+* The maximum number of models per subscription is 10.
+* The maximum number of items that a catalog can hold is 100,000.
+* The maximum number of usage points that are kept is ~5,000,000. The oldest will be deleted if new ones will be uploaded or reported.
+* The maximum size of data that can be sent in POST (e.g. import catalog data, import usage data) is 200MB.
+* The number of transactions per second for a recommendation model build that is not active is ~2TPS. A recommendation model build that is active can hold up to 20TPS.
 
 ##Integration
 
 ###Authentication
-Please follow the Microsoft Azure Marketplace guidelines regarding authentication. The marketplace supports either Basic or OAuth authentication methods.
+Please follow the Microsoft Azure Marketplace guidelines regarding authentication. The marketplace supports either the Basic or OAuth authentication method.
 
 ###Service URI
-The service root URIs for each of the Azure ML Recommendations APIs is [here.](https://api.datamarket.azure.com/amla/recommendations/v2/)
+The service root URIs for the Azure Machine Learning Recommendations APIs are [here.](https://api.datamarket.azure.com/amla/recommendations/v2/)
 
 The full service URI is expressed using elements of the OData specification.
 
-###API Version
-Each API call will have at the end query parameter called apiVersion that should be set to "1.0".
+###API version
+Each API call will have, at the end, a query parameter called apiVersion that should be set to "1.0".
 
 ###Create a model
 Creating a “create model” request:
@@ -95,7 +95,7 @@ Creating a “create model” request:
 
 HTTP Status code: 200
 
-- `feed/entry/content/properties/id` - contains the model id
+- `feed/entry/content/properties/id` - Contains the model ID.
 
 OData XML
 
@@ -130,7 +130,7 @@ OData XML
 
 ###Import catalog data
 
-If you upload several catalog files to the same model with several calls we will insert only the new catalog items. Existing items will remain with the original values.
+If you upload several catalog files to the same model with several calls, we will insert only the new catalog items. Existing items will remain with the original values.
 
 | HTTP Method | URI |
 |:--------|:--------|
@@ -138,19 +138,19 @@ If you upload several catalog files to the same model with several calls we will
 
 |	Parameter Name	|	Valid Values						|
 |:--------			|:--------								|
-|	modelId	|	The unique identifier of the model.  |
-| filename | Textual identifier of the catalog.<br>Only letters (A-Z, a-z), numbers (0-9), hyphens (-) and underscore (_) are allowed<br>Max length: 50 |
+|	modelId	|	Unique identifier of the model.  |
+| filename | Textual identifier of the catalog.<br>Only letters (A-Z, a-z), numbers (0-9), hyphens (-) and underscore (_) are allowed.<br>Max length: 50 |
 |	apiVersion		| 1.0 |
 |||
-| Request Body | The catalog data. Format:<br>`<Item Id>,<Item Name>,<Item Category>[,<description>]`<br><br><table><tr><th>Name</th><th>Mandatory</th><th>Type</th><th>Description</th></tr><tr><td>Item Id</td><td>Yes</td><td>Alphanumeric, Max Length 50</td><td>Unique identifier of an Item</td></tr><tr><td>Item Name</td><td>Yes</td><td>Alphanumeric, Max Length 255</td><td>The Item Name</td></tr><tr><td>Item Category</td><td>Yes</td><td>Alphanumeric, Max Length 255</td><td>The category to which this item belongs (e.g. Cooking Books, Drama…)</td></tr><tr><td>Description</td><td>No</td><td>Alphanumeric, Max Length 4000</td><td>A description of this item</td></tr></table><br>Maximum file size 200MB<br><br>Example:<br><pre>2406e770-769c-4189-89de-1c9283f93a96,Clara Callan,Book<br>21bf8088-b6c0-4509-870c-e1c7ac78304a,The Forgetting Room: A Fiction (Byzantium Book),Book<br>3bb5cb44-d143-4bdd-a55c-443964bf4b23,Spadework,Book<br>552a1940-21e4-4399-82bb-594b46d7ed54,Restraint of Beasts,Book</pre> |
+| Request Body | Catalog data. Format:<br>`<Item Id>,<Item Name>,<Item Category>[,<description>]`<br><br><table><tr><th>Name</th><th>Mandatory</th><th>Type</th><th>Description</th></tr><tr><td>Item Id</td><td>Yes</td><td>Alphanumeric, max length 50</td><td>Unique identifier of an item</td></tr><tr><td>Item Name</td><td>Yes</td><td>Alphanumeric, max length 255</td><td>Item name</td></tr><tr><td>Item Category</td><td>Yes</td><td>Alphanumeric, max length 255</td><td>Category to which this item belongs (e.g. Cooking Books, Drama…)</td></tr><tr><td>Description</td><td>No</td><td>Alphanumeric, max length 4000</td><td>Description of this item</td></tr></table><br>Maximum file size is 200MB.<br><br>Example:<br><pre>2406e770-769c-4189-89de-1c9283f93a96,Clara Callan,Book<br>21bf8088-b6c0-4509-870c-e1c7ac78304a,The Forgetting Room: A Fiction (Byzantium Book),Book<br>3bb5cb44-d143-4bdd-a55c-443964bf4b23,Spadework,Book<br>552a1940-21e4-4399-82bb-594b46d7ed54,Restraint of Beasts,Book</pre> |
 
 
 **Response**:
 
 HTTP Status code: 200
 
-- `Feed\entry\content\properties\LineCount` - number of lines accepted
-- `Feed\entry\content\properties\ErrorCount` - number of lines that were not inserted due to an error
+- `Feed\entry\content\properties\LineCount` - Number of lines accepted.
+- `Feed\entry\content\properties\ErrorCount` - Number of lines that were not inserted due to an error.
 
 OData XML
 
@@ -178,8 +178,8 @@ OData XML
 
 ###Import usage data
 
-####Uploading file
-This sections shows how to upload usage data using a file. You can call this API several times with usage data. All usage data will be saved for all calls.
+####Uploading a file
+This section shows how to upload usage data by using a file. You can call this API several times with usage data. All usage data will be saved for all calls.
 
 | HTTP Method | URI |
 |:--------|:--------|
@@ -187,19 +187,19 @@ This sections shows how to upload usage data using a file. You can call this API
 
 |	Parameter Name	|	Valid Values						|
 |:--------			|:--------								|
-|	modelId	|	The unique identifier of the model.  |
-| filename | Textual identifier of the catalog.<br>Only letters (A-Z, a-z), numbers (0-9), hyphens (-) and underscore (_) are allowed<br>Max length: 50 |
+|	modelId	|	Unique identifier of the model.  |
+| filename | Textual identifier of the catalog.<br>Only letters (A-Z, a-z), numbers (0-9), hyphens (-) and underscore (_) are allowed.<br>Max length: 50 |
 |	apiVersion		| 1.0 |
 |||
-| Request Body | The usage data. Format:<br>`<User Id>,<Item Id>[,<Time>,<Event>]`<br><br><table><tr><th>Name</th><th>Mandatory</th><th>Type</th><th>Description</th></tr><tr><td>User Id</td><td>Yes</td><td>Alphanumeric</td><td>Unique identifier of a User</td></tr><tr><td>Item Id</td><td>Yes</td><td>Alphanumeric, Max Length 50</td><td>Unique identifier of an Item</td></tr><tr><td>Time</td><td>No</td><td>Date in format: YYYY/MM/DDTHH:MM:SS (e.g. 2013/06/20T10:00:00)</td><td>Time of data</td></tr><tr><td>Event</td><td>No, if supplied then must also put date</td><td>One of the following:<br>• Click<br>• RecommendationClick<br>•	AddShopCart<br>• RemoveShopCart<br>• Purchase</td><td></td></tr></table><br>Maximum file size 200MB<br><br>Example:<br><pre>149452,1b3d95e2-84e4-414c-bb38-be9cf461c347<br>6360,1b3d95e2-84e4-414c-bb38-be9cf461c347<br>50321,1b3d95e2-84e4-414c-bb38-be9cf461c347<br>71285,1b3d95e2-84e4-414c-bb38-be9cf461c347<br>224450,1b3d95e2-84e4-414c-bb38-be9cf461c347<br>236645,1b3d95e2-84e4-414c-bb38-be9cf461c347<br>107951,1b3d95e2-84e4-414c-bb38-be9cf461c347</pre> |
+| Request Body | Usage data. Format:<br>`<User Id>,<Item Id>[,<Time>,<Event>]`<br><br><table><tr><th>Name</th><th>Mandatory</th><th>Type</th><th>Description</th></tr><tr><td>User Id</td><td>Yes</td><td>Alphanumeric</td><td>Unique identifier of a user</td></tr><tr><td>Item Id</td><td>Yes</td><td>Alphanumeric, max length 50</td><td>Unique identifier of an item</td></tr><tr><td>Time</td><td>No</td><td>Date in format: YYYY/MM/DDTHH:MM:SS (e.g. 2013/06/20T10:00:00)</td><td>Time of data</td></tr><tr><td>Event</td><td>No, if supplied then must also put date</td><td>One of the following:<br>• Click<br>• RecommendationClick<br>•	AddShopCart<br>• RemoveShopCart<br>• Purchase</td><td></td></tr></table><br>Maximum file size is 200MB.<br><br>Example:<br><pre>149452,1b3d95e2-84e4-414c-bb38-be9cf461c347<br>6360,1b3d95e2-84e4-414c-bb38-be9cf461c347<br>50321,1b3d95e2-84e4-414c-bb38-be9cf461c347<br>71285,1b3d95e2-84e4-414c-bb38-be9cf461c347<br>224450,1b3d95e2-84e4-414c-bb38-be9cf461c347<br>236645,1b3d95e2-84e4-414c-bb38-be9cf461c347<br>107951,1b3d95e2-84e4-414c-bb38-be9cf461c347</pre> |
 
 **Response**:
 
 HTTP Status code: 200
 
-- `Feed\entry\content\properties\LineCount` - number of lines accepted
-- `Feed\entry\content\properties\ErrorCount` - number of lines that were not inserted due to an error
-- `Feed\entry\content\properties\FileId` - the file identifier
+- `Feed\entry\content\properties\LineCount` - Number of lines accepted.
+- `Feed\entry\content\properties\ErrorCount` - Number of lines that were not inserted due to an error.
+- `Feed\entry\content\properties\FileId` - File identifier.
 
 
 OData XML
@@ -228,7 +228,7 @@ OData XML
 
 
 ####Using data acquisition
-This section shows how to send events in real time to Azure ML Recommendations usually from your web site.
+This section shows how to send events in real time to Azure Machine Learning Recommendations, usually from your website.
 
 | HTTP Method | URI |
 |:--------|:--------|
@@ -238,7 +238,7 @@ This section shows how to send events in real time to Azure ML Recommendations u
 |:--------			|:--------								|
 |	apiVersion		| 1.0 |
 |||
-|Request body| Event data entry for each event you want to send. You should send for the same user or browser session the same id in the SessionId field. (see sample of event body below)|
+|Request body| Event data entry for each event you want to send. You should send for the same user or browser session the same ID in the SessionId field. (See sample of event body below.)|
 
 
 - Example for event 'Click':
@@ -254,7 +254,7 @@ This section shows how to send events in real time to Azure ML Recommendations u
 		</EventData>
 		</Event>
 
-- Example for event 'Recommendation Click':
+- Example for event 'RecommendationClick':
 
 		<Event xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   		<ModelId>2779c063-48fb-46c1-bae3-74acddc8c1d1</ModelId>
@@ -267,7 +267,7 @@ This section shows how to send events in real time to Azure ML Recommendations u
   		</EventData>
 		</Event>
 
-- Example for event 'Adding to shop cart':
+- Example for event 'AddShopCart':
 
 		<Event xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   		<ModelId>2779c063-48fb-46c1-bae3-74acddc8c1d1</ModelId>
@@ -280,7 +280,7 @@ This section shows how to send events in real time to Azure ML Recommendations u
   		</EventData>
 		</Event>
 
-- Example for event 'Removing from shop cart':
+- Example for event 'RemoveShopCart':
 
 		<Event xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   		<ModelId>2779c063-48fb-46c1-bae3-74acddc8c1d1</ModelId>
@@ -310,7 +310,7 @@ This section shows how to send events in real time to Azure ML Recommendations u
 		</EventData>
 		</Event>
 
-- Example sending 2 events 'Click' and 'AddShopCart':
+- Example sending 2 events, 'Click' and 'AddShopCart':
 
 		<Event xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   		<ModelId>2779c063-48fb-46c1-bae3-74acddc8c1d1</ModelId>
@@ -341,7 +341,7 @@ HTTP Status code: 200
 
 |	Parameter Name	|	Valid Values						|
 |:--------			|:--------								|
-| modelId |	The unique identifier of the model.  |
+| modelId |	Unique identifier of the model.  |
 | userDescription | Textual identifier of the catalog. Note that if you use spaces you must encode it with %20 instead. See example above.<br>Max length: 50 |
 | apiVersion | 1.0 |
 |||
@@ -351,22 +351,22 @@ HTTP Status code: 200
 
 HTTP Status code: 200
 
-This is an asynchronous API. You will get a Build Id as a response. To know when the build has ended, you should call the “Get Builds Status of a Model” API and locate this build Id in the response. Note that a build can take from minutes to hours depending on the size of the data.
+This is an asynchronous API. You will get a build ID as a response. To know when the build has ended, you should call the “Get Builds Status of a Model” API and locate this build ID in the response. Note that a build can take from minutes to hours depending on the size of the data.
 
 You cannot consume recommendations till the build ends.
 
 Valid build status:
 
-- Create – model was created
-- Queued – model build was triggered and it is queued
-- Building – the model is being build
-- Success – the build ended successfully
-- Error – the build ended with a failure
-- Cancelled – build was canceled
-- Cancelling – build is being cancelled
+- Create – Model was created.
+- Queued – Model build was triggered and it is queued.
+- Building – Model is being built.
+- Success – Build ended successfully.
+- Error – Build ended with a failure.
+- Cancelled – Build was canceled.
+- Cancelling – Build is being canceled.
 
 
-Note: the build id can be found under the path: `Feed\entry\content\properties\Id`
+Note that the build ID can be found under the following path: `Feed\entry\content\properties\Id`
 
 OData XML
 
@@ -407,7 +407,7 @@ OData XML
   	</entry>
 	</feed>
 
-###Get Builds Status of a Model
+###Get build status of a model
 
 | HTTP Method | URI |
 |:--------|:--------|
@@ -417,7 +417,7 @@ OData XML
 
 |	Parameter Name	|	Valid Values						|
 |:--------			|:--------								|
-|	modelId			|	The unique identifier of the model.	|
+|	modelId			|	Unique identifier of the model.	|
 |	onlyLastBuild	|	Indicates whether to return all the build history of the model or only the status of the most recent build.	|
 |	apiVersion		|	1.0									|
 
@@ -426,34 +426,34 @@ OData XML
 
 HTTP Status code: 200
 
-The response includes one entry per build, each entry has the following data:
+The response includes one entry per build. Each entry has the following data:
 
-- `feed/entry/content/properties/UserName` – the name of the user
-- `feed/entry/content/properties/ModelName` – the name of the model
-- `feed/entry/content/properties/ModelId` – the model unique identifier
-- `feed/entry/content/properties/IsDeployed` – is the build deployed (a.k.a. active build)
-- `feed/entry/content/properties/BuildId` – the build unique identifier
-- `feed/entry/content/properties/BuildType` - the type of the build
-- `feed/entry/content/properties/Status` – build status. Can be one of the following: Error, Building, Queued, Cancelling, Cancelled, Success
-- `feed/entry/content/properties/StatusMessage` – detailed status message (applies only to specific states)
-- `feed/entry/content/properties/Progress` – build progress (%)
-- `feed/entry/content/properties/StartTime` – Build start time
-- `feed/entry/content/properties/EndTime` – Build end time
-- `feed/entry/content/properties/ExecutionTime` – Build duration
-- `feed/entry/content/properties/ProgressStep` – details about the current stage that a build in progress is in.
+- `feed/entry/content/properties/UserName` – Name of the user.
+- `feed/entry/content/properties/ModelName` – Name of the model.
+- `feed/entry/content/properties/ModelId` – Model unique identifier.
+- `feed/entry/content/properties/IsDeployed` – Whether the build is deployed (a.k.a. active build).
+- `feed/entry/content/properties/BuildId` – Build unique identifier.
+- `feed/entry/content/properties/BuildType` - Type of the build.
+- `feed/entry/content/properties/Status` – Build status. Can be one of the following: Error, Building, Queued, Cancelling, Cancelled, Success
+- `feed/entry/content/properties/StatusMessage` – Detailed status message (applies only to specific states).
+- `feed/entry/content/properties/Progress` – Build progress (%).
+- `feed/entry/content/properties/StartTime` – Build start time.
+- `feed/entry/content/properties/EndTime` – Build end time.
+- `feed/entry/content/properties/ExecutionTime` – Build duration.
+- `feed/entry/content/properties/ProgressStep` – Details about the current stage that a build in progress is in.
 
 Valid build status:
-- Created – build request entry was created
-- Queued – build request was triggered and it is queued
-- Building – the build is in process
-- Success – the build ended successfully
-- Error – the build ended with a failure
-- Cancelled – build was canceled
-- Cancelling – build is being cancelled
+- Created – Build request entry was created.
+- Queued – Build request was triggered and it is queued.
+- Building – Build is in process.
+- Success – Build ended successfully.
+- Error – Build ended with a failure.
+- Cancelled – Build was canceled.
+- Cancelling – Build is being canceled.
 
 Valid values for build type:
-- Rank - rank build (for rank build details please refer to "Machine Learning Recommendation API documentation" document)
-- Recommendation - recommendation build
+- Rank - Rank build. (For rank build details, please refer to the "Machine Learning Recommendation API documentation" document.)
+- Recommendation - Recommendation build.
 
 OData XML
 
@@ -491,7 +491,7 @@ OData XML
     </feed>
 
 
-###Get Recommendations
+###Get recommendations
 
 | HTTP Method | URI |
 |:--------|:--------|
@@ -501,22 +501,22 @@ OData XML
 
 |	Parameter Name	|	Valid Values						|
 |:--------			|:--------								|
-| modelId | The unique identifier of the model. |
-| itemIds | Comma separated list of the items to recommend for.<br>Max length: 200 |
-| numberOfResults | The number of required results. |
-| includeMetatadata | Future use, put always false. |
+| modelId | Unique identifier of the model. |
+| itemIds | Comma-separated list of the items to recommend for.<br>Max length: 200 |
+| numberOfResults | Number of required results. |
+| includeMetatadata | Future use, always false. |
 | apiVersion | 1.0 |
 
 **Response:**
 
 HTTP Status code: 200
 
-The response includes one entry per recommended item, each entry has the following data:
+The response includes one entry per recommended item. Each entry has the following data:
 
-- `Feed\entry\content\properties\Id` - The recommended item id
-- `Feed\entry\content\properties\Name` - The name of the item
-- `Feed\entry\content\properties\Rating` - The rating of the recommendation, higher number means higher confidence
-- `Feed\entry\content\properties\Reasoning` - the recommendation reasoning (e.g. recommendation explanations)
+- `Feed\entry\content\properties\Id` - Recommended item ID.
+- `Feed\entry\content\properties\Name` - Name of the item.
+- `Feed\entry\content\properties\Rating` - Rating of the recommendation; higher number means higher confidence.
+- `Feed\entry\content\properties\Reasoning` - Recommendation reasoning (e.g. recommendation explanations).
 
 OData XML
 
@@ -671,11 +671,11 @@ The example response below includes 10 recommended items:
  	 </entry>
 	</feed>
 
-###Update Model
-You can update the model description or the active build id.
-*Active Build Id* - Every build for every model has a “build id”. The active “build id” is the first successfully build of every new model. Once you have an active build Id and you do additional builds for the same model you need to explicitly set it as the default build id if you want to. When you consume recommendations, if you do not specify the build id that you want to use - the default one will be used automatically.
+###Update model
+You can update the model description or the active build ID.
+*Active build ID* - Every build for every model has a build ID. The active build ID is the first successful build of every new model. Once you have an active build ID and you do additional builds for the same model, you need to explicitly set it as the default build ID if you want to. When you consume recommendations, if you do not specify the build ID that you want to use, the default one will be used automatically.
 
-This mechanism enables you once you have a recommendation model in production to build new models and test them before you promote them to production.
+This mechanism enables you - once you have a recommendation model in production - to build new models and test them before you promote them to production.
 
 | HTTP Method | URI |
 |:--------|:--------|
@@ -684,10 +684,10 @@ This mechanism enables you once you have a recommendation model in production to
 
 |	Parameter Name	|	Valid Values						|
 |:--------			|:--------								|
-| id | The unique identifier of the model. |
+| id | Unique identifier of the model. |
 | apiVersion | 1.0 |
 |||
-| Request Body | `<ModelUpdateParams xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">`<br>`   <Description>New Description</Description>`<br>`          <ActiveBuildId>-1</ActiveBuildId>`<br>`</ModelUpdateParams>`<br><br>Note that the xml tags Description and ActiveBuildId are optional, If you do not want to set Description or ActiveBuildId remove the entire tag. |
+| Request Body | `<ModelUpdateParams xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">`<br>`   <Description>New Description</Description>`<br>`          <ActiveBuildId>-1</ActiveBuildId>`<br>`</ModelUpdateParams>`<br><br>Note that the XML tags Description and ActiveBuildId are optional. If you do not want to set Description or ActiveBuildId, remove the entire tag. |
 
 **Response**:
 
@@ -705,7 +705,7 @@ OData XML
 	</feed>
 
 ##Legal
-This document is provided “as-is”. Information and views expressed in this document, including URL and other Internet Web site references, may change without notice. 
+This document is provided “as-is”. Information and views expressed in this document, including URL and other Internet website references, may change without notice. 
 Some examples depicted herein are provided for illustration only and are fictitious. No real association or connection is intended or should be inferred. 
 This document does not provide you with any legal rights to any intellectual property in any Microsoft product. You may copy and use this document for your internal, reference purposes. 
 © 2014 Microsoft. All rights reserved. 


### PR DESCRIPTION
Edit complete.

If the list of steps in the "General overview" section should be done in the order shown, the list should be numbered instead of bulleted.

This topic contained four instances of "Get Builds Status of a Model." I changed "builds" to "build" except where the text seemed to be referring to a specific name. Please check all mentions and make sure that the spelling is accurate in the context. (Even in the name of the API, "Builds" doesn't look right to me.)

Line 48 now includes the phrase "the recommendation's services." The original text was "the recommendations services." Please confirm that the edit is accurate, and that "recommendations" wasn't meant to refer to Azure Machine Learning Recommendations.

In the text at the end of the "Using data acquisition" section, there seems to be a line break missing between "Response:" and "HTTP Status code: 200."

It looks like a line break is missing before the paragraph that defines "Active build ID" (line 676).
