### PR TITLE
Edit hdinsight-sample-10gb-graysort.md

### DIFF
--- a/articles/hdinsight-sample-10gb-graysort.md
+++ b/articles/hdinsight-sample-10gb-graysort.md
@@ -18,17 +18,17 @@
 
 # The 10GB GraySort Hadoop sample in HDInsight
  
-This sample topic shows how to run a general purpose GraySort Hadoop MapReduce program on Azure HDInsight using Azure PowerShell. A GraySort is a benchmark sort whose metric is the sort rate (TB/minute) that is achieved while sorting very large amounts of data, usually a 100 TB minimum. 
+This sample topic shows how to run a general-purpose GraySort Hadoop MapReduce program on Azure HDInsight by using Azure PowerShell. GraySort is a benchmark sort whose metric is the sort rate (TB/minute) that is achieved while sorting very large amounts of data, usually a 100TB minimum. 
 
-This sample uses a modest 10 GB of data so that it can be run relatively quickly. It uses the MapReduce applications developed by Owen O'Malley and Arun Murthy that won the annual general purpose ("daytona") terabyte sort benchmark in 2009 with a rate of 0.578 TB/min (100 TB in 173 minutes). For more information on this and other sorting benchmarks, see the [Sortbenchmark](http://sortbenchmark.org/)   site.
+This sample uses a modest 10GB of data so that it can be run relatively quickly. It uses the MapReduce applications developed by Owen O'Malley and Arun Murthy that won the annual general-purpose ("daytona") terabyte sort benchmark in 2009 with a rate of 0.578TB/min (100TB in 173 minutes). For more information on this and other sorting benchmarks, see the [Sortbenchmark](http://sortbenchmark.org/) site.
 
 This sample uses three sets of MapReduce programs:	
  
 1. **TeraGen** is a MapReduce program that you can use to generate the rows of data to sort.
-2. **TeraSort** samples the input data and uses MapReduce to sort the data into a total order. TeraSort is a standard sort of MapReduce functions, except for a custom partitioner that uses a sorted list of N-1 sampled keys that define the key range for each reduce. In particular, all keys such that sample[i-1] <= key < sample[i] are sent to reduce i. This guarantees that the output of reduce i are all less than the output of reduce i+1.
-3. **TeraValidate** is a MapReduce program that validates the output is globally sorted. It creates one map per a file in the output directory and each map ensures that each key is less than or equal to the previous one. The map function also generates records of the first and last keys of each file and the reduce function ensures that the first key of file i is greater than the last key of file i-1. Any problems are reported as output of the reduce with the keys that are out of order.
+2. **TeraSort** samples the input data and uses MapReduce to sort the data into a total order. TeraSort is a standard sort of MapReduce functions, except for a custom partitioner that uses a sorted list of N-1 sampled keys that define the key range for each reduce. In particular, all keys such that sample[i-1] <= key < sample[i] are sent to reduce i. This guarantees that the outputs of reduce i are all less than the output of reduce i+1.
+3. **TeraValidate** is a MapReduce program that validates that the output is globally sorted. It creates one map per file in the output directory, and each map ensures that each key is less than or equal to the previous one. The map function also generates records of the first and last keys of each file, and the reduce function ensures that the first key of file i is greater than the last key of file i-1. Any problems are reported as an output of the reduce with the keys that are out of order.
 
-The input and output format, used by all three applications, read and write the text files in the right format. The output of the reduce has replication set to 1, instead of the default 3, because the benchmark contest does not require the output data be replicated on to multiple nodes.
+The input and output format, used by all three applications, reads and writes the text files in the right format. The output of the reduce has replication set to 1, instead of the default 3, because the benchmark contest does not require that the output data be replicated on to multiple nodes.
 
  
 **You will learn:**		
@@ -36,16 +36,16 @@ The input and output format, used by all three applications, read and write the 
 * What a MapReduce program written in Java looks like.
 
 
-**Prerequisites**	
+**Prerequisites:**	
 
