### PR TITLE
[Hackadoc] Fixing link to dead page

### DIFF
--- a/includes/sql-azure-management.md
+++ b/includes/sql-azure-management.md
@@ -334,6 +334,6 @@ complete details and more usage examples, see [Monitoring SQL Database using Dyn
   [sp_addrolemember (Transact-SQL)]: http://msdn.microsoft.com/en-us/library/ms187750.aspx
   [ALTER LOGIN (SQL Database)]: http://msdn.microsoft.com/en-us/library/windowsazure/ee336254.aspx
   [Monitoring SQL Database using Dynamic Management Views]: http://msdn.microsoft.com/en-us/library/windowsazure/ff394114.aspx
-  [Introducing SQL Database]: http://msdn.microsoft.com/en-us/library/windowsazure/ee336230.aspx
+  [Introducing SQL Database]: http://azure.microsoft.com/en-us/services/sql-database/
   [SQL Database Provisioning Model]: http://msdn.microsoft.com/en-us/library/ee336227.aspx
   [Adding Users to your SQL Database]: http://blogs.msdn.com/b/sqlazure/archive/2010/06/21/10028038.aspx


### PR DESCRIPTION
"Introducing SQL Database" link at bottom of page used to link to:
https://msdn.microsoft.com/library/azure/ee336230.aspx which is a dead link. updating to http://azure.microsoft.com/en-us/services/sql-database/