### PR TITLE
Edit hdinsight-mahout.md

### DIFF
--- a/articles/hdinsight-mahout.md
+++ b/articles/hdinsight-mahout.md
@@ -16,47 +16,47 @@
 	ms.date="02/23/2015" 
 	ms.author="larryfr"/>
 
-#Generate movie recommendations using Apache Mahout with HDInsight (Hadoop)
+#Generate movie recommendations by using Apache Mahout with HDInsight
 
-Learn how to use the [Apache Mahout](http://mahout.apache.org) machine learning library to generate movie recommendations with Microsoft Azure HDInsight (Hadoop).
+Learn how to use the [Apache Mahout](http://mahout.apache.org) machine learning library with Azure HDInsight to generate movie recommendations.
 
-> [AZURE.NOTE] You must have an HDInsight cluster to use the information in this article. For information on creating one, see [Get started using Hadoop in HDInsight][getstarted].
+> [AZURE.NOTE] You must have an HDInsight cluster to use the information in this article. For information about creating one, see [Get started using Hadoop in HDInsight][getstarted].
 >
-> Mahout is provided with HDInsight 3.1 or later version of the clusters. If you are using an earlier version of HDInsight, see [Install Mahout](#install) before continuing.
+> Mahout is provided with the HDInsight 3.1 version of the clusters. If you are using an earlier version of HDInsight, see [Install Mahout](#install) before you continue.
 
 ##<a name="learn"></a>What you will learn
 
-Mahout is a [machine learning][ml] library for Apache Hadoop. Mahout contains algorithms for processing data, such as filtering, classification, and clustering. In this article you will use a recommendation engine to generate movie recommendations based on movies that your friends have seen. You will also learn how to performing classifications with a decision forest. This will teach you the following.
+Mahout is a [machine learning][ml] library for Apache Hadoop. Mahout contains algorithms for processing data, such as filtering, classification, and clustering. In this article, you will use a recommendation engine to generate movie recommendations that are based on movies your friends have seen. You will also learn how to perform classifications with a decision forest. This will teach you the following:
 
-* How to run Mahout jobs from PowerShell
+* How to run Mahout jobs by using Windows PowerShell
 
 * How to run Mahout jobs from the Hadoop command line
 
-* How to install Mahout on HDInsight 2.0 and 3.0 clusters
+* How to install Mahout on HDInsight 3.0 and HDInsight 2.0 clusters
 
-##<a name="recommendations"></a>Generate recommendations using PowerShell
+##<a name="recommendations"></a>Generate recommendations by using Windows PowerShell
 
-> [AZURE.NOTE] While the job used in this section works with PowerShell, many of the classes provided with Mahout do not currently work with PowerShell and must be run using the Hadoop command line. For an listing of classes that do not work with PowerShell, see the [Troubleshooting](#troubleshooting) section.
+> [AZURE.NOTE] Although the job used in this section works by using Windows PowerShell, many of the classes provided with Mahout do not currently work with Windows PowerShell, and they must be run by using the Hadoop command line. For a list of classes that do not work with Windows PowerShell, see the [Troubleshooting](#troubleshooting) section.
 >
-> For an example of using the Hadoop command line to run Mahout jobs, see [Classify data using the Hadoop command line](#classify).
+> For an example of using the Hadoop command line to run Mahout jobs, see [Classify data by using the Hadoop command line](#classify).
 
-One of the functions provided by Mahout is a recommendation engine. This accepts data in the format of `userID`, `itemId`, `prefValue` (the users preference for the item). Mahout can then perform co-occurance analysis to determine that _users that have a preference for an item also have a preference for these other items_. Mahout will then determine users with like item preferences, which can then be used to make recommendations.
+One of the functions that is provided by Mahout is a recommendation engine. This engine accepts data in the format of `userID`, `itemId`, and `prefValue` (the users preference for the item). Mahout can then perform co-occurance analysis to determine: _users who have a preference for an item also have a preference for these other items_. Mahout then determines users with like-item preferences, which can be used to make recommendations.
 
-The following is an extremely simple example using movies:
+The following is an extremely simple example that uses movies:
 
-* __Co-occurance__ - Joe, Alice, and Bob all liked _Star Wars_, _The Empire Strikes Back_, and _Return of the Jedi_. Mahout would determine that users who like any one of these movies also like the other two.
+* __Co-occurance__: Joe, Alice, and Bob all liked _Star Wars_, _The Empire Strikes Back_, and _Return of the Jedi_. Mahout determines that users who like any one of these movies also like the other two.
 
-* __Co-occurance__ - Bob and Alice also liked _The Phantom Menace_, _Attack of the Clones_, and _Revenge of the Sith_. Mahout would determine that users who liked the previous three movies also like these three
+* __Co-occurance__: Bob and Alice also liked _The Phantom Menace_, _Attack of the Clones_, and _Revenge of the Sith_. Mahout determines that users who liked the previous three movies also like these three.
 
-* __Similarity recommendation__ - Since Joe liked the first three, Mahout will look at movies that others with similar preferences have liked, but that Joe has not watched (liked/rated.) In this case, Mahout would recommend _The Phantom Menace_, _Attack of the Clones_, and _Revenge of the Sith_.
+* __Similarity recommendation__: Because Joe liked the first three movies, Mahout looks at movies that others with similar preferences liked, but Joe has not watched (liked/rated). In this case, Mahout recommends _The Phantom Menace_, _Attack of the Clones_, and _Revenge of the Sith_.
 
 ###Load the data
 
-Conveniently, GroupLens Research provides [rating data for movies][movielens] in a Mahout compatible format.
+Conveniently, [GroupLens Research][movielens] provides rating data for movies in a format that is compatible with Mahout.
 
-1. Download the [MovieLens 100k][100k] archive, which contains 100,000 ratings from 1000 users on 1700 movies.
+1. Download the [MovieLens 100k][100k] archive, which contains 100,000 ratings from 1000 users for 1700 movies.
 
-2. Extract the archive. It should contain an __ml-100k__ directory, which contains many data files prefixed with __u.__. The file that will be analyzed by Mahout is __u.data__. The data structure of this file is `userID`, `movieID`, `userRating`, and `timestamp`. Here is an example of the data.
+2. Extract the archive. It should contain an __ml-100k__ directory, which contains many data files prefixed with __u.__. The file that will be analyzed by Mahout is __u.data__. The data structure of this file is `userID`, `movieID`, `userRating`, and `timestamp`. Here is an example of the data:
 
 
 		196	242	3	881250949
@@ -66,15 +66,15 @@ Conveniently, GroupLens Research provides [rating data for movies][movielens] in
 		166	346	1	886397596
 
 
-3. Upload the __u.data__ file to __example/data/u.data__ on your HDInsight cluster. If you have [Azure PowerShell][aps], you can use the [HDInsight-Tools][tools] PowerShell module to upload the file. For other ways to upload files, see [Upload data for Hadoop Jobs in HDInsight][upload]. The following demonstrates using `Add-HDInsightFile` to upload the file
+3. Upload the __u.data__ file to __example/data/u.data__ in your HDInsight cluster. If you have [Azure PowerShell][aps], you can use the [HDInsight-Tools][tools] module to upload the file. For other ways to upload files, see [Upload data for Hadoop Jobs in HDInsight][upload]. The following command uses `Add-HDInsightFile` to upload the file:
 
     	PS C:\> Add-HDInsightFile -LocalPath "path\to\u.data" -DestinationPath "example/data/u.data" -ClusterName "your cluster name"
 
-    This will upload the __u.data__ file to __example/data/u.data__ in the default storage your cluster. We can then access this data using the __wasb:///example/data/u.data__ URI from HDInsight jobs.
+    This uploads the __u.data__ file to __example/data/u.data__ in the default storage in your cluster. You can then access this data by using the __wasb:///example/data/u.data__ URI from HDInsight jobs.
 
 ###Run the job
 
-Use the following PowerShell script to run a job using the Mahout recommendation engine with the __u.data__ file uploaded previously.
+Use the following Windows PowerShell script to run a job that uses the Mahout recommendation engine with the __u.data__ file that you uploaded previously:
 
 	# The HDInsight cluster name.
 	$clusterName = "the cluster name"
@@ -117,26 +117,26 @@ Use the following PowerShell script to run a job using the Mahout recommendation
 	Write-Host "STDERR"
 	Get-AzureHDInsightJobOutput -Cluster $clusterName -JobId $job.JobId -StandardError
 
-> [AZURE.NOTE] Mahout jobs do not remove temporary data created while processing the job. This is why the `--tempDir` parameter is specified in the example job - to isolate the temp files into a specific path for easy deletion.
+> [AZURE.NOTE] Mahout jobs do not remove temporary data that is created while processing the job. The `--tempDir` parameter is specified in the example job to isolate the temporary files into a specific path for easy deletion.
 >
-> To remove these files, you can use one of the utilities mentioned in the [Upload data for Hadoop jobs in HDInsight][upload]. Or use the `Remove-HDInsightFile` function in the [HDInsight-Tools][tools] PowerShell script.
+> To remove these files, you can use one of the tools mentioned in [Upload data for Hadoop jobs in HDInsight][upload]. Or you can use the `Remove-HDInsightFile` function in the [HDInsight-Tools][tools] module.
 >
-> If you do not remove the temp files, or the output file, you will receive an error if you run the job again.
+> If you do not remove the temporary files or the output file, you will receive an error message if you run the job again.
 
-The Mahout job does not return the output to STDOUT, but instead stores it in the specified output directory as __part-r-00000__. To download and view the file, use the `Get-HDInsightFile` function in the [HDInsight-Tools][tools] PowerShell module.
+The Mahout job does not return the output to STDOUT. Instead, it stores it in the specified output directory as __part-r-00000__. To download and view the file, use the `Get-HDInsightFile` function in the [HDInsight-Tools][tools] module.
 
-The following is an example of the contents of the file:
+The following is an example of the content of the file:
 
 	1	[234:5.0,347:5.0,237:5.0,47:5.0,282:5.0,275:5.0,88:5.0,515:5.0,514:5.0,121:5.0]
 	2	[282:5.0,210:5.0,237:5.0,234:5.0,347:5.0,121:5.0,258:5.0,515:5.0,462:5.0,79:5.0]
 	3	[284:5.0,285:4.828125,508:4.7543354,845:4.75,319:4.705128,124:4.7045455,150:4.6938777,311:4.6769233,248:4.65625,272:4.649266]
 	4	[690:5.0,12:5.0,234:5.0,275:5.0,121:5.0,255:5.0,237:5.0,895:5.0,282:5.0,117:5.0]
 
-The first column is the `userID`. The values contained in '[' and ']' are the `movieId`:`recommendationScore`.
+The first column is the `userID`. The values contained in '[' and ']' are `movieId`:`recommendationScore`.
 
 ###View the output
 
-While the generated output might be OK for use in an application, it's not very human readable. Some of the other files extracted to the __ml-100k__ folder earlier can be used to resolve the `movieId` to a movie name. While there is a Python script that will do this included in the __ml-100k__ folder (__show\_recommendations.py__,) you can also use the following PowerShell script.
+Although the generated output might be OK for use in an application, it's not very readable. Some of the other files extracted to the __ml-100k__ folder earlier can be used to resolve `movieId` to a movie name. A Python script that will do this is included in the __ml-100k__ folder (__show\_recommendations.py__), or you can use the following Windows PowerShell script:
 
 	<#
 	.SYNOPSIS
@@ -220,14 +220,14 @@ While the generated output might be OK for use in an application, it's not very 
 	                        @{Expression={$_.Value};Label="Score"}
 	$recommendations | format-table $recommendationFormat
 
-To use this script, you must have the __ml-100k__ folder extracted previously, as well as a local copy of the __part-r-00000__ output file generated by the Mahout job. The following is an example of running the script.
+To use this script, you must have previously extracted the __ml-100k__ folder, in addition to having a local copy of the __part-r-00000__ output file that was generated by the Mahout job. The following is an example of running the script:
 
 	PS C:\> show-recommendation.ps1 -userId 4 -userDataFile .\ml-100k\u.data -movieFile .\ml-100k\u.item -recommendationFile .\output.txt
 
 
 > [AZURE.NOTE] The example Python script, __show\_recommendations.py__, takes the same parameters.
 
-The output should appear similar to the following.
+The output should appear similar to the following:
 
 	Reading movies descriptions
 	Reading rated movies
@@ -258,57 +258,55 @@ The output should appear similar to the following.
 	Donnie Brasco (1997)                     4.6792455
 	Lone Star (1996)                         4.7099237  
 
-##<a name="classify"></a>Classify data using the Hadoop command line
+##<a name="classify"></a>Classify data by using the Hadoop command line
 
-One of the classification methods available with Mahout is to build a [random forest][forest]. This is a multi-step process that involves using training data to generate a decision trees, which are then be used to classify data. This uses the __org.apache.mahout.classifier.df.tools.Describe__ class provided by Mahout, and currently must be ran using the Hadoop command line.
+One of the classification methods available with Mahout is to build a [random forest][forest]. This is a multiple step process that involves using training data to generate decision trees, which are then used to classify data. This uses the __org.apache.mahout.classifier.df.tools.Describe__ class provided by Mahout. It currently must be run by using the Hadoop command line.
 
 ###Load the data
 
-The current Mahout implementation is compatible with the University of California, Irvine (UCI) repository format [why does this matter, what is this format]
+1. Download the following files from [The NSL-KDD Data Set](http://nsl.cs.unb.ca/NSL-KDD/).
 
-1. Download the following files from [http://nsl.cs.unb.ca/NSL-KDD/](http://nsl.cs.unb.ca/NSL-KDD/).
+  * [KDDTrain+.ARFF](http://nsl.cs.unb.ca/NSL-KDD/KDDTrain+.arff): the training file
 
-  * [KDDTrain+.ARFF](http://nsl.cs.unb.ca/NSL-KDD/KDDTrain+.arff) - the training file
+  * [KDDTest+.ARFF](http://nsl.cs.unb.ca/NSL-KDD/KDDTest+.arff): the test data
 
-  * [KDDTest+.ARFF](http://nsl.cs.unb.ca/NSL-KDD/KDDTest+.arff) - the test data
+2. Open each file and remove the lines at the top that begin with '@', and then save the files. If these are not removed, you will receive error messages when using this data with Mahout.
 
-2. Open each file and remove the lines at the top that begin with '@', and then save the files. If these are not removed, you will receive errors when using this data with Mahout.
-
-2. Upload the to __example/data__. You can do this using the `Add-HDInsightFile` function in the [HDInsight-Tools][tools] PowerShell module.
+2. Upload the files to __example/data__. You can do this by using the `Add-HDInsightFile` function in the [HDInsight-Tools][tools] module.
 
 ###Run the job
 
-1. Since this job requires the Hadoop command line, you must first enable remote desktop through the [Azure Management Portal][management]. In the portal, select your HDInsight cluster, and then select __Enable Remote__ at the bottom of the __Configuration__ page.
+1. This job requires the Hadoop command line, so you must first enable Remote Desktop through the [Azure portal][management]. In the portal, select your HDInsight cluster, and then select __Enable Remote__ at the bottom of the __Configuration__ page:
 
     ![enable remote][enableremote]
 
     When prompted, enter a user name and password to use for remote sessions.
 
-2. Once remote access is enabled, select __Connect__ to begin the connection. This will download an __.rdp__ file, which can be used to start a Remote Desktop session.
+2. When remote access is enabled, select __Connect__ to begin the connection. This downloads an __.rdp__ file, which can be used to start a Remote Desktop session.
 
     ![connect][connect]
 
-3. After connecting, use the __Hadoop Command Line__ icon to open the Hadoop Command Line.
+3. After connecting, use the __Hadoop Command Line__ icon to open the Hadoop command line:
 
 	![hadoop cli][hadoopcli]
 
-3. Use the following command to generate the file descriptor (__KDDTrain+.info__,) using Mahout.
+3. Use the following command to generate the file descriptor (__KDDTrain+.info__), which uses Mahout.
 
 		hadoop jar "c:/apps/dist/mahout-0.9.0.2.1.3.0-1887/examples/target/mahout-examples-0.9.0.2.1.3.0-1887-job.jar" org.apache.mahout.classifier.df.tools.Describe -p "wasb:///example/data/KDDTrain+.arff" -f "wasb:///example/data/KDDTrain+.info" -d N 3 C 2 N C 4 N C 8 N 2 C 19 N L
 
-	The `N 3 C 2 N C 4 N C 8 N 2 C 19 N L` describes the attributes of the data in the file. One numerical attribute, 2 categorical, etc. L indicates a label.
+	The `N 3 C 2 N C 4 N C 8 N 2 C 19 N L` describes the attributes of the data in the file. For example, L indicates a label.
 
-4. Build a forest of decision trees using the following command.
+4. Build a forest of decision trees by using the following command:
 
 		hadoop jar c:/apps/dist/mahout-0.9.0.2.1.3.0-1887/examples/target/mahout-examples-0.9.0.2.1.3.0-1887-job.jar org.apache.mahout.classifier.df.mapreduce.BuildForest -Dmapred.max.split.size=1874231 -d wasb:///example/data/KDDTrain+.arff -ds wasb:///example/data/KDDTrain+.info -sl 5 -p -t 100 -o nsl-forest
 
-    The output of this operation is stored in the __nsl-forest__ directory, which is located in storage for your HDInsight cluster at __wasb://user/&lt;username>/nsl-forest/nsl-forest.seq. The &lt;username> is the user name used for your remote desktop session. This file is not human readable.
+    The output of this operation is stored in the __nsl-forest__ directory, which is located in the storage for your HDInsight cluster at __wasb://user/&lt;username>/nsl-forest/nsl-forest.seq. The &lt;username> is the user name that you used for your Remote Desktop session. This file is not readable by humans.
 
-5. Test the forest by classifying the __KDDTest+.arff__ dataset using the following command.
+5. Test the forest by classifying the __KDDTest+.arff__ dataset. Use the following command:
 
     	hadoop jar c:/apps/dist/mahout-0.9.0.2.1.3.0-1887/examples/target/mahout-examples-0.9.0.2.1.3.0-1887-job.jar org.apache.mahout.classifier.df.mapreduce.TestForest -i wasb:///example/data/KDDTest+.arff -ds wasb:///example/data/KDDTrain+.info -m nsl-forest -a -mr -o wasb:///example/data/predictions
 
-    This command will return summary information on classification process similar to the following.
+    This command returns summary information about the classification process similar to the following:
 
 	    14/07/02 14:29:28 INFO mapreduce.TestForest:
 
@@ -334,51 +332,51 @@ The current Mahout implementation is compatible with the University of Californi
 	    Reliability                                53.4921%
 	    Reliability (standard deviation)            0.4933
 
-  This job also produces a file located at __wasb:///example/data/predictions/KDDTest+.arff.out__, however this file is not human readable.
+  This job also produces a file located at __wasb:///example/data/predictions/KDDTest+.arff.out__. However, this file is not readable by humans.
 
-> [AZURE.NOTE] Mahout jobs do not overwrite files. If you wish to run these jobs again, you must delete the files created by previous jobs.
+> [AZURE.NOTE] Mahout jobs do not overwrite files. If you want to run these jobs again, you must delete the files that were created by previous jobs.
 
 ##<a name="troubleshooting"></a>Troubleshooting
 
 ###<a name="install"></a>Install Mahout
 
-Mahout is installed on HDInsight 3.1 and later versions of the clusters, and can be installed manually on 3.0 or 2.1 clusters using the following steps.
+Mahout is installed on HDInsight 3.1 clusters, and it can be installed manually on HDInsight 3.0 or HDInsight 2.1 clusters by using the following steps:
 
-1. The version of Mahout to use depends on the HDInsight version of your cluster. You can find the cluster version by using the following with [Azure PowerShell][aps]:
+1. The version of Mahout to use depends on the HDInsight version of your cluster. You can find the cluster version by using the following [Azure PowerShell][aps] command:
 
     	PS C:\> Get-AzureHDInsightCluster -Name YourClusterName | Select version
 
 
-  * __For HDInsight 2.1__, you can download a jar file containing [Mahout 0.9](http://repo2.maven.org/maven2/org/apache/mahout/mahout-core/0.9/mahout-core-0.9-job.jar).
+  * __For HDInsight 2.1__, you can download a Java Archive (JAR) file that contains [Mahout 0.9](http://repo2.maven.org/maven2/org/apache/mahout/mahout-core/0.9/mahout-core-0.9-job.jar).
 
-  * __For HDInsight 3.0__,you must [build Mahout from source][build] and specify the Hadoop version provided by HDInsight. Install the prerequisits listed on the build page, download the source, and then use the following command to create the Mahout jar files.
+  * __For HDInsight 3.0__, you must [build Mahout from the source][build] and specify the Hadoop version provided by HDInsight. Install the prerequisites listed on the build page, download the source, and then use the following command to create the Mahout jar files:
 
 			mvn -Dhadoop2.version=2.2.0 -DskipTests clean package
 
-    	Once the build completes, the jar file will be created at __mahout\mrlegacy\target\mahout-mrlegacy-1.0-SNAPSHOT-job.jar__.
+    	After the build completes, you can find the JAR file at __mahout\mrlegacy\target\mahout-mrlegacy-1.0-SNAPSHOT-job.jar__.
 
-    	> [AZURE.NOTE] Once Mahout 1.0 is released, you should be able to use the pre-built packages with HDInsight 3.0.
+    	> [AZURE.NOTE] When Mahout 1.0 is released, you should be able to use the prebuilt packages with HDInsight 3.0.
 
-2. Upload the jar file to __example/jars__ in the default storage for your cluster. The following example uses the [send-hdinsight][sendhdinsight] script to upload the file.
+2. Upload the jar file to __example/jars__ in the default storage for your cluster. The following example uses the [send-hdinsight][sendhdinsight] script to upload the file:
 
     	PS C:\> .\Send-HDInsight -LocalPath "path\to\mahout-core-0.9-job.jar" -DestinationPath "example/jars/mahout-core-0.9-job.jar" -ClusterName "your cluster name"
 
 ###Cannot overwrite files
 
-Mahout jobs do not clean up temp files created during processing. In addition, the jobs will not overwrite an existing output file.
+Mahout jobs do not clean up temporary files that were created during processing. In addition, the jobs will not overwrite an existing output file.
 
-To avoid errors when running Mahout jobs, either delete temp and output files between runs, or use unique temp and output directory names.
+To avoid errors when running Mahout jobs, delete temporary and output files between runs, or use unique temporary and output directory names.
 
-###Cannot find the jar file
+###Cannot find the JAR file
 
-While HDInsight 3.1 and later versions of the clusters include Mahout, the path and filename include the version number of Mahout installed on the cluster. The example PowerShell script in this tutorial uses a path that is valid as of July 2014, but the version number will change in future updates to HDInsight. To determine the current path to the Mahout jar file for your cluster, use the following PowerShell commands, then modify the script to reference the file path returned.
+HDInsight 3.1 clusters include Mahout. The path and file name include the version number of Mahout that is installed on the cluster. The Windows PowerShell example script in this tutorial uses a path that is valid as of July 2014, but the version number will change in future updates to HDInsight. To determine the current path to the Mahout JAR file for your cluster, use the following Windows PowerShell command, and then modify the script to reference the file path that is returned:
 
 	Use-AzureHDInsightCluster -Name $clusterName
 	$jarFile = Invoke-Hive -Query '!${env:COMSPEC} /c dir /b /s ${env:MAHOUT_HOME}\examples\target\*-job.jar'
 
-###<a name="nopowershell"></a>Classes that do not work with PowerShell
+###<a name="nopowershell"></a>Classes that do not work with Windows PowerShell
 
-Mahout jobs that use the following classes will return a variety of errors if used from PowerShell.
+Mahout jobs that use the following classes return a variety of error messages if they are used from Windows PowerShell:
 
 * org.apache.mahout.utils.clustering.ClusterDumper
 * org.apache.mahout.utils.SequenceFileDumper
@@ -397,7 +395,7 @@ Mahout jobs that use the following classes will return a variety of errors if us
 * org.apache.mahout.classifier.sequencelearning.hmm.RandomSequenceGenerator
 * org.apache.mahout.classifier.df.tools.Describe
 
-To run jobs that use these classes, connect to the HDInsight cluster and run the jobs using the Hadoop command line. See [Classify data using the Hadoop command line](#classify) for an example.
+To run jobs that use these classes, connect to the HDInsight cluster, and run the jobs by using the Hadoop command line. See [Classify data using the Hadoop command line](#classify) for an example.
 
 
 [build]: http://mahout.apache.org/developers/buildingmahout.html


### PR DESCRIPTION
Edit complete. Sent the following feedback to Larry:
Your titles use HDInsight (Hadoop). Hadoop is not another name for HDInsight…it is associated with Apache, right? So I am suggesting deleting it from the title…you can explain it in the intro sentence if you need to.
Line 25: We can’t make promises about future versions.
General comment: PowerShell always needs its little buddy Windows with it. Or if you are talking about Azure PowerShell, use that.
Line 135: '[' and ']' is not clear. I don’t see it in any of the code.
Line 266: I agree with you and I deleted this:
The current Mahout implementation is compatible with the University of California, Irvine (UCI) repository format [why does this matter, what is this format]
Line 293: “using Mahout” was not clear. Did I interpret correctly?
Line 297: This is as clear as mud: One numerical attribute, 2 categorical, etc. I deleted it until you can clarify it.
Line 358: Is this up-to-date? When Mahout 1.0 is released, you should be able to use the prebuilt packages with HDInsight 3.0.)
Line 372 references July 2014…any update?
