### PR TITLE
Edit hdinsight-analyze-flight-delay-data.md

### DIFF
--- a/articles/hdinsight-analyze-flight-delay-data.md
+++ b/articles/hdinsight-analyze-flight-delay-data.md
@@ -1,6 +1,6 @@
 <properties 
-	pageTitle="Analyze flight delay data using Hadoop in HDInsight | Azure" 
-	description="Learn how to  use one PowerShell script to provision HDInsight cluster, run Hive job, run Sqool job, and delete the cluster." 
+	pageTitle="Analyze flight delay data by using Hadoop in HDInsight | Azure" 
+	description="Learn how to use one Windows PowerShell script to provision an HDInsight cluster, run a Hive job, run a Sqoop job, and delete the cluster." 
 	services="hdinsight" 
 	documentationCenter="" 
 	authors="mumian" 
@@ -16,38 +16,38 @@
 	ms.date="12/04/2014" 
 	ms.author="jgao"/>
 
-#Analyze flight delay data using Hadoop in HDInsight
+#Analyze flight delay data by using Hadoop in HDInsight
 
-Hive provides means of running Hadoop MapReduce jobs through an SQL-like scripting language, called *[HiveQL][hadoop-hiveql]*, which can be applied towards summarizing, querying, and analyzing large volumes of data. 
+Hive provides a means of running Hadoop MapReduce jobs through a Structured Query Language (SQL)-like scripting language, called *[HiveQL][hadoop-hiveql]*, which can be applied towards summarizing, querying, and analyzing large volumes of data. 
 
-One of the major benefits of HDInsight is the separation of data storage and compute. HDInsight use Azure Blob storage for data storage. A common MapReduce process can be broken into 3 parts:
+One of the major benefits of HDInsight is the separation of data storage and compute. HDInsight uses Azure Blob storage for data storage. A common MapReduce process can be broken into 3 parts:
 
-1. **Store data in Azure blob storage.**  This can be a continuous process. For example, weather data, sensor data, web logs, and in this case, flight delays data are saved into blob storage.
-2. **Run jobs.**  When it is time to process the data, you run a PowerShell script (or a client application) to provision an HDInsight cluster, run jobs, and delete the cluster.  The jobs save output data to Azure Blob storage. The output data retains even after the  the cluster is deleted. This way, you only pay for what you have consumed. 
-3. **Retrieve the output from blob storage**, or in this tutorial, export the data to an Azure SQL database.
+1. **Store data in Azure Blob storage.** This can be a continuous process. For example, weather data, sensor data, web logs, and in this case, flight delay data are saved into Azure Blob storage.
+2. **Run jobs.** When it is time to process the data, you run a Windows PowerShell script (or a client application) to provision an HDInsight cluster, run jobs, and delete the cluster. The jobs save output data to Azure Blob storage. The output data is retained even after the cluster is deleted. This way, you pay for only what you have consumed. 
+3. **Retrieve the output from Azure Blob storage**, or in this tutorial, export the data to an Azure SQL database.
 
-The following diagram illustrate the scenario and the structure of this article:
+The following diagram illustrates the scenario and the structure of this article:
 
 ![HDI.FlightDelays.flow][img-hdi-flightdelays-flow]
 
 **Note**: The numbers in the diagram correspond to the section titles.
 
-The main portion of the tutorial shows you how to use one PowerShell script to perform the following:
+The main portion of the tutorial shows you how to use one Windows PowerShell script to perform the following:
 
 - Provision an HDInsight cluster.
-- Run an Hive job on the cluster to calculate average delays at airports.  The flight delay data is stored in an Azure blob storage account 
+- Run a Hive job on the cluster to calculate average delays at airports. The flight delay data is stored in an Azure Blob storage account. 
 - Run a Sqoop job to export the Hive job output to an Azure SQL database.
 - Delete the HDInsight cluster. 
 
