### PR TITLE
Update minor spelling correction

### DIFF
--- a/articles/data-factory-introduction.md
+++ b/articles/data-factory-introduction.md
@@ -134,7 +134,7 @@ An important characteristic of Hub is that a pipeline runs on a single hub. This
 ###Slice
 A slice is a logical time based partitioning of the data produced by one or more activity runs. A table in an Azure data factory is composed of slices over the time axis. The width of a slice is determined by the schedule – hourly/daily. When the schedule is “hourly”, a slice is produced hourly with the start time and end time of a pipeline and so on.  
 
-Slices provide the ability for IT Professionals to work with a subset of overall data for a specific time window (for example: the slice that is produced for the duration (hour): 1:00 PM to 2:00 PM). They can also view all the downstream data slices for a given time internal and rerun a slice in case of a failure.
+Slices provide the ability for IT Professionals to work with a subset of overall data for a specific time window (for example: the slice that is produced for the duration (hour): 1:00 PM to 2:00 PM). They can also view all the downstream data slices for a given time interval and rerun a slice in case of a failure.
 
 The run is a unit of processing for a slice. There could be one or more runs for a slice in case of retries or if you rerun your slice in case of failures. A slice is identified by its start time. 
 


### PR DESCRIPTION
The word "interval" was misspelled as "internal"