### PR TITLE
[HackaDoc] Add missing reference to HBase SDK NuGet

### DIFF
--- a/articles/hdinsight-hbase-analyze-twitter-sentiment.md
+++ b/articles/hdinsight-hbase-analyze-twitter-sentiment.md
@@ -561,9 +561,9 @@ In this section, you will create a ASP.NET MVC Web application to read the real-
 **To install Nuget packages:**
 
 1. From the **Tools** menu, click **Nuget Package Manager**, and then click **Package Manager Console**. The console panel is opened at the bottom of the page.
-2. Use the following command to install the [Protobuf-net](https://www.nuget.org/packages/protobuf-net/) package, which is used to serialize and deserialize objects.
+2. Use the following command to install the [HBase .NET SDK](https://www.nuget.org/packages/Microsoft.HBase.Client/) package, which is client library to access HBase cluster.
 
-		Install-Package protobuf-net 
+		Install-Package Microsoft.HBase.Client 
 
 **To add HBaseReader class:**
 


### PR DESCRIPTION
Second part of the article misses reference to HBase SDK NuGet. The reference to proto-buf is removed as it is no longer needed - hbase sdk pulls it in automatically.