-In the appendixes, you can find the instructions for uploading flight delay data, creating/uploading Hive query string, and preparing Azure SQL database for the Sqoop job.
+In the appendixes, you can find the instructions for uploading flight delay data, creating/uploading a Hive query string, and preparing the Azure SQL database for the Sqoop job.
 
 ##In this tutorial
 
 * [Prerequisites](#prerequisite)
 * [Provision HDInsight cluster and run Hive/Sqoop jobs (M1)](#runjob)
 * [Appendix A: Upload flight delay data to Azure Blob storage (A1)](#appendix-a)
-* [Appendix B: Create and upload HiveQL script (A2)](#appendix-b)
-* [Appendix C: Prepare Azure SQL database for the Sqoop Job output (A3)](#appendix-c)
+* [Appendix B: Create and upload a HiveQL script (A2)](#appendix-b)
+* [Appendix C: Prepare an Azure SQL database for the Sqoop job output (A3)](#appendix-c)
 * [Next steps](#nextsteps)
 
 ##<a id="prerequisite"></a>Prerequisites
@@ -59,25 +59,25 @@ Before you begin this tutorial, you must have the following:
 
 ###Understand HDInsight storage
 
-Hadoop clusters in HDInsight use Azure Blob storage for data storage.  It is called *WASB* or *Azure Storage - Blob*. WASB is Microsoft's implementation of *HDFS* on Azure Blob storage. For more information see [Use Azure Blob storage with HDInsight][hdinsight-storage]. 
+Hadoop clusters in HDInsight use Azure Blob storage for data storage. It is called *WASB* or *Azure Storage - Blob*. WASB is Microsoft's implementation of Hadoop Distributed File System (HDFS) on Azure Blob storage. For more information see [Use Azure Blob storage with HDInsight][hdinsight-storage]. 
 
-When provisioning an HDInsight cluster, a Blob storage container of an Azure storage account is designated as the default file system, just like HDFS. This storage account is referred as the *default storage account*, and the Blob container is referred as the *default Blob container* or *default container*. The default storage account must co-locate in the same data center as the HDInsight cluster. Deleting an HDInsight cluster does not delete the default container or the default storage account.
+When you provision an HDInsight cluster, a Blob storage container of an Azure storage account is designated as the default file system, just like in HDFS. This storage account is referred to as the *default storage account*, and the Blob container is referred to as the *default Blob container* or *default container*. The default storage account must co-locate in the same data center as the HDInsight cluster. Deleting an HDInsight cluster does not delete the default container or the default storage account.
 
-In addition to the default storage account, other Azure storage accounts can be bound to an HDInsight cluster during the provision process. The binding is to add the storage account and storage account key to the configuration file. So the cluster can access those storage accounts at run-time. For instructions on adding additional storage accounts, see [Provision Hadoop clusters in HDInsight][hdinsight-provision]. 
+In addition to the default storage account, other Azure storage accounts can be bound to an HDInsight cluster during the provisioning process. The binding is to add the storage account and storage account key to the configuration file so the cluster can access those storage accounts at run time. For instructions on adding additional storage accounts, see [Provision Hadoop clusters in HDInsight][hdinsight-provision]. 
 
 The WASB syntax is:
 
 	wasb[s]://<ContainerName>@<StorageAccountName>.blob.core.windows.net/<path>/<filename>
 
->[AZURE.NOTE] The WASB path is virtual path.  For more information see [Use Azure Blob storage with HDInsight][hdinsight-storage]. 
+>[AZURE.NOTE] The WASB path is a virtual path. For more information see [Use Azure Blob storage with HDInsight][hdinsight-storage]. 
 
-For files stored in the default container. it can be accessed from HDInsight using any of the following URIs (using flightdelays.hql as an example):
+Files stored in the default container can be accessed from HDInsight by using any of the following URIs (using flightdelays.hql as an example):
 
 	wasb://mycontainer@mystorageaccount.blob.core.windows.net/tutorials/flightdelays/flightdelays.hql
 	wasb:///tutorials/flightdelays/flightdelays.hql
 	/tutorials/flightdelays/flightdelays.hql
 
-To access the file directly from the storage account, the blob name for the file is:
+For accessing the file directly from the storage account, the blob name for the file is:
 
 	tutorials/flightdelays/flightdelays.hql
 
@@ -85,23 +85,23 @@ Notice there is no "/" in the front of the blob name.
 
 **Files used in this tutorial**
 
-This tutorial uses the on-time performance of airline flights data from [Research and Innovative Technology Administration, Bureau of Transportation Statistics][rita-website] (RITA). The data has been uploaded to an Azure Blob storage container with the Public Blob access permission. Because it is a public blob container, you do not need to bind this storage account to the HDInsight cluster running the Hive script. The HiveQL script is also uploaded to the same Blob container. If you want to learn how to get/upload the data to your own storage account, and how to create/upload the HiveQL script file, see [Appendix A](#appendix-a) and [Appendix B](#appendix-b).
+This tutorial uses the on-time performance of airline flight data from [Research and Innovative Technology Administration, Bureau of Transportation Statistics][rita-website] (RITA). The data has been uploaded to an Azure Blob storage container with the Public Blob access permission. Because it is a public Blob container, you do not need to bind this storage account to the HDInsight cluster running the Hive script. The HiveQL script is also uploaded to the same Blob container. If you want to learn how to get/upload the data to your own storage account, and how to create/upload the HiveQL script file, see [Appendix A](#appendix-a) and [Appendix B](#appendix-b).
 
 The following table lists the files used in this tutorial:
 
 <table border="1">
 <tr><th>Files</th><th>Description</th></tr>
-<tr><td>wasb://flightdelay@hditutorialdata.blob.core.windows.net/flightdelays.hql</td><td>The HiveQL script file used by the Hive job that you will run. This script has been uploaded to an Azure Blob storage account with the public access.  The <a href="#appendix-b">Appendix B</a> has the instructions on preparing and uploading this file to your own Azure Blob storage account.</td></tr>
-<tr><td>wasb://flightdelay@hditutorialdata.blob.core.windows.net/2013Data</td><td>Input data for the Hive jobs. The data has been uploaded to an Azure Blob storatge account with the public access.  The <a href="#appendix-a">Appendix A</a> has the instruction on getting the data and uploading the data to your own Azure Blob storage account.</td></tr>
-<tr><td>\tutorials\flightdelays\output</td><td>Output path for the Hive job. The default container is used for storing the output data.</td></tr>
+<tr><td>wasb://flightdelay@hditutorialdata.blob.core.windows.net/flightdelays.hql</td><td>The HiveQL script file used by the Hive job that you will run. This script has been uploaded to an Azure Blob storage account with the public access. <a href="#appendix-b">Appendix B</a> has instructions on preparing and uploading this file to your own Azure Blob storage account.</td></tr>
+<tr><td>wasb://flightdelay@hditutorialdata.blob.core.windows.net/2013Data</td><td>Input data for the Hive job. The data has been uploaded to an Azure Blob storage account with the public access. <a href="#appendix-a">Appendix A</a> has instructions on getting the data and uploading the data to your own Azure Blob storage account.</td></tr>
+<tr><td>\tutorials\flightdelays\output</td><td>The output path for the Hive job. The default container is used for storing the output data.</td></tr>
 <tr><td>\tutorials\flightdelays\jobstatus</td><td>The Hive job status folder on the default container.</td></tr>
 </table>
 
 
 
-###Understand Hive internal table and external table
+###Understand the Hive internal table and external table
 
-There are a few things you need to know about Hive internal table and external table:
+There are a few things you need to know about the Hive internal table and external table:
 
 - The CREATE TABLE command creates an internal table. The data file must be located in the default container.
 - The CREATE TABLE command moves the data file to the /hive/warehouse/<TableName> folder.
@@ -111,7 +111,7 @@ There are a few things you need to know about Hive internal table and external t
 
 For more information, see [HDInsight: Hive Internal and External Tables Intro][cindygross-hive-tables].
 
-> [AZURE.NOTE] One of the HiveQL statements creates an Hive external table. Hive external table keeps the data file in the original location. Hive internal table moves the data file to hive\warehouse. Hive internal table requires the data file to be located in the default container. For data stored outside default Blob container, you must use Hive external tables.
+> [AZURE.NOTE] One of the HiveQL statements creates a Hive external table. The Hive external table keeps the data file in the original location. The Hive internal table moves the data file to hive\warehouse. The Hive internal table requires the data file to be located in the default container. For data stored outside default Blob container, you must use Hive external tables.
 
 
 
@@ -123,25 +123,25 @@ For more information, see [HDInsight: Hive Internal and External Tables Intro][c
 
 ##<a id="runjob"></a>Provision HDInsight cluster and run Hive/Sqoop jobs 
 
-Hadoop MapReduce is batch processing. The most cost-effective way to run an Hive job is to provision a cluster for the job, and delete the job after the job is completed. The following script covers the whole process. For more information on provision HDInsight cluster and running Hive jobs, see [Provision Hadoop clusters in HDInsight][hdinsight-provision] and  [Use Hive with HDInsight][hdinsight-use-hive]. 
+Hadoop MapReduce is batch processing. The most cost-effective way to run a Hive job is to provision a cluster for the job, and delete the job after the job is completed. The following script covers the whole process. For more information on provisioning an HDInsight cluster and running Hive jobs, see [Provision Hadoop clusters in HDInsight][hdinsight-provision] and [Use Hive with HDInsight][hdinsight-use-hive]. 
 
-**To run the Hive queries using PowerShell**
+**To run the Hive queries by using Windows PowerShell**
 
-1. Create an Azure SQL database and the table for the Sqoop job output using the instructions in [Appendix C](#appendix-c).
+1. Create an Azure SQL database and the table for the Sqoop job output by using the instructions in [Appendix C](#appendix-c).
 2. Prepare the parameters:
 
 	<table border="1">
 	<tr><th>Variable Name</th><th>Notes</th></tr>
-	<tr><td>$hdinsightClusterName</td><td>HDInsight cluster name. If the cluster doesn't exist, the script will create one with the name entered.</td></tr>
-	<tr><td>$storageAccountName</td><td>The Azure storage account that will be used as the default storage account. This value is only needed when the script needs to create an HDInsight cluster. Leave it blank if you have specified an existing HDInsight cluster name for $hdinsightClusterName. If the storage account with the value enter doesn't exist, the script will create one with the name.</td></tr>
-	<tr><td>$blobContainerName</td><td>Blob container that will be used for the default file system. If you leave it blank, the $hdinsightClusterName value will be used. </td></tr>
-	<tr><td>$sqlDatabaseServerName</td><td>Azure SQL database server name. It has to be an existing server. See <a href="#appendix-c">Appendix C</a> for creating one.</td></tr>
-	<tr><td>$sqlDatabaseUsername</td><td>The Azure SQL database server login name.</td></tr>
-	<tr><td>$sqlDatabasePassword</td><td>The Azure SQL database server login password.</td></tr>
-	<tr><td>$sqlDatabaseName</td><td>The SQL Database where Sqoop will export data to. The default name is "HDISqoop". The table name for the Sqooop job output is "AvgDelays". </td></tr>
+	<tr><td>$hdinsightClusterName</td><td>The HDInsight cluster name. If the cluster doesn't exist, the script will create one with the name entered.</td></tr>
+	<tr><td>$storageAccountName</td><td>The Azure storage account that will be used as the default storage account. This value is needed only when the script needs to create an HDInsight cluster. Leave it blank if you have specified an existing HDInsight cluster name for $hdinsightClusterName. If the storage account with the value entered doesn't exist, the script will create one with the name.</td></tr>
+	<tr><td>$blobContainerName</td><td>The Blob container that will be used for the default file system. If you leave it blank, the $hdinsightClusterName value will be used. </td></tr>
+	<tr><td>$sqlDatabaseServerName</td><td>The Azure SQL database server name. It has to be an existing server. See <a href="#appendix-c">Appendix C</a> for information about creating one.</td></tr>
+	<tr><td>$sqlDatabaseUsername</td><td>The login name for the Azure SQL database server.</td></tr>
+	<tr><td>$sqlDatabasePassword</td><td>The login password for the Azure SQL database server.</td></tr>
+	<tr><td>$sqlDatabaseName</td><td>The SQL database where Sqoop will export data to. The default name is "HDISqoop". The table name for the Sqoop job output is "AvgDelays". </td></tr>
 	</table>
-2. Open PowerShell ISE.
-2. Copy and paste the following script into the script pane:
+3. Open Windows PowerShell Integrated Scripting Environment (ISE).
+4. Copy and paste the following script into the script pane:
 
 		[CmdletBinding()]
 		Param(
@@ -182,11 +182,11 @@ Hadoop MapReduce is batch processing. The most cost-effective way to run an Hive
 		# Treat all errors as terminating
 		$ErrorActionPreference = "Stop"
 		
-		#region - HDinsight cluster variables
+		#region - HDInsight cluster variables
 		[int]$clusterSize = 1                # One data node is sufficient for this tutorial.
 		[String]$location = "Central US"     # For better performance, choose a data center near you.
 		[String]$hadoopUserLogin = "admin"   # Use "admin" as the Hadoop login name
-		[String]$hadoopUserpw = "Pass@word1" # Use "Pass@word1" as te the Hadoop login password
+		[String]$hadoopUserpw = "Pass@word1" # Use "Pass@word1" as the Hadoop login password
 		
 		[Bool]$isNewCluster = $false      # Indicates whether a new HDInsight cluster is created by the script.  
 		                                  # If this variable is true, then the script can optionally delete the cluster after running the Hive and Sqoop jobs.
@@ -236,7 +236,7 @@ Hadoop MapReduce is batch processing. The most cost-effective way to run an Hive
 		{
 		    Write-Host "`tThe HDInsight cluster, $hdinsightClusterName, exists. This cluster will be used to run the Hive job." -ForegroundColor Cyan
 		
-		    #region - Retrieve the default storage account/container names of the cluster exists
+		    #region - Retrieve the default storage account/container names if the cluster exists
 		    # The Hive job output will be stored in the default container. The 
 		    # information is used to download a copy of the output file from 
 		    # Blob storage to workstation for the validation purpose.
@@ -272,7 +272,7 @@ Hadoop MapReduce is batch processing. The most cost-effective way to run an Hive
 		        }
 		        $blobContainerName = $blobContainerName.ToLower()
 		
-		        #region - Provision HDInsigtht cluster
+		        #region - Provision HDInsight cluster
 		        # Create an Azure storage account if it doesn't exist
 		        if (-not (Get-AzureStorageAccount|Where-Object{$_.Label -eq $storageAccountName}))
 		        {
@@ -382,11 +382,11 @@ Hadoop MapReduce is batch processing. The most cost-effective way to run an Hive
 		Write-Host "End of the PowerShell script" -ForegroundColor Green
 		Write-Host "`tCurrent system time: " (get-date) -ForegroundColor Yellow
 
-4. Press **F5** to run the script. The output shall be similar to:
+5. Press **F5** to run the script. The output shall be similar to:
 
 	![HDI.FlightDelays.RunHiveJob.output][img-hdi-flightdelays-run-hive-job-output]
 		
-5. Connect to your SQL Database and see average flight delays by city in the *AvgDelays* table:
+6. Connect to your SQL database and see average flight delays by city in the *AvgDelays* table:
 
 	![HDI.FlightDelays.AvgDelays.Dataset][image-hdi-flightdelays-avgdelays-dataset]
 
@@ -394,16 +394,16 @@ Hadoop MapReduce is batch processing. The most cost-effective way to run an Hive
 
 ---
 ##<a id="appendix-a"></a>Appendix A - Upload flight delay data to Azure Blob storage
-Prior to uploading the data file and the HiveQL script files (see [Appendix B](#appendix-b), it requires some planning. The idea is to store the data files and the HiveQL file before provision an HDInsight cluster and run the Hive job.  You have two options:
+Uploading the data file and the HiveQL script files (see [Appendix B](#appendix-b)) requires some planning. The idea is to store the data files and the HiveQL file before provisioning an HDInsight cluster and running the Hive job. You have two options:
 
 - **Use the same Azure storage account that will be used by the HDInsight cluster as the default file system.** Because the HDInsight cluster will have the storage account access key, you don't need to make any additional changes.
-- **Use a different Azure storage account from the HDInsight cluster default file system.** If this is the case, you must modified the provision part of the PowerShell script found in [Provision HDInsight cluster and run Hive/Sqoop jobs](#runjob) to include the storage account as an additional storage account. For the instructions, see [Provision Hadoop clusters in HDInsight][hdinsight-provision]. By doing so, the HDInsight cluster knows the access key for the storage account.
+- **Use a different Azure storage account from the HDInsight cluster default file system.** If this is the case, you must modify the provisioning part of the Windows PowerShell script found in [Provision HDInsight cluster and run Hive/Sqoop jobs](#runjob) to include the storage account as an additional storage account. For instructions, see [Provision Hadoop clusters in HDInsight][hdinsight-provision]. The HDInsight cluster then knows the access key for the storage account.
 
 >[AZURE.NOTE] The WASB path for the data file is hard coded in the HiveQL script file. You must update it accordingly.
 
 **To download the flight data**
 
-1. Browse to [Research and Innovative Technology Administration, Bureau of Transportation Statistics][rita-website] (RITA).
+1. Browse to [Research and Innovative Technology Administration, Bureau of Transportation Statistics][rita-website].
 2. On the page, select the following values:
 
 	<table border="1">
@@ -414,9 +414,9 @@ Prior to uploading the data file and the HiveQL script files (see [Appendix B](#
 	</table>
 
 3. Click **Download**. 
-4. Unzip the file to the **C:\Tutorials\FlightDelays\Data** folder.  Each file is a CSV file and is approximately 60 GB in size.
+4. Unzip the file to the **C:\Tutorials\FlightDelays\Data** folder. Each file is a CSV file and is approximately 60GB in size.
 5.	Rename the file to the name of the month that it contains data for. For example, the file containing the January data would be named *January.csv*.
-6. Repeat step 2 and 5 to download a file for each of the 12 months in 2013. You will need minimum one file to run the tutorial.  
+6. Repeat steps 2 and 5 to download a file for each of the 12 months in 2013. You will need a minimum of one file to run the tutorial.  
 
 **To upload the flight delay data to Azure Blob storage**
 
@@ -428,7 +428,7 @@ Prior to uploading the data file and the HiveQL script files (see [Appendix B](#
 	<tr><td>$blobContainerName</td><td>The Blob container where you want to upload the data to.</td></tr>
 	</table>
 2. Open PowerShell ISE.
-2. Paste the following script into the script pane:
+3. Paste the following script into the script pane:
 
 		[CmdletBinding()]
 		Param(
@@ -452,7 +452,7 @@ Prior to uploading the data file and the HiveQL script files (see [Appendix B](#
 		if (-not (Get-AzureAccount)){ Add-AzureAccount}
 		#EndRegion
 		
-		#Region - Validate user inpute
+		#Region - Validate user input
 		# Validate the storage account
 		if (-not (Get-AzureStorageAccount|Where-Object{$_.Label -eq $storageAccountName}))
 		{
@@ -488,11 +488,11 @@ Prior to uploading the data file and the HiveQL script files (see [Appendix B](#
 		    Write-Host "The source folder on the workstation doesn't exist" -ForegroundColor Red
 		}
 		
-		# List the uploaded files on HDinsight
+		# List the uploaded files on HDInsight
 		Get-AzureStorageBlob -Container $blobContainerName  -Context $storageContext -Prefix $destFolder
 		#EndRegion
 
-3. Press **F5** to run the script.
+4. Press **F5** to run the script.
 
 If you choose to use a different method for uploading the files, please make sure the file path is *tutorials/flightdelays/data*. The syntax for accessing the files is:
 
@@ -502,24 +502,24 @@ If you choose to use a different method for uploading the files, please make sur
 
 >[AZURE.NOTE] You must update the Hive query to read from the new location.
 
-> You must either configure the container access permission to be public or bind the storage account to the HDInsight cluster.  Otherwise, the Hive query string will not be able to access the data files. 
+> You must either configure the container access permission to be public or bind the storage account to the HDInsight cluster. Otherwise, the Hive query string will not be able to access the data files. 
 
 ---
-##<a id="appendix-b"></a>Appendix B - Create and upload HiveQL script
+##<a id="appendix-b"></a>Appendix B - Create and upload a HiveQL script
 
-Using Azure PowerShell, you can run multiple HiveQL statements one at a time, or package the HiveQL statement into a script file. The section shows you how to create a HiveQL script and upload the script to Azure Blob storage using PowerShell. Hive requires the HiveQL scripts to be stored on WASB.
+Using Azure PowerShell, you can run multiple HiveQL statements one at a time, or package the HiveQL statement into a script file. This section shows you how to create a HiveQL script and upload the script to Azure Blob storage by using Azure PowerShell. Hive requires the HiveQL scripts to be stored on WASB.
 
 The HiveQL script will perform the following:
 
 1. **Drop the delays_raw table**, in case the table already exists.
 2. **Create the delays_raw external Hive table** pointing to the WASB location with the flight delay files. This query specifies that fields are delimited by "," and that lines are terminated by "\n". This poses a problem when field values *contain* commas because Hive cannot differentiate between a comma that is a field delimiter and a one that is part of a field value (which is the case in field values for ORIGIN\_CITY\_NAME and DEST\_CITY\_NAME). To address this, the query creates TEMP columns to hold data that is incorrectly split into columns.  
-3. **Drop the delays table**, in case the table already exists;
-4. **Create the delays table**. It is helpful to clean up the data before further processing. This query creates a new table, *delays* from the *delays_raw* table. Note that the TEMP columns (as mentioned previously) are not copied, and that the *substring* function is used to remove quotation marks from the data. 
-5. **Computes the average weather delay and groups the results by city name.** It will also output the results to WASB. Note that the query will remove apostrophes from the data and will exclude rows where the value for *weather_deal*y is *null*, which is necessary because Sqoop, used later in this tutorial, doesn't handle those values gracefully by default.
+3. **Drop the delays table**, in case the table already exists.
+4. **Create the delays table**. It is helpful to clean up the data before further processing. This query creates a new table, *delays*, from the *delays_raw* table. Note that the TEMP columns (as mentioned previously) are not copied, and that the *substring* function is used to remove quotation marks from the data. 
+5. **Compute the average weather delay and groups the results by city name.** It will also output the results to WASB. Note that the query will remove apostrophes from the data and will exclude rows where the value for *weather_delay* is *null*. This is necessary because Sqoop, used later in this tutorial, doesn't handle those values gracefully by default.
 
 For a full list of the HiveQL commands, see [Hive Data Definition Language][hadoop-hiveql]. Each HiveQL command must terminate with a semicolon.
 
-**To create an HiveQL script file**
+**To create a HiveQL script file**
 
 1. Prepare the parameters:
 
@@ -530,12 +530,12 @@ For a full list of the HiveQL commands, see [Hive Data Definition Language][hado
 	</table>
 2. Open Azure PowerShell ISE.
 
-2. Copy and paste the following script into the script pane:
+3. Copy and paste the following script into the script pane:
 
 		[CmdletBinding()]
 		Param(
 		
-		    # Azure blob storage variables
+		    # Azure Blob storage variables
 		    [Parameter(Mandatory=$True,
 		               HelpMessage="Enter the Azure storage account name for creating a new HDInsight cluster. If the account doesn't exist, the script will create one.")]
 		    [String]$storageAccountName,
@@ -550,20 +550,20 @@ For a full list of the HiveQL commands, see [Hive Data Definition Language][hado
 		# Treat all errors as terminating
 		$ErrorActionPreference = "Stop"
 		
-		# the HQL script file is exported as this file before uploaded to WASB
+		# the HiveQL script file is exported as this file before it's uploaded to WASB
 		$hqlLocalFileName = "C:\tutorials\flightdelays\flightdelays.hql" 
 		
-		# the HQL script file will be upload to WASB as this blob name
+		# the HiveQL script file will be upload to WASB as this blob name
 		$hqlBlobName = "tutorials/flightdelays/flightdelays.hql" 
 		
-		# this two constants are used by the HQL scrpit file
+		# these two constants are used by the HiveQL script file
 		#$srcDataFolder = "tutorials/flightdelays/data" 
 		$dstDataFolder = "/tutorials/flightdelays/output"
 		#endregion
 		
 		#region - Validate the file and file path
 		
-		# check if a file with the same file name already exist on the workstation
+		# check if a file with the same file name already exists on the workstation
 		Write-Host "`nvalidating the folder structure on the workstation for saving the HQL script file ..."  -ForegroundColor Green
 		if (test-path $hqlLocalFileName){
 		
@@ -680,28 +680,28 @@ For a full list of the HiveQL commands, see [Hive Data Definition Language][hado
 
 	Here are the variables used in the script:
 
-	- **$hqlLocalFileName**: The script saves the HiveQL script file locally before uploading it to WASB. This is the file name. The default values is <u>C:\tutorials\flightdelays\flightdelays.hql</u>.
-	- **$hqlBlobName**: This is the HiveQL script file blob name used in the Azure Blob storage. The default values is <u>tutorials/flightdelays/flightdelays.hql</u>. Because the file will be written directly to Azure Blob storage, there is NOT a "/" at the beginning of the blob name. If you want to access the file from WASB, you will need to add a "/" at the beginning of the file name.
+	- **$hqlLocalFileName**: The script saves the HiveQL script file locally before uploading it to WASB. This is the file name. The default value is <u>C:\tutorials\flightdelays\flightdelays.hql</u>.
+	- **$hqlBlobName**: This is the HiveQL script file blob name used in the Azure Blob storage. The default value is <u>tutorials/flightdelays/flightdelays.hql</u>. Because the file will be written directly to Azure Blob storage, there is NOT a "/" at the beginning of the blob name. If you want to access the file from WASB, you will need to add a "/" at the beginning of the file name.
 	- **$srcDataFolder** and **$dstDataFolder**:  = "tutorials/flightdelays/data" 
  = "tutorials/flightdelays/output"
 
 
 ---
-##<a id="appendix-c"></a>Appendix C - Prepare Azure SQL database for the Sqoop job output
+##<a id="appendix-c"></a>Appendix C - Prepare an Azure SQL database for the Sqoop job output
 **To prepare the SQL database (merge this with the Sqoop script)**
 
 1. Prepare the parameters:
 
 	<table border="1">
 	<tr><th>Variable Name</th><th>Notes</th></tr>
-	<tr><td>$sqlDatabaseServerName</td><td>The Azure SQL database server name. Enter nothing to create a new server.</td></tr>
-	<tr><td>$sqlDatabaseUsername</td><td>The Azure SQL database server login name. If $sqlDatabaseServerName is an existing server, the login and login password are used to authenticate with the server.  Otherwise they are used to create a new server.</td></tr>
-	<tr><td>$sqlDatabasePassword</td><td>The Azure SQL database server login password.</td></tr>
-	<tr><td>$sqlDatabaseLocation</td><td>This value is only used when creating a new Azure database server.</td></tr>
-	<tr><td>$sqlDatabaseName</td><td>The SQL Database used to create the AvgDelays table for the Sqoop job. Leave it blank will result a database called "HDISqoop" created. The table name for the Sqooop job output is "AvgDelays". </td></tr>
+	<tr><td>$sqlDatabaseServerName</td><td>The name of the Azure SQL database server. Enter nothing to create a new server.</td></tr>
+	<tr><td>$sqlDatabaseUsername</td><td>The login name for the Azure SQL database server. If $sqlDatabaseServerName is an existing server, the login and login password are used to authenticate with the server. Otherwise they are used to create a new server.</td></tr>
+	<tr><td>$sqlDatabasePassword</td><td>The login password for the Azure SQL database server.</td></tr>
+	<tr><td>$sqlDatabaseLocation</td><td>This value is used only when you're creating a new Azure database server.</td></tr>
+	<tr><td>$sqlDatabaseName</td><td>The SQL database used to create the AvgDelays table for the Sqoop job. Leaving it blank will create a database called "HDISqoop". The table name for the Sqoop job output is "AvgDelays". </td></tr>
 	</table>
 2. Open PowerShell ISE. 
-2. Copy and paste the following script into the script pane:
+3. Copy and paste the following script into the script pane:
 	
 		[CmdletBinding()]
 		Param(
@@ -729,7 +729,7 @@ For a full list of the HiveQL commands, see [Hive Data Definition Language][hado
 		    [Parameter(Mandatory=$True,
 		               HelpMessage="Enter the database name if you have created one. Enter nothing to create one.")]
 		    [AllowEmptyString()]
-		    [String]$sqlDatabaseName # specify the database name if you have one created.  Otherwise use "" to have the script create one for you.
+		    [String]$sqlDatabaseName # specify the database name if you have one created. Otherwise use "" to have the script create one for you.
 		)
 		
 		# Treat all errors as terminating
@@ -765,7 +765,7 @@ For a full list of the HiveQL commands, see [Hive Data Definition Language][hado
 		}
 		#endregion
 		
-		#region - Create and validate Azure SQL Database server
+		#region - Create and validate Azure SQL database server
 		if ([string]::IsNullOrEmpty($sqlDatabaseServer))
 		{
 			Write-Host "`nCreating SQL Database server ..."  -ForegroundColor Green
@@ -817,7 +817,7 @@ For a full list of the HiveQL commands, see [Hive Data Definition Language][hado
 		}
 		#endregion
 			
-		#region -  Excute a SQL command to create the AvgDelays table
+		#region -  Execute an SQL command to create the AvgDelays table
 			
 		Write-Host "`nCreating SQL Database table ..."  -ForegroundColor Green
 		$conn = New-Object System.Data.SqlClient.SqlConnection
@@ -832,20 +832,20 @@ For a full list of the HiveQL commands, see [Hive Data Definition Language][hado
 		
 		Write-host "`nEnd of the PowerShell script" -ForegroundColor Green
 
-	>[AZURE.NOTE] The script uses a REST service, http://bot.whatismyipaddress.com, to retrieve your external IP address. The IP address is used for creating a firewall rule for your SQL Database server.  
+	>[AZURE.NOTE] The script uses a representational state transfer (REST) service, http://bot.whatismyipaddress.com, to retrieve your external IP address. The IP address is used for creating a firewall rule for your SQL database server.  
 
 	Here are some variables used in the script:
 
-	- **$ipAddressRestService**: The default value is <u>http://bot.whatismyipaddress.com</u>. It is a public IP address Rest service for getting your external IP address. You can use other services if you want. The external IP address retrieved using the service will be used to create a firewall rule for your Azure SQL database server, so that you can access the database from your workstation (using PowerShell script).
-	- **$fireWallRuleName**: This is the Azure SQL database server firewall rule name. The default name is <u>FlightDelay</u>. You can rename it if you want.
-	- **$sqlDatabaseMaxSizeGB**: This value is only used when creating a new Azure SQL database server. The default value is <u>10GB</u>. 10GB is sufficient for this tutorial.
-	- **$sqlDatabaseName**: This value is used only when creating a new Azure SQL database. The default value is <u>HDISqoop</u>. If you rename it, you must update the Sqoop PowerShell script accordingly. 
+	- **$ipAddressRestService**: The default value is <u>http://bot.whatismyipaddress.com</u>. It is a public IP address REST service for getting your external IP address. You can use other services if you want. The external IP address retrieved through the service will be used to create a firewall rule for your Azure SQL database server, so that you can access the database from your workstation (by using a Windows PowerShell script).
+	- **$fireWallRuleName**: This is the name of the firewall rule for the Azure SQL database server. The default name is <u>FlightDelay</u>. You can rename it if you want.
+	- **$sqlDatabaseMaxSizeGB**: This value is used only when you're creating a new Azure SQL database server. The default value is <u>10GB</u>. 10GB is sufficient for this tutorial.
+	- **$sqlDatabaseName**: This value is used only when you're creating a new Azure SQL database. The default value is <u>HDISqoop</u>. If you rename it, you must update the Sqoop Windows PowerShell script accordingly. 
 
 4. Press **F5** to run the script. 
 5. Validate the script output. Make sure the script ran successfully.	
 
 ##<a id="nextsteps"></a> Next steps
-Now that you understand how to upload file to Blob storage, how to populate a Hive table using the data from Blob storage, how to run Hive queries, and how to use Sqoop to export data from HDFS to Azure SQL Database. To learn more, see the following articles:
+Now you understand how to upload a file to Azure Blob storage, how to populate a Hive table by using the data from Azure Blob storage, how to run Hive queries, and how to use Sqoop to export data from HDFS to an Azure SQL database. To learn more, see the following articles:
 
 * [Getting Started with HDInsight][hdinsight-get-started]
 * [Use Hive with HDInsight][hdinsight-use-hive]


### PR DESCRIPTION
Edit complete.

In the figure near the beginning of the article, "Run an Hive job" should be "Run a Hive job."

Please make sure that the first note (line 33) is formatted correctly. Other notes are formatted as [WACOM.NOTE] or [AZURE.NOTE].

The article mentions "WASB" multiple times. Please confirm that this acronym is okay to use. It isn't mentioned in any Azure style/naming standards, and we typically avoid unauthorized acronyms for branding and legal reasons. But it does appear in other Azure documentation on the web.

The article uses both "Blob" and "blob." Please check each mention and confirm that the initial-capped spelling refers to the Azure service (that is, it's a specific name), whereas the lowercase spelling refers to the generic concept.

I spelled out some acronyms, but not URI and CSV. I figure these are common enough. But you can spell them out if you think that would be helpful for readers. Or if you think the ones I spelled out don't need to be for the audience, you can reject those edits.

Line 88 includes the text "you do not need to bind this storage account to the HDInsight cluster running the Hive script." It would be clearer to change "running" to "by running" or "that runs" (whichever of those is accurate).

In code, I made minor changes only to what appeared to be comments. If you don't want any editing at all to the code comments (even fixing typos), you can reject the edits.

Line 419 says "Repeat steps 2 and 5..." Please make sure this is accurate and shouldn't be "Repeat steps 2 through 5..."

Line 570 includes the typo "overwirte." I didn't change it to "overwrite" because it's code.

The year mentioned throughout the article is 2013, so the article may be a bit out of date.

Please make sure that none of the screen shots contain sensitive data.