-- You must have an Azure Account. For options on signing up for an account see [Try Azure out for free](http://azure.microsoft.com/pricing/free-trial/) page.
+- You must have an Azure account. For options on signing up for an account, see the [Try Azure out for free](http://azure.microsoft.com/pricing/free-trial/) page.
 
-- You must have provisioned an HDInsight cluster. For instructions on the various ways in which such clusters can be created, see [Provision HDInsight Clusters](../hdinsight-provision-clusters/)
+- You must have provisioned an HDInsight cluster. For instructions on the various ways in which such clusters can be created, see [Provision HDInsight clusters](../hdinsight-provision-clusters/).
 
-- You must have installed Azure PowerShell, and have configured them for use with your account. For instructions on how to do this, see [Install and configure Azure PowerShell][powershell-install-configure].
+- You must have installed Azure PowerShell, and have configured it for use with your account. For instructions on how to do this, see [Install and configure Azure PowerShell][powershell-install-configure].
 
 ##In this article
-This topic shows you how to run the series of MapReduce programs that make up the Sample, presents the Java code for the MapReduce program, summarizes what you have learned, and outlines some next steps. It has the following sections.
+This topic shows you how to run the series of MapReduce programs that make up the sample, presents the Java code for the MapReduce program, summarizes what you have learned, and outlines some next steps. It has the following sections:
 	
 1. [Run the sample with Azure PowerShell](#run-sample)	
 2. [The Java code for the TeraSort MapReduce program](#java-code)
@@ -63,26 +63,26 @@ Three tasks are required by the sample, each corresponding to one of the MapRedu
 
 **To run the TeraGen program**	
 
-1. Open Azure PowerShell. For instructions of opening Azure PowerShell console window, see [Install and configure Azure PowerShell][powershell-install-configure].
+1. Open Azure PowerShell. For instructions on opening the Azure PowerShell console window, see [Install and configure Azure PowerShell][powershell-install-configure].
 2. Set the two variables in the following commands, and then run them:
 	
-		# Provide the Azure subscription name and the HDInsight cluster name.
+		# Provide the Azure subscription name and the HDInsight cluster name
 		$subscriptionName = "myAzureSubscriptionName"   
 		$clusterName = "myClusterName"
                  
-4. Run the following command to create a MapReduce job definition"
+4. Run the following command to create a MapReduce job definition:
 
 		# Create a MapReduce job definition for the TeraGen MapReduce program
 		$teragen = New-AzureHDInsightMapReduceJobDefinition -JarFile "/example/jars/hadoop-examples.jar" -ClassName "teragen" -Arguments "-Dmapred.map.tasks=50", "100000000", "/example/data/10GB-sort-input" 
 
 	> [AZURE.NOTE] *hadoop-examples.jar* comes with version 2.1 HDInsight clusters. The file has been renamed to *hadoop-mapreduce.jar* on version 3.0 HDInsight clusters.
 	
-	The *"-Dmapred.map.tasks=50"* argument specifies that 50 maps will be created to execute the job. The *100000000* argument specifies the amount of data to generate. The final argument,  */example/data/10GB-sort-input*, specifies the output directory to which the results are saved (which contains the input for the following sort stage).
+	The *"-Dmapred.map.tasks=50"* argument specifies that 50 maps will be created to execute the job. The *100000000* argument specifies the amount of data to generate. The final argument, */example/data/10GB-sort-input*, specifies the output directory to which the results are saved (and which contains the input for the following sort stage).
 
-5. Run the following commands to submit job, wait for job to complete and then print the standard error:
+5. Run the following commands to submit the job, wait for the job to finish, and then print the standard error:
 
-		# Run the TeraGen MapReduce job.
-		# Wait for the job to complete.
+		# Run the TeraGen MapReduce job
+		# Wait for the job to finish
 		# Print output and standard error file of the MapReduce job
 		Select-AzureSubscription $subscriptionName         
 		$teragen | Start-AzureHDInsightJob -Cluster $clustername | Wait-AzureHDInsightJob -WaitTimeoutInSeconds 3600 | Get-AzureHDInsightJobOutput -Cluster $clustername -StandardError 
@@ -93,7 +93,7 @@ Three tasks are required by the sample, each corresponding to one of the MapRedu
 1. Open Azure PowerShell.
 2. Set the two variables in the following commands, and then run them:
 	
-		# Provide the Azure subscription name and the HDInsight cluster name.
+		# Provide the Azure subscription name and the HDInsight cluster name
 		$subscriptionName = "myAzureSubscriptionName"   
 		$clusterName = "myClusterName"
 
@@ -104,10 +104,10 @@ Three tasks are required by the sample, each corresponding to one of the MapRedu
 
 	The *"-Dmapred.map.tasks=50"* argument specifies that 50 maps will be created to execute the job. The *100000000* argument specifies the amount of data to generate. The final two arguments specify the input and output directories. 
 
-4. Run the following command to submit the job, wait for the job to complete, and print the standand error:
+4. Run the following command to submit the job, wait for the job to finish, and print the standard error:
 
-		# Run the TeraSort MapReduce job.
-		# Wait for the job to complete.
+		# Run the TeraSort MapReduce job
+		# Wait for the job to finish
 		# Print output and standard error file of the MapReduce job 
 		Select-AzureSubscription $subscriptionName        
 		$terasort | Start-AzureHDInsightJob -Cluster $clustername | Wait-AzureHDInsightJob -WaitTimeoutInSeconds 3600 | Get-AzureHDInsightJobOutput -Cluster $clustername -StandardError 
@@ -118,7 +118,7 @@ Three tasks are required by the sample, each corresponding to one of the MapRedu
 1. Open Azure PowerShell.
 2. Set the two variables in the following commands, and then run them:
 	
-		# Provide the Azure subscription name and the HDInsight cluster name.
+		# Provide the Azure subscription name and the HDInsight cluster name
 		$subscriptionName = "myAzureSubscriptionName"   
 		$clusterName = "myClusterName"
                  
@@ -127,21 +127,21 @@ Three tasks are required by the sample, each corresponding to one of the MapRedu
 		#	Create a MapReduce job definition for the TeraValidate MapReduce program
 		$teravalidate = New-AzureHDInsightMapReduceJobDefinition -JarFile "/example/jars/hadoop-examples.jar" -ClassName "teravalidate" -Arguments "-Dmapred.map.tasks=50", "-Dmapred.reduce.tasks=25", "/example/data/10GB-sort-output", "/example/data/10GB-sort-validate" 
 
-	The *"-Dmapred.map.tasks=50"* argument specifies that 50 maps will be created to execute the job. he *"-Dmapred.reduce.tasks=25"* argument specifies that 25 reduce tasks will be created to execute the job. The final two arguments specify the input and output directories.  
+	The *"-Dmapred.map.tasks=50"* argument specifies that 50 maps will be created to execute the job. The *"-Dmapred.reduce.tasks=25"* argument specifies that 25 reduce tasks will be created to execute the job. The final two arguments specify the input and output directories.  
  
 
-4. Run the following commands to submit the MapReduce job, wait for the job to complete and print the standard error:
+4. Run the following commands to submit the MapReduce job, wait for the job to finish, and print the standard error:
 
-		# Run the TeraSort MapReduce job.
-		# Wait for the job to complete.
+		# Run the TeraSort MapReduce job
+		# Wait for the job to finish
 		# Print output and standard error file of the MapReduce job 
 		Select-AzureSubscription $subscriptionName 
 		$teravalidate | Start-AzureHDInsightJob -Cluster $clustername | Wait-AzureHDInsightJob -WaitTimeoutInSeconds 3600 | Get-AzureHDInsightJobOutput -Cluster $clustername -StandardError 
 
 
-<h2><a id="java-code"></a>The Java code for the TerraSort MapReduce program</h2>
+<h2><a id="java-code"></a>The Java code for the TeraSort MapReduce program</h2>
 
-The code for the TerraSort MapReduce program is presented for inspection in this section. 
+The code for the TeraSort MapReduce program is presented for inspection in this section. 
 
 
 	/**
@@ -412,16 +412,16 @@ The code for the TerraSort MapReduce program is presented for inspection in this
 
 <h2><a id="summary"></a>Summary</h2>
 
-This sample has demonstrated how to run a series of MapReduce jobs using Azure HDInsight, where the data output for one job becomes the input for the next job in the series.
+This sample has demonstrated how to run a series of MapReduce jobs by using Azure HDInsight, where the data output for one job becomes the input for the next job in the series.
 
 <h2><a id="next-steps"></a>Next steps</h2>
 
-For tutorials running other samples and providing instructions on using Pig, Hive, and MapReduce jobs on Azure HDInsight with Azure PowerShell, see the following topics:
+For tutorials that guide you through running other samples and that provide instructions on using Pig, Hive, and MapReduce jobs on Azure HDInsight with Azure PowerShell, see the following topics:
 
 * [Get started with Azure HDInsight][hdinsight-get-started]
 * [Sample: Pi estimator][hdinsight-sample-pi-estimator]
-* [Sample: Wordcount][hdinsight-sample-wordcount]
-* [Sample: C# Steaming][hdinsight-sample-csharp-streaming]
+* [Sample: Word count][hdinsight-sample-wordcount]
+* [Sample: C# Streaming][hdinsight-sample-csharp-streaming]
 * [Use Pig with HDInsight][hdinsight-use-pig]
 * [Use Hive with HDInsight][hdinsight-use-hive]
 * [Azure HDInsight SDK documentation][hdinsight-sdk-documentation]


### PR DESCRIPTION
Edit complete.

The link "Get started with Azure HDInsight" goes to a page titled "Get started using Hadoop with Hive in HDInsight to analyze mobile handset use." Please confirm that this is the right link.

This article uses "reduce" as a noun multiple times. Please confirm that this is technically accurate. The word "reduce" is normally a verb, whereas "reduction" is the noun form.

This article uses both "article" and "topic" to refer to itself (and related articles). Please standardize on whichever word is more accurate.

Line 28 includes the text "In particular, all keys such that sample[i-1] <= key < sample[i] are sent to reduce i." Please confirm that this sentence is technically accurate and that readers will understand it exactly as written. I'm not sure what "such that" means in the context.

I didn't do any editing to the long Java code sample because it's provided under license. If it's okay to change the code comments, keep in mind that other code comments begin with a capital letter and don't have a period at the end (unless a particular comment consists of more than one sentence).

There's a typo in code: "paritions" (should be "partitions"). I didn't try to change it.
