### PR TITLE
[HackaDoc] Update reference to HBase SDK NuGet package

### DIFF
--- a/articles/hdinsight-hbase-analyze-twitter-sentiment.md
+++ b/articles/hdinsight-hbase-analyze-twitter-sentiment.md
@@ -179,11 +179,10 @@ Create a console application to get Tweets, calculate Tweet sentiment score and 
 **To install Nuget packages and add SDK references:**
 
 1. From the **Tools** menu, click **Nuget Package Manager**, and then click **Package Manager Console**. The console panel will open at the bottom of the page.
-2. Use the following commands to install the [Tweetinvi](https://www.nuget.org/packages/TweetinviAPI/) package, which is used to access the Twitter API, and the [Protobuf-net](https://www.nuget.org/packages/protobuf-net/) package, which is used to serialize and deserialize objects.
+2. Use the following commands to install the [HBase .NET SDK](https://www.nuget.org/packages/Microsoft.HBase.Client/) package, which is client library to access HBase cluster, and the [Tweetinvi](https://www.nuget.org/packages/TweetinviAPI/) package, which is used to access the Twitter API.
 
-		Install-Package TweetinviAPI
-		Install-Package protobuf-net 
 		Install-Package Microsoft.HBase.Client
+		Install-Package TweetinviAPI
 	
 3. From **Solution Explorer**, right-click **References**, and then click **Add Reference**.
 4. In the left pane, expand **Assemblies**, and then click **Framework**.


### PR DESCRIPTION
Reference to protobuf is no longer needed as it's pulled in automatically by Microsoft.HBase.Client package.