### PR TITLE
Edit hdinsight-high-availability.md

### DIFF
--- a/articles/hdinsight-high-availability.md
+++ b/articles/hdinsight-high-availability.md
@@ -20,42 +20,42 @@
 #Availability and reliability of Hadoop clusters in HDInsight
 
 ## Introduction ##
-A second headnode has been added to the Hadoop clusters deployed by HDInsight to increase the availability and reliability of the service needed to manage workloads. Standard implementations of Hadoop clusters typically have a single headnode. These clusters are designed to manage the failure of worker nodes smoothly, but any outages of master services running on the headnode would cause the cluster to cease to work. 
+A second head node has been added to the Hadoop clusters deployed by Azure HDInsight to increase the availability and reliability of the service needed to manage workloads. Standard implementations of Hadoop clusters typically have a single head node. These clusters are designed to manage the failure of worker nodes smoothly, but any outages of master services running on the head node would cause the cluster to cease to work. 
 
 ![](http://i.imgur.com/jrUmrH4.png)
 
-HDInsight removes this single point of failure with the addition of a secondary headnode (Head Node1). [ZooKeeper][zookeeper] nodes (ZKs) have been added and are used for Leader Election of headnodes and to insure that worker nodes and gateways (GWs) know when to fail over to the secondary headnode (Head Node1) when the active headnode (HeadNode0) becomes inactive.
+HDInsight removes this single point of failure with the addition of a secondary head node (Head Node1). [ZooKeeper][zookeeper] nodes (ZKs) have been added and are used for leader election of head nodes and to insure that worker nodes and gateways (GWs) know when to fail over to the secondary head node (Head Node1) when the active head node (Head Node0) becomes inactive.
 
 
-## How to check on the service status on the active headnode ##
-To determine which headnode is active and to check on the status of the services running on that head node, you must connect to the Hadoop cluster using the Remote Desktop Protocol (RDP). The ability to remote into the cluster is disabled by default in Azure, so it must be first be enabled. For instructions on how to do this in the portal, see [Connect to HDInsight clusters using RDP](../hdinsight-administer-use-management-portal/#rdp)
-Once you have remoted into the cluster, double-click on the **Hadoop Service Available Status** icon located on the desktop to obtain status about which headnode the Namenode, Jobtracker, Templeton, Oozieservice, Metastore, and Hiveserver2 services are running, or for HDI 3.0, the Namenode, Resource Manager, History Server, Templeton, Oozieservice, Metastore and Hiveserver2.
+## How to check on the service status on the active head node ##
+To determine which head node is active and to check on the status of the services running on that head node, you must connect to the Hadoop cluster by using the Remote Desktop Protocol (RDP). The ability to remote into the cluster is disabled by default in Azure, so it must first be enabled. For instructions on how to do this in the portal, see [Connect to HDInsight clusters using RDP](../hdinsight-administer-use-management-portal/#rdp).
+Once you have remoted into the cluster, double-click on the **Hadoop Service Available Status** icon located on the desktop to obtain status about which head node the Namenode, Jobtracker, Templeton, Oozieservice, Metastore, and Hiveserver2 services are running, or for HDI 3.0, the Namenode, Resource Manager, History Server, Templeton, Oozieservice, Metastore, and Hiveserver2 services.
 
 ![](http://i.imgur.com/MYTkCHW.png)
 
 
-## How to access log files on the secondary headnode ##
+## How to access log files on the secondary head node ##
 
-To access job logs on the secondary headnode in the event that it has become the active headnode, browsing the JobTracker UI still works as it does for the primary active node. To access the Job Tracker, you must connect to the Hadoop cluster using the Remote Desktop Protocol (RDP) as described in the previous section. Once you have remoted into the cluster, double-click on the **Hadoop Name Node** icon located on the desktop and then click on the **NameNode logs** to get to the directory of logs on the secondary headnode.
+To access job logs on the secondary head node in the event that it has become the active head node, browsing the JobTracker UI still works as it does for the primary active node. To access JobTracker, you must connect to the Hadoop cluster by using RDP as described in the previous section. Once you have remoted into the cluster, double-click on the **Hadoop Name Node** icon located on the desktop and then click on the **NameNode logs** to get to the directory of logs on the secondary head node.
 
 ![](http://i.imgur.com/eL6jzgB.png)
 
 
-## How to configure the size of the headnode ##
-The headnodes are allocated as large VMs by default. This size is adequate for the management of most Hadoop jobs run on the cluster. But there are scenarios that may require that extra large VMs are needed for the headnodes. One example is when the cluster has to manage a large number of small Oozie jobs. 
+## How to configure the size of the head node ##
+The head nodes are allocated as large virtual machines (VMs) by default. This size is adequate for the management of most Hadoop jobs run on the cluster. But there are scenarios that may require extra-large VMs for the head nodes. One example is when the cluster has to manage a large number of small Oozie jobs. 
 
-Extra large VMs can be configured using either Azure PowerShell cmdlets or the HDInsight SDK.
+Extra-large VMs can be configured by using either Azure PowerShell cmdlets or the HDInsight SDK.
 
-The creation and provisioning of a cluster using PowerShell is documented in [Administer HDInsight using PowerShell](../hdinsight-administer-use-powershell/). The configuration of an extra large headnode requires the addition of the `-HeadNodeVMSize ExtraLarge` parameter to the `New-AzureHDInsightcluster` cmdlet used in this code.
+The creation and provisioning of a cluster by using Azure PowerShell is documented in [Administer HDInsight using PowerShell](../hdinsight-administer-use-powershell/). The configuration of an extra-large head node requires the addition of the `-HeadNodeVMSize ExtraLarge` parameter to the `New-AzureHDInsightcluster` cmdlet used in this code.
 
     # Create a new HDInsight cluster in Azure PowerShell
-	# Configured with an ExtraLarge Headnode VM
+	# Configured with an ExtraLarge head-node VM
     New-AzureHDInsightCluster -Name $clusterName -Location $location -HeadNodeVMSize ExtraLarge -DefaultStorageAccountName "$storageAccountName.blob.core.windows.net" -DefaultStorageAccountKey $storageAccountKey -DefaultStorageContainerName $containerName  -ClusterSizeInNodes $clusterNodes
 
-For SDK, the story is similar. The creation and provisioning of a cluster using the SDK is documented in [Using HDInsight .NET SD](../hdinsight-provision-clusters/#sdk). The configuration of an extra large headnode requires the addition of the `HeadNodeSize = NodeVMSize.ExtraLarge` parameter to the `ClusterCreateParameters()` method used in this code.
+For the SDK, the story is similar. The creation and provisioning of a cluster by using the SDK is documented in [Using HDInsight .NET SD](../hdinsight-provision-clusters/#sdk). The configuration of an extra-large head node requires the addition of the `HeadNodeSize = NodeVMSize.ExtraLarge` parameter to the `ClusterCreateParameters()` method used in this code.
 
     # Create a new HDInsight cluster with the HDInsight SDK
-	# Configured with an ExtraLarge Headnode VM
+	# Configured with an ExtraLarge head-node VM
     ClusterCreateParameters clusterInfo = new ClusterCreateParameters()
     {
     Name = clustername,


### PR DESCRIPTION
This file used a mix of "headnode" and "head node" in text. I went with the latter (including the specific names "Head Node0" and "Head Node1," because that's what the first figure showed). I hyphenated it only when it directly precedes a noun. Note that the second figure uses "headnode1," so there may be some inconsistency in the naming.

All the links to articles produced 404 errors when I tried to open them.