### PR TITLE
Fix inaccuracies

### DIFF
--- a/articles/web-sites-nodejs-iojs.md
+++ b/articles/web-sites-nodejs-iojs.md
@@ -8,7 +8,7 @@
 
 #How to use io.js with Azure Websites
 
-The popular Node fork [io.js] features various differences to Joyent's Node.js project, including a more open governance model, a supposedly faster release cycle and a faster adoption of new and experimental JavaScript features.
+The popular Node fork [io.js] features various differences to Joyent's Node.js project, including a more open governance model, a faster release cycle and a faster adoption of new and experimental JavaScript features.
 
 While Azure Websites has many Node.js versions preinstalled, it also allows for an user-provided Node.js binary. This article discusses two methods enabling the use of io.js on Azure Websites: The use of an extended deployment script, which automatically configures Azure to use the latest available io.js version, as well as the manual upload of a io.js binary. 
 
@@ -26,9 +26,9 @@ The first file, **.deployment**, instructs Azure Websites to run **deploy.cmd** 
 
 The manual installation of a custom io.js version includes only two steps. First, download the **win-x64** binary directly from the [io.js distribution]. Required are two files - **iojs.exe** and **iojs.lib**. Save both files to a folder inside your website, for example in **bin/iojs**.
 
-To configure Azure Websites to use **iojs.exe** instead of a pre-installed Node version, create a **IISNode.yml** file at the root of your application and add the following line. The **--harmony** flag is optional, but enables many of the ECMAScript 6 "Harmony" features that distinguish io.js from Node.js.
+To configure Azure Websites to use **iojs.exe** instead of a pre-installed Node version, create a **IISNode.yml** file at the root of your application and add the following line.
 
-    nodeProcessCommandLine: "D:\home\site\wwwroot\bin\iojs\iojs.exe" --harmony
+    nodeProcessCommandLine: "D:\home\site\wwwroot\bin\iojs\iojs.exe"
 
 ##<a id="nextsteps"></a>Next Steps
 


### PR DESCRIPTION
- The release cycle is empirically faster, not supposedly
- The --harmony flag should *not* be used in io.js, and it is *not* necessary for many ES6 features; the stable ones are turned on by default, and unstable ones are hidden behind --harmony. See https://iojs.org/en/es6.html for more information.