### PR TITLE
Edit hdinsight-hadoop-spark-install.md

### DIFF
--- a/articles/hdinsight-hadoop-spark-install.md
+++ b/articles/hdinsight-hadoop-spark-install.md
@@ -18,22 +18,22 @@
 
 # Install and use Spark on HDInsight Hadoop clusters
 
-You can install Spark on any type of cluster in Hadoop on HDInsight using **Script Action** cluster customization. Script action lets you run scripts to customize a cluster, only when the cluster is being created. For more information, see [Customize HDInsight cluster using script action][hdinsight-cluster-customize].
+You can install Spark on any type of cluster in Hadoop on Azure HDInsight by using **Script Action** cluster customization. Script Action lets you run scripts to customize a cluster, only when the cluster is being created. For more information, see [Customize HDInsight cluster using Script Action][hdinsight-cluster-customize].
 
-In this topic, you will learn how to install Spark using Script Action. Once you have installed Spark, you'll also learn how to run Spark query on HDInsight clusters.
+In this topic, you will learn how to install Spark by using Script Action. Once you have installed Spark, you'll also learn how to run a Spark query on HDInsight clusters.
 
 
 ## <a name="whatis"></a>What is Spark?
 
-<a href="http://spark.apache.org/docs/latest/index.html" target="_blank">Apache Spark</a> is an open-source parallel processing framework that supports in-memory processing to boost the performance of big data analytic applications. Spark's in-memory computation capabilities make it a good choice for iterative algorithms in machine learning and graph computations.
+<a href="http://spark.apache.org/docs/latest/index.html" target="_blank">Apache Spark</a> is an open-source parallel processing framework that supports in-memory processing to boost the performance of big-data analytic applications. Spark's in-memory computation capabilities make it a good choice for iterative algorithms in machine learning and graph computations.
 
-Spark can also be used to perform conventional disk-based data processing. Spark improves over traditional MapReduce framework by avoiding writes to disk in the intermediate stages. Also, Spark is compatible with HDFS and WASB so the existing data can easily be processed using Spark. 
+Spark can also be used to perform conventional disk-based data processing. Spark improves the traditional MapReduce framework by avoiding writes to disk in the intermediate stages. Also, Spark is compatible with the Hadoop Distributed File System (HDFS) and Azure Blob storage so the existing data can easily be processed via Spark. 
 
 This topic provides instructions on how to customize an HDInsight cluster to install Spark.
 
 ## <a name="whatis"></a>Which version of Spark can I install?
 
-In this topic, we use a script action custom script to install Spark on an HDInsight cluster. This script can install Spark 1.2.0 or Spark 1.0.2 depending on the version of HDInsight cluster you provision.
+In this topic, we use a Script Action custom script to install Spark on an HDInsight cluster. This script can install Spark 1.2.0 or Spark 1.0.2 depending on the version of the HDInsight cluster you provision.
 
 - If you use the script while provisioning an **HDInsight 3.2** cluster, it installs **Spark 1.2.0**.
 - If you use the script while provisioning an **HDInsight 3.1** cluster, it installs **Spark 1.0.2**. 
@@ -43,17 +43,17 @@ You can modify this script or create your own script to install other versions o
 
 ## <a name="install"></a>How do I install Spark?
 
-A sample script to install Spark on an HDInsight cluster is available from a read-only Azure storage blob at [https://hdiconfigactions.blob.core.windows.net/sparkconfigactionv03/spark-installer-v03.ps1](https://hdiconfigactions.blob.core.windows.net/sparkconfigactionv03/spark-installer-v03.ps1). This section provides instructions on how to use the sample script while provisioning the cluster using the Azure Management Portal. 
+A sample script to install Spark on an HDInsight cluster is available from a read-only Azure storage blob at [https://hdiconfigactions.blob.core.windows.net/sparkconfigactionv03/spark-installer-v03.ps1](https://hdiconfigactions.blob.core.windows.net/sparkconfigactionv03/spark-installer-v03.ps1). This section provides instructions on how to use the sample script while provisioning the cluster by using the Azure portal. 
 
-> [AZURE.NOTE] The sample script works only with HDInsight cluster version 3.1 and 3.2.  For more information on HDInsight cluster versions, see [HDInsight cluster versions](http://azure.microsoft.com/documentation/articles/hdinsight-component-versioning/).
+> [AZURE.NOTE] The sample script works only with HDInsight 3.1 and 3.2 clusters. For more information on HDInsight cluster versions, see [HDInsight cluster versions](http://azure.microsoft.com/documentation/articles/hdinsight-component-versioning/).
 
-1. Start provisioning a cluster using the **CUSTOM CREATE** option, as described at [Provisioning a cluster using custom options](http://azure.microsoft.com/documentation/articles/hdinsight-provision-clusters/#portal). Pick the cluster version depending on the following:
+1. Start provisioning a cluster by using the **CUSTOM CREATE** option, as described at [Provisioning a cluster using custom options](http://azure.microsoft.com/documentation/articles/hdinsight-provision-clusters/#portal). Pick the cluster version depending on the following:
 
-	- If you want to install **Spark 1.2.0** provision HDInsight 3.2 cluster.
-	- If you want to install **Spark 1.0.2** provision HDInsight 3.1 cluster.
+	- If you want to install **Spark 1.2.0**, provision an HDInsight 3.2 cluster.
+	- If you want to install **Spark 1.0.2**, provision an HDInsight 3.1 cluster.
 
 
-2. On the **Script Actions** page of the wizard, click **add script action** to provide details about the Script Action, as shown below:
+2. On the **Script Actions** page of the wizard, click **add script action** to provide details about the script action, as shown below:
 
 	![Use Script Action to customize a cluster](./media/hdinsight-hadoop-customize-cluster/HDI.CustomProvision.Page6.png "Use Script Action to customize a cluster")
 	
@@ -62,16 +62,16 @@ A sample script to install Spark on an HDInsight cluster is available from a rea
 		<tr><td>Name</td>
 			<td>Specify a name for the script action. For example, <b>Install Spark</b>.</td></tr>
 		<tr><td>Script URI</td>
-			<td>Specify the URI to the script that is invoked to customize the cluster. For example, <i>https://hdiconfigactions.blob.core.windows.net/sparkconfigactionv03/spark-installer-v03.ps1</i></td></tr>
+			<td>Specify the Uniform Resource Identifier (URI) to the script that is invoked to customize the cluster. For example, <i>https://hdiconfigactions.blob.core.windows.net/sparkconfigactionv03/spark-installer-v03.ps1</i></td></tr>
 		<tr><td>Node Type</td>
-			<td>Specifies the nodes on which the customization script is run. You can choose <b>All Nodes</b>, <b>Head nodes only</b>, or <b>Worker nodes</b> only.
+			<td>Specify the nodes on which the customization script is run. You can choose <b>All nodes</b>, <b>Head nodes only</b>, or <b>Worker nodes only</b>.
 		<tr><td>Parameters</td>
 			<td>Specify the parameters, if required by the script. The script to install Spark does not require any parameters so you can leave this blank.</td></tr>
 	</table>	
 
 	You can add more than one script action to install multiple components on the cluster. After you have added the scripts, click the checkmark to start provisioning the cluster.
 
-You can also use the script to install Spark on HDInsight using PowerShell or the HDInsight .NET SDK. Instructions for these procedures are provided later in this topic.
+You can also use the script to install Spark on HDInsight by using Azure PowerShell or the HDInsight .NET SDK. Instructions for these procedures are provided later in this topic.
 
 ## <a name="usespark"></a>How do I use Spark in HDInsight?
 Spark provides APIs in Scala, Python, and Java. You can also use the interactive Spark shell to run Spark queries. This section provides instructions on how to use the different approaches to work with Spark:
@@ -81,22 +81,22 @@ Spark provides APIs in Scala, Python, and Java. You can also use the interactive
 - [Using a standalone Scala program](#standalone)
 
 ###<a name="sparkshell"></a>Using the Spark shell to run interactive queries
-Perform the following steps to run Spark queries from an interactive Spark shell. In this section we run a Spark query on a sample data file (/example/data/gutenberg/davinci.txt) that is available on HDInsight clusters by default.
+Perform the following steps to run Spark queries from an interactive Spark shell. In this section, we run a Spark query on a sample data file (/example/data/gutenberg/davinci.txt) that is available on HDInsight clusters by default.
 
-1. From the Azure Management Portal, enable remote desktop for the cluster you created with Spark installed, and then remote into the cluster. For instructions, see <a href="http://azure.microsoft.com/documentation/articles/hdinsight-administer-use-management-portal/#rdp" target="_blank">Connect to HDInsight clusters using RDP</a>.
+1. From the Azure portal, enable Remote Desktop for the cluster you created with Spark installed, and then remote into the cluster. For instructions, see <a href="http://azure.microsoft.com/documentation/articles/hdinsight-administer-use-management-portal/#rdp" target="_blank">Connect to HDInsight clusters using RDP</a>.
 
-2. In the RDP session, from the Desktop, open the Hadoop Command Line (from a Desktop shortcut), and navigate to the location where Spark is installed, for example, **C:\apps\dist\spark-1.2.0**.
+2. In the Remote Desktop Protocol (RDP) session, from the desktop, open the Hadoop command line (from a desktop shortcut), and navigate to the location where Spark is installed; for example, **C:\apps\dist\spark-1.2.0**.
 
 
-3. Run the following command to start the Spark shell.
+3. Run the following command to start the Spark shell:
 
 		 .\bin\spark-shell --master yarn
 
-	After the command finishes running, you should get a Scala prompt.
+	After the command finishes running, you should get a Scala prompt:
 
 		 scala>
 
-5. On the Scala prompt, enter the Spark query shown below. This query counts the occurrence of each word in the davinci.txt file that is available at /example/data/gutenberg/ location on the WASB storage associated with the cluster.
+5. On the Scala prompt, enter the Spark query shown below. This query counts the occurrence of each word in the davinci.txt file that is available at the /example/data/gutenberg/ location on the Azure Blob storage associated with the cluster.
 
 		val file = sc.textFile("/example/data/gutenberg/davinci.txt")
 		val counts = file.flatMap(line => line.split(" ")).map(word => (word, 1)).reduceByKey(_ + _)
@@ -113,28 +113,28 @@ Perform the following steps to run Spark queries from an interactive Spark shell
 
 ###<a name="sparksql"></a>Using the Spark shell to run Spark SQL queries
 
-Spark SQL allows you to use Spark to run relational queries expressed in SQL, HiveQL, or Scala. In this section, we look at using Spark to run a Hive query on a sample Hive table. The Hive table used in this section (called **hivesampletable**) is available by default when you provision a cluster.
+Spark SQL allows you to use Spark to run relational queries expressed in Structured Query Language (SQL), HiveQL, or Scala. In this section, we look at using Spark to run a Hive query on a sample Hive table. The Hive table used in this section (called **hivesampletable**) is available by default when you provision a cluster.
 
-1. From the Azure Management Portal, enable remote desktop for the cluster you created with Spark installed, and then remote into the cluster. For instructions, see <a href="http://azure.microsoft.com/documentation/articles/hdinsight-administer-use-management-portal/#rdp" target="_blank">Connect to HDInsight clusters using RDP</a>.
+1. From the Azure portal, enable Remote Desktop for the cluster you created with Spark installed, and then remote into the cluster. For instructions, see <a href="http://azure.microsoft.com/documentation/articles/hdinsight-administer-use-management-portal/#rdp" target="_blank">Connect to HDInsight clusters using RDP</a>.
 
-2. In the RDP session, from the Desktop, open the Hadoop Command Line (from a Desktop shortcut), and navigate to the location where Spark is installed, for example, **C:\apps\dist\spark-1.2.0**.
+2. In the RDP session, from the desktop, open the Hadoop command line (from a desktop shortcut), and navigate to the location where Spark is installed; for example, **C:\apps\dist\spark-1.2.0**.
 
 
-3. Run the following command to start the Spark shell.
+3. Run the following command to start the Spark shell:
 
 		 .\bin\spark-shell --master yarn
 
-	After the command finishes running, you should get a Scala prompt.
+	After the command finishes running, you should get a Scala prompt:
 
 		 scala>
 
-4. On the Scala prompt, set the Hive context. This is required to work with Hive queries using Spark.
+4. On the Scala prompt, set the Hive context. This is required to work with Hive queries by using Spark.
 
 		val hiveContext = new org.apache.spark.sql.hive.HiveContext(sc)
 
-	where, **sc** is default Spark context that is set when you start the Spark shell.
+	Note that **sc** is default Spark context that is set when you start the Spark shell.
 
-5. Run a Hive query using the hive context and print the output to the console. The query retrieves data on devices of a specific make and limits the number of records retrieved to 20.
+5. Run a Hive query by using the Hive context and print the output to the console. The query retrieves data on devices of a specific make and limits the number of records retrieved to 20.
 
 		hiveContext.sql("""SELECT * FROM hivesampletable WHERE devicemake LIKE "HTC%" LIMIT 20""").collect().foreach(println)
 
@@ -148,14 +148,14 @@ Spark SQL allows you to use Spark to run relational queries expressed in SQL, Hi
 
 ### <a name="standalone"></a>Using a standalone Scala program
 
-In this section we write a Scala application that counts the number of lines containing the letters 'a' and 'b' in a sample data file (/example/data/gutenberg/davinci.txt) that is available on HDInsight clusters by default. To write and use a standalone Scala program with a cluster customized with Spark installation, you must perform the following steps:
+In this section, we write a Scala application that counts the number of lines containing the letters 'a' and 'b' in a sample data file (/example/data/gutenberg/davinci.txt) that is available on HDInsight clusters by default. To write and use a standalone Scala program with a cluster customized with Spark installation, you must perform the following steps:
 
 - Write a Scala program
-- Build it to get the .jar file
+- Build the Scala program to get the .jar file
 - Run the job on the cluster
 
 #### Write a Scala program
-In this section you write a Scala program that counts the number of lines containing 'a' and 'b' in the sample data file. 
+In this section, you write a Scala program that counts the number of lines containing 'a' and 'b' in the sample data file. 
 
 1. Open a text editor and paste the following code:
 
@@ -167,7 +167,7 @@ In this section you write a Scala program that counts the number of lines contai
 		
 		object SimpleApp {
 		  def main(args: Array[String]) {
-		    val logFile = "/example/data/gutenberg/davinci.txt"			//location of sample data file on WASB
+		    val logFile = "/example/data/gutenberg/davinci.txt"			//Location of the sample data file on Azure Blob storage
 		    val conf = new SparkConf().setAppName("SimpleApplication")
 		    val sc = new SparkContext(conf)
 		    val logData = sc.textFile(logFile, 2).cache()
@@ -180,10 +180,10 @@ In this section you write a Scala program that counts the number of lines contai
 2. Save the file with the name **SimpleApp.scala**.
 
 #### Build the Scala program
-In this section, you use <a href="http://www.scala-sbt.org/0.13/docs/index.html" target="_blank">Simple Build Tool</a> (or sbt) to build the scala program. sbt requires Java 1.6 or later so make sure you have the right version of Java installed before continuing with this section.
+In this section, you use the <a href="http://www.scala-sbt.org/0.13/docs/index.html" target="_blank">Simple Build Tool</a> (or sbt) to build the Scala program. sbt requires Java 1.6 or later, so make sure you have the right version of Java installed before continuing with this section.
 
-1. Install sbt from  http://www.scala-sbt.org/0.13/tutorial/Installing-sbt-on-Windows.html.
-2. Create a folder called **SimpleScalaApp** and within this folder create a file called **simple.sbt**. This is a configuration file that contains information about the Scala version, library dependencies, etc. Paste the following into the simple.sbt file and save it.
+1. Install sbt from http://www.scala-sbt.org/0.13/tutorial/Installing-sbt-on-Windows.html.
+2. Create a folder called **SimpleScalaApp**, and within this folder create a file called **simple.sbt**. This is a configuration file that contains information about the Scala version, library dependencies, etc. Paste the following into the simple.sbt file and save it:
 
 
 		name := "SimpleApp"
@@ -199,21 +199,21 @@ In this section, you use <a href="http://www.scala-sbt.org/0.13/docs/index.html"
 	>[AZURE.NOTE] Make sure you retain the empty lines in the file.
 
 	
-3. Under the **SimpleScalaApp** folder, create a directory structure **\src\main\scala** and paste the Scala program (**SimpleApp.scala**) you created earlier under \src\main\scala folder.
+3. Under the **SimpleScalaApp** folder, create a directory structure **\src\main\scala** and paste the Scala program (**SimpleApp.scala**) you created earlier under the \src\main\scala folder.
 4. Open a command prompt, navigate to the SimpleScalaApp directory, and enter the following command:
 
 
 		sbt package
 
 
-	Once the application is compiled, you will see a **simpleapp_2.10-1.0.jar** created under **\target\scala-2.10** directory within the root SimpleScalaApp folder.
+	Once the application is compiled, you will see a **simpleapp_2.10-1.0.jar** file created under the **\target\scala-2.10** directory within the root SimpleScalaApp folder.
 
 
 #### Run the job on the cluster
-In this section you will remote into the cluster that has Spark installed and then copy the SimpleScalaApp project's target folder. You will then use the **spark-submit** command to submit the job on the cluster.
+In this section, you remote into the cluster that has Spark installed and then copy the SimpleScalaApp project's target folder. You then use the **spark-submit** command to submit the job on the cluster.
 
 1. Remote into the cluster that has Spark installed. From the computer where you wrote and built the SimpleApp.scala program, copy the **SimpleScalaApp\target** folder and paste it to a location on the cluster.
-2. In the RDP session, from the Desktop, open the Hadoop Command Line, and navigate to the location you pasted the **target** folder.
+2. In the RDP session, from the desktop, open the Hadoop command line, and navigate to the location where you pasted the **target** folder.
 3. Enter the following command to run the SimpleApp.scala program:
 
 
@@ -224,36 +224,36 @@ In this section you will remote into the cluster that has Spark installed and th
 
 		Lines with a: 21374, Lines with b: 11430
 
-## <a name="usingPS"></a>Install Spark on HDInsight Hadoop clusters using PowerShell
+## <a name="usingPS"></a>Install Spark on HDInsight Hadoop clusters by using Azure PowerShell
 
-In this section we use the **<a href = "http://msdn.microsoft.com/library/dn858088.aspx" target="_blank">Add-AzureHDInsightScriptAction</a>** cmdlet to invoke scripts using Script Action to customize a cluster. Before proceeding, make sure you have installed and configured PowerShell. For information on configuring a workstation to run HDInsight Powershell cmdlets, see [Install and configure Azure PowerShell][powershell-install-configure].
+In this section, we use the **<a href = "http://msdn.microsoft.com/library/dn858088.aspx" target="_blank">Add-AzureHDInsightScriptAction</a>** cmdlet to invoke scripts by using Script Action to customize a cluster. Before proceeding, make sure you have installed and configured Azure PowerShell. For information on configuring a workstation to run Azure PowerShell cmdlets for HDInsight, see [Install and configure Azure PowerShell][powershell-install-configure].
 
 Perform the following steps:
 
 1. Open an Azure PowerShell window and declare the following variables:
 
-		# PROVIDE VALUES FOR THESE VARIABLES
+		# Provide values for these variables
 		$subscriptionName = "<SubscriptionName>"		# Name of the Azure subscription
-		$clusterName = "<HDInsightClusterName>"			# The HDInsight cluster name
-		$storageAccountName = "<StorageAccountName>"	# Azure storage account that hosts the default container
-		$storageAccountKey = "<StorageAccountKey>"      # Key for the storage account
+		$clusterName = "<HDInsightClusterName>"			# HDInsight cluster name
+		$storageAccountName = "<StorageAccountName>"	# Azure Storage account that hosts the default container
+		$storageAccountKey = "<StorageAccountKey>"      # Key for the Storage account
 		$containerName = $clusterName
-		$location = "<MicrosoftDataCenter>"				# The location of the HDInsight cluster. It must in the same data center as the storage account.
-		$clusterNodes = <ClusterSizeInNumbers>			# The number of nodes in the HDInsight cluster.
-		$version = "<HDInsightClusterVersion>"          # For example "3.2"
+		$location = "<MicrosoftDataCenter>"				# Location of the HDInsight cluster. It must be in the same data center as the Storage account.
+		$clusterNodes = <ClusterSizeInNumbers>			# Number of nodes in the HDInsight cluster
+		$version = "<HDInsightClusterVersion>"          # For example, "3.2"
 	
 2. Specify the configuration values such as nodes in the cluster and the default storage to be used.
 
-		# SPECIFY THE CONFIGURATION OPTIONS
+		# Specify the configuration options
 		Select-AzureSubscription $subscriptionName
 		$config = New-AzureHDInsightClusterConfig -ClusterSizeInNodes $clusterNodes
 		$config.DefaultStorageAccount.StorageAccountName="$storageAccountName.blob.core.windows.net"
 		$config.DefaultStorageAccount.StorageAccountKey=$storageAccountKey
 		$config.DefaultStorageAccount.StorageContainerName=$containerName
 	
-3. Use **Add-AzureHDInsightScriptAction** cmdlet to to add Script Action to cluster configuration. Later, when the cluster is being created, the Script Action gets executed. 
+3. Use the **Add-AzureHDInsightScriptAction** cmdlet to add a script action to cluster configuration. Later, when the cluster is being created, the script action gets executed. 
 
-		# ADD SCRIPT ACTION TO CLUSTER CONFIGURATION
+		# Add a script action to the cluster configuration
 		$config = Add-AzureHDInsightScriptAction -Config $config -Name "Install Spark" -ClusterRoleCollection HeadNode -Uri https://hdiconfigactions.blob.core.windows.net/sparkconfigactionv03/spark-installer-v03.ps1
 
 	**Add-AzureHDInsightScriptAction** cmdlet takes the following parameters:
@@ -264,16 +264,16 @@ Perform the following steps:
 	<th style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; width:550px; padding-left:5px; padding-right:5px;">Definition</th></tr>
 	<tr>
 	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">Config</td>
-	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px; padding-right:5px;">The configuration object to which script action information is added</td></tr>
+	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px; padding-right:5px;">The configuration object to which script action information is added.</td></tr>
 	<tr>
 	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">Name</td>
-	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">Name of the script action</td></tr>
+	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">Name of the script action.</td></tr>
 	<tr>
 	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">ClusterRoleCollection</td>
-	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">Specifies the nodes on which the customization script is run. The valid values are HeadNode (to install on the headnode) or DataNode (to install on all the datanodes). You can use either or both values.</td></tr>
+	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">Specifies the nodes on which the customization script is run. The valid values are HeadNode (to install on the head node) or DataNode (to install on all the data nodes). You can use either or both values.</td></tr>
 	<tr>
 	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">Uri</td>
-	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">Specifies the URI to the script that is executed</td></tr>
+	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">Specifies the URI to the script that is executed.</td></tr>
 	<tr>
 	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">Parameters</td>
 	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">Parameters required by the script. The sample script used in this topic does not require any parameters, and hence you do not see this parameter in the snippet above.
@@ -282,23 +282,23 @@ Perform the following steps:
 	
 4. Finally, start provisioning a customized cluster with Spark installed.  
 	
-		# START PROVISIONING A CLUSTER WITH SPARK INSTALLED
+		# Start provisioning a cluster with Spark installed
 		New-AzureHDInsightCluster -Config $config -Name $clusterName -Location $location -Version $version 
 
 When prompted, enter the credentials for the cluster. It can take several minutes before the cluster is created.
 
 
-## <a name="usingSDK"></a>Install Spark on HDInsight Hadoop clusters using the .NET SDK
+## <a name="usingSDK"></a>Install Spark on HDInsight Hadoop clusters by using the .NET SDK
 
-The HDInsight .NET SDK provides .NET client libraries that makes it easier to work with HDInsight from a .NET application. This section provides instructions on how to use Script Action from the SDK to provision a cluster that has Spark installed. The following procedures must be performed:
+The HDInsight .NET SDK provides .NET client libraries that make it easier to work with HDInsight from a .NET Framework application. This section provides instructions on how to use Script Action from the SDK to provision a cluster that has Spark installed. The following procedures must be performed:
 
-- Install HDInsight .NET SDK
+- Install the HDInsight .NET SDK
 - Create a self-signed certificate
 - Create a console application
 - Run the application
 
 
-**To install HDInsight .NET SDK**
+**To install the HDInsight .NET SDK**
 
 You can install latest published build of the SDK from [NuGet](http://nuget.codeplex.com/wikipage?title=Getting%20Started). The instructions will be shown in the next procedure.
 
@@ -311,9 +311,9 @@ Create a self-signed certificate, install it on your workstation, and upload it 
 
 1. Open Visual Studio 2013.
 
-2. From the File menu, click **New**, and then click **Project**.
+2. From the **File** menu, click **New**, and then click **Project**.
 
-3. From New Project, type or select the following values:
+3. From **New Project**, type or select the following values:
 	
 	<table style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse;">
 	<tr>
@@ -334,7 +334,7 @@ Create a self-signed certificate, install it on your workstation, and upload it 
 
 5. From the **Tools** menu, click **Nuget Package Manager**, and then click **Package Manager Console**.
 
-6. Run the following commands in the console to install the package.
+6. Run the following command in the console to install the package:
 
 		Install-Package Microsoft.WindowsAzure.Management.HDInsight
 
@@ -349,11 +349,11 @@ Create a self-signed certificate, install it on your workstation, and upload it 
 		using Microsoft.WindowsAzure.Management.HDInsight.ClusterProvisioning;
 		using Microsoft.WindowsAzure.Management.HDInsight.Framework.Logging;
 	
-9. In the Main() function, copy and paste the following code, and provide values for the variables :
+9. In the Main() function, copy and paste the following code, and provide values for the variables:
 		
         var clusterName = args[0];
 
-        // PROVIDE VALUES FOR THE VARIABLES
+        // Provide values for the variables
         string thumbprint = "<CertificateThumbprint>";  
         string subscriptionId = "<AzureSubscriptionID>";
         string location = "<MicrosoftDataCenterLocation>";
@@ -363,17 +363,17 @@ Create a self-signed certificate, install it on your workstation, and upload it 
         string password = "<HDInsightUserPassword>";
         int clustersize = <NumberOfNodesInTheCluster>;
 
-        // PROVIDE THE CERTIFICATE THUMBPRINT TO RETRIEVE THE CERTIFICATE FROM THE CERTIFICATE STORE 
+        // Provide the certificate thumbprint to retrieve the certificate from the certificate store 
         X509Store store = new X509Store();
         store.Open(OpenFlags.ReadOnly);
         X509Certificate2 cert = store.Certificates.Cast<X509Certificate2>().First(item => item.Thumbprint == thumbprint);
 
-        // CREATE AN HDINSIGHT CLIENT OBJECT
+        // Create an HDInsight client object
         HDInsightCertificateCredential creds = new HDInsightCertificateCredential(new Guid(subscriptionId), cert);
         var client = HDInsightClient.Connect(creds);
 		client.IgnoreSslErrors = true;
         
-        // PROVIDE THE CLUSTER INFORMATION
+        // Provide the cluster information
 		var clusterInfo = new ClusterCreateParameters()
         {
             Name = clusterName,
@@ -389,12 +389,12 @@ Create a self-signed certificate, install it on your workstation, and upload it 
 
 10. Append the following code to the Main() function to use the [ScriptAction](http://msdn.microsoft.com/library/microsoft.windowsazure.management.hdinsight.clusterprovisioning.data.scriptaction.aspx) class to invoke a custom script to install Spark.
 
-		// ADD THE SCRIPT ACTION TO INSTALL SPARK
+		// Add the script action to install Spark
         clusterInfo.ConfigActions.Add(new ScriptAction(
           "Install Spark", // Name of the config action
           new ClusterNodeType[] { ClusterNodeType.HeadNode }, // List of nodes to install Spark on
-          new Uri("https://hdiconfigactions.blob.core.windows.net/sparkconfigactionv03/spark-installer-v03.ps1"), // Location of the script to install Spark
-		  null //because the script used does not require any parameters.
+          new Uri("https://hdiconfigactions.blob.core.windows.net/sparkconfigactionv03/spark-installer-v03.ps1"), // Location of the script to install Spark.
+		  null //Because the script used does not require any parameters
         ));
 
 11. Finally, create the cluster.
@@ -405,7 +405,7 @@ Create a self-signed certificate, install it on your workstation, and upload it 
 
 **To run the application**
 
-Open a PowerShell console, navigate to the location where you saved the Visual Studio project, navigate to the \bin\debug directory within the project, and then run the following command:
+Open an Azure PowerShell console, navigate to the location where you saved the Visual Studio project, navigate to the \bin\debug directory within the project, and then run the following command:
 
 	.\CreateSparkCluster <cluster-name>
 
@@ -413,9 +413,9 @@ Provide a cluster name and press ENTER to provision a cluster with Spark install
 
 
 ## See also##
-- [Install R on HDInsight clusters][hdinsight-install-r] provides instructions on how to use cluster customization to install and use R on HDinsight Hadoop clusters. R is an open source language and environment for statistical computing and provides hundreds of build-in statistical functions and its own programming language that combines aspects of functional and object-oriented programming. It also provides extensive graphical capabilities.
-- [Install Giraph on HDInsight clusters](../hdinsight-hadoop-giraph-install). Use cluster customization to install Giraph on HDInsight Hadoop clusters. Giraph allows you to perform graph processing using Hadoop, and can be used with Azure HDInsight.
-- [Install Solr on HDInsight clusters](../hdinsight-hadoop-solr-install). Use cluster customization to install Solr on HDInsight Hadoop clusters. Solr allows you to perform search powerful search operations on data stored.
+- [Install R on HDInsight clusters][hdinsight-install-r] provides instructions on how to use cluster customization to install and use R on HDInsight Hadoop clusters. R is an open-source language and environment for statistical computing. It provides hundreds of built-in statistical functions and its own programming language that combines aspects of functional and object-oriented programming. It also provides extensive graphical capabilities.
+- [Install Giraph on HDInsight clusters](../hdinsight-hadoop-giraph-install). Use cluster customization to install Giraph on HDInsight Hadoop clusters. Giraph allows you to perform graph processing by using Hadoop, and can be used with Azure HDInsight.
+- [Install Solr on HDInsight clusters](../hdinsight-hadoop-solr-install). Use cluster customization to install Solr on HDInsight Hadoop clusters. Solr allows you to perform powerful search operations on data stored.
 
 
 


### PR DESCRIPTION
Edit complete.

On line 46, in "Azure storage blob," if "storage" refers to a Storage account rather than storage in general, it should be initial capped.

Per naming guidelines, I changed instances of "PowerShell" by itself to "Azure PowerShell." Please make sure that all mentions are technically accurate and shouldn't be "Windows PowerShell" instead.

I'm not sure about the term "script action." It doesn't appear in the Azure terminology resources. In this document, I tried to capitalize the term as "Script Action" when it seems to refer to a specific name (of a feature or a service) but use the lowercase "script action" for generic references. Please confirm that I made the right decisions.

Line 303 says "You can install the latest published build of the SDK from... The instructions will be shown in the next procedure." But the procedure that immediately follows this line doesn't seem to show that. Please check this.