### PR TITLE
Edit hdinsight-hadoop-giraph-install.md

### DIFF
--- a/articles/hdinsight-hadoop-giraph-install.md
+++ b/articles/hdinsight-hadoop-giraph-install.md
@@ -18,28 +18,28 @@
 
 # Install and use Giraph on HDInsight Hadoop clusters
 
-You can install Giraph on any type of cluster in Hadoop on HDInsight using **Script Action** cluster customization. Script action lets you run scripts to customize a cluster, only when the cluster is being created. For more information, see [Customize HDInsight cluster using script action][hdinsight-cluster-customize].
+You can install Giraph on any type of cluster in Hadoop on Azure HDInsight by using **Script Action** cluster customization. Script Action lets you run scripts to customize a cluster, only when the cluster is being created. For more information, see [Customize HDInsight clusters using Script Action][hdinsight-cluster-customize].
 
-In this topic, you will learn how to install Giraph using Script Action. Once you have installed Giraph, you'll also learn how to use Giraph for most typical applications, which is to process large scale graphs.
+In this topic, you will learn how to install Giraph by using Script Action. Once you have installed Giraph, you'll also learn how to use Giraph for most typical applications, which is to process large-scale graphs.
 
 
 ## <a name="whatis"></a>What is Giraph?
 
-<a href="http://giraph.apache.org/" target="_blank">Apache Giraph</a> allows you to perform graph processing using Hadoop, and can be used with Azure HDInsight. Graphs model relationships between objects, such as the connections between routers on a large network like the Internet, or relationships between people on social networks (sometimes referred to as a social graph.) Graph processing allows you to reason about the relationships between objects in a graph, such as:
+<a href="http://giraph.apache.org/" target="_blank">Apache Giraph</a> allows you to perform graph processing by using Hadoop, and can be used with Azure HDInsight. Graphs model relationships between objects, such as the connections between routers on a large network like the Internet, or relationships between people on social networks (sometimes referred to as a social graph). Graph processing allows you to reason about the relationships between objects in a graph, such as:
 
-- Identifying potential friends based on your current relationships
-- Identifying the shortest route between two computers in a network
-- Calculating the page rank of web pages
+- Identifying potential friends based on your current relationships.
+- Identifying the shortest route between two computers in a network.
+- Calculating the page rank of webpages.
 
    
 ## <a name="install"></a>How do I install Giraph?
 
-A sample script to install Giraph on an HDInsight cluster is available from a read-only Azure storage blob at [https://hdiconfigactions.blob.core.windows.net/giraphconfigactionv01/giraph-installer-v01.ps1](https://hdiconfigactions.blob.core.windows.net/giraphconfigactionv01/giraph-installer-v01.ps1). This section provides instructions on how to use the sample script while provisioning the cluster using the Azure Management Portal. 
+A sample script to install Giraph on an HDInsight cluster is available from a read-only Azure storage blob at [https://hdiconfigactions.blob.core.windows.net/giraphconfigactionv01/giraph-installer-v01.ps1](https://hdiconfigactions.blob.core.windows.net/giraphconfigactionv01/giraph-installer-v01.ps1). This section provides instructions on how to use the sample script while provisioning the cluster by using the Azure portal. 
 
-> [AZURE.NOTE] The sample script works only with HDInsight cluster version 3.1.  For more information on HDInsight cluster versions, see [HDInsight cluster versions](http://azure.microsoft.com/documentation/articles/hdinsight-component-versioning/).
+> [AZURE.NOTE] The sample script works only with HDInsight cluster version 3.1. For more information on HDInsight cluster versions, see [HDInsight cluster versions](http://azure.microsoft.com/documentation/articles/hdinsight-component-versioning/).
 
-1. Start provisioning a cluster using the **CUSTOM CREATE** option, as described at [Provisioning a cluster using custom options](http://azure.microsoft.com/documentation/articles/hdinsight-provision-clusters/#portal). 
-2. On the **Script Actions** page of the wizard, click **add script action** to provide details about the Script Action, as shown below:
+1. Start provisioning a cluster by using the **CUSTOM CREATE** option, as described at [Provisioning a cluster using custom options](http://azure.microsoft.com/documentation/articles/hdinsight-provision-clusters/#portal). 
+2. On the **Script Actions** page of the wizard, click **add script action** to provide details about the script action, as shown below:
 
 	![Use Script Action to customize a cluster](./media/hdinsight-hadoop-giraph-install/hdi-script-action-giraph.png "Use Script Action to customize a cluster")
 	
@@ -48,22 +48,22 @@ A sample script to install Giraph on an HDInsight cluster is available from a re
 		<tr><td>Name</td>
 			<td>Specify a name for the script action. For example, <b>Install Giraph</b>.</td></tr>
 		<tr><td>Script URI</td>
-			<td>Specify the URI to the script that is invoked to customize the cluster. For example, <i>https://hdiconfigactions.blob.core.windows.net/giraphconfigactionv01/giraph-installer-v01.ps1</i></td></tr>
+			<td>Specify the Uniform Resource Identifier (URI) to the script that is invoked to customize the cluster. For example, <i>https://hdiconfigactions.blob.core.windows.net/giraphconfigactionv01/giraph-installer-v01.ps1</i></td></tr>
 		<tr><td>Node Type</td>
-			<td>Specifies the nodes on which the customization script is run. You can choose <b>All Nodes</b>, <b>Head nodes only</b>, or <b>Worker nodes</b> only.
+			<td>Specify the nodes on which the customization script is run. You can choose <b>All nodes</b>, <b>Head nodes only</b>, or <b>Worker nodes only</b>.
 		<tr><td>Parameters</td>
-			<td>Specify the parameters, if required by the script. The script to install Giraph does not require any parameters so you can leave this blank.</td></tr>
+			<td>Specify the parameters, if required by the script. The script to install Giraph does not require any parameters, so you can leave this blank.</td></tr>
 	</table>	
 
 	You can add more than one script action to install multiple components on the cluster. After you have added the scripts, click the checkmark to start provisioning the cluster.
 
-You can also use the script to install Giraph on HDInsight using PowerShell or the HDInsight .NET SDK. Instructions for these procedures are provided later in this topic.
+You can also use the script to install Giraph on HDInsight by using Azure PowerShell or the HDInsight .NET SDK. Instructions for these procedures are provided later in this topic.
 
 ## <a name="usegiraph"></a>How do I use Giraph in HDInsight?
 
-We use the SimpleShortestPathsComputation to demonstrate the basic <a href = "http://people.apache.org/~edwardyoon/documents/pregel.pdf">Pregel</a> implementation for finding the shortest path between objects in a graph. Use the following steps to upload the sample data and the sample jar, run a job using the SimpleShortestPathsComputation example, and then view the results.
+We use the SimpleShortestPathsComputation example to demonstrate the basic <a href = "http://people.apache.org/~edwardyoon/documents/pregel.pdf">Pregel</a> implementation for finding the shortest path between objects in a graph. Use the following steps to upload the sample data and the sample jar, run a job by using the SimpleShortestPathsComputation example, and then view the results.
 
-1. **Upload a sample data file to WASB**. On your local workstation, create a new file named **tiny_graph.txt**. It should contain the following lines.
+1. Upload a sample data file to Azure Blob storage. On your local workstation, create a new file named **tiny_graph.txt**. It should contain the following lines:
 
 		[0,0,[[1,1],[3,3]]]
 		[1,0,[[0,1],[2,2],[3,1]]]
@@ -71,20 +71,20 @@ We use the SimpleShortestPathsComputation to demonstrate the basic <a href = "ht
 		[3,0,[[0,3],[1,1],[4,4]]]
 		[4,0,[[3,4],[2,4]]]
 
-	Upload the tiny_graph.txt file to the primary storage for your HDInsight cluster. For instructions on how to upload data, see [Upload data for Hadoop jobs in HDInsight](../hdinsight-upload-data/)
+	Upload the tiny_graph.txt file to the primary storage for your HDInsight cluster. For instructions on how to upload data, see [Upload data for Hadoop jobs in HDInsight](../hdinsight-upload-data/).
 
-	This data describes a relationship between objects in a directed graph, using the format [source\_id, source\_value,[[dest\_id], [edge\_value],...]]. Each line represents a relationship between a **source\_id** and one or more **dest\_id** objects. The **edge\_value** (or weight,) can be thought of as the strength or distance of the connection between the **source_id** and the **dest\_id**.
+	This data describes a relationship between objects in a directed graph, by using the format [source\_id, source\_value,[[dest\_id], [edge\_value],...]]. Each line represents a relationship between a **source\_id** object and one or more **dest\_id** objects. The **edge\_value** (or weight) can be thought of as the strength or distance of the connection between **source_id** and **dest\_id**.
 
-	Drawn out, and using the value (or weight,) as the distance between objects, the above data might look like this.
+	Drawn out, and using the value (or weight) as the distance between objects, the above data might look like this:
 
 	![tiny_graph.txt drawn as circles with lines of varying distance between](.\media\hdinsight-hadoop-giraph-install\giraph-graph.png)
 
 	
 
-4. Run the **SimpleShortstPathsComputation** example. Use the following PowerShell cmdlets to run the example using the tiny_graph.txt file as input. This requires that you have installed and configured [Azure PowerShell][powershell-install-configure].
+4. Run the SimpleShortestPathsComputation example. Use the following Azure PowerShell cmdlets to run the example by using the tiny_graph.txt file as input. This requires that you have installed and configured [Azure PowerShell][powershell-install-configure].
 
 		$clusterName = "clustername"
-		# Giraph examples JAR
+		# Giraph examples jar
 		$jarFile = "wasb:///example/jars/giraph-examples.jar"
 		# Arguments for this job
 		$jobArguments = "org.apache.giraph.examples.SimpleShortestPathsComputation",
@@ -100,7 +100,7 @@ We use the SimpleShortestPathsComputation to demonstrate the basic <a href = "ht
 		  -ClassName "org.apache.giraph.GiraphRunner"
 		  -Arguments $jobArguments
 		
-		# Run the job, write output to the PowerShell window
+		# Run the job, write output to the Azure PowerShell window
 		$job = Start-AzureHDInsightJob -Cluster $clusterName -JobDefinition $jobDefinition
 		Write-Host "Wait for the job to complete ..." -ForegroundColor Green
 		Wait-AzureHDInsightJob -Job $job
@@ -111,16 +111,16 @@ We use the SimpleShortestPathsComputation to demonstrate the basic <a href = "ht
 
 	In the above example, replace **clustername** with the name of your HDInsight cluster that has Giraph installed.
 
-5. **View the results**.  Once the job has completed, the results will be stored in two output files at __wasb:///example/out/shotestpaths__ folder. The files are called __part-m-00001__ and __part-m-00002__ files. Perform the following steps to download and view the output.
+5. View the results. Once the job has finished, the results will be stored in two output files in the __wasb:///example/out/shotestpaths__ folder. The files are called __part-m-00001__ and __part-m-00002__. Perform the following steps to download and view the output:
 
 		$subscriptionName = "<SubscriptionName>"       # Azure subscription name
-		$storageAccountName = "<StorageAccountName>"   # Azure storage account name
+		$storageAccountName = "<StorageAccountName>"   # Azure Storage account name
 		$containerName = "<ContainerName>"             # Blob storage container name
 
 		# Select the current subscription
 		Select-AzureSubscription $subscriptionName
 		
-		# Create the storage account context object
+		# Create the Storage account context object
 		$storageAccountKey = Get-AzureStorageKey $storageAccountName | %{ $_.Primary }
 		$storageContext = New-AzureStorageContext -StorageAccountName $storageAccountName -StorageAccountKey $storageAccountKey
 
@@ -128,7 +128,7 @@ We use the SimpleShortestPathsComputation to demonstrate the basic <a href = "ht
 		Get-AzureStorageBlobContent -Container $containerName -Blob example/output/shortestpaths/part-m-00001 -Context $storageContext -Force
 		Get-AzureStorageBlobContent -Container $containerName -Blob example/output/shortestpaths/part-m-00002 -Context $storageContext -Force
 
-	This will create the __example/output/shortestpaths__ directory structure in the current directory on your workstation, and downloads the two output files to that loation.
+	This will create the __example/output/shortestpaths__ directory structure in the current directory on your workstation, and download the two output files to that location.
 
 	Use the __Cat__ cmdlet to display the contents of the files: 
 
@@ -143,46 +143,46 @@ We use the SimpleShortestPathsComputation to demonstrate the basic <a href = "ht
 		1	0.0
 		3	1.0
 
-	The SimpleShortestPathComputation example is hard coded to start with the object ID 1 and find the shortest path to other objects. So the output should be read as `destination_id distance`, where distance is the value (or weight) of the edges traveled between object ID 1 and the target ID.
+	The SimpleShortestPathComputation example is hard coded to start with object ID 1 and find the shortest path to other objects. So the output should be read as `destination_id distance`, where distance is the value (or weight) of the edges traveled between object ID 1 and the target ID.
 	
 	Visualizing this, you can verify the results by traveling the shortest paths between ID 1 and all other objects. Note that the shortest path between ID 1 and ID 4 is 5. This is the total distance between <span style="color:orange">ID 1 and 3</span>, and then <span style="color:red">ID 3 and 4</span>.
 
 	![Drawing of objects as circles with shortest paths drawn between](.\media\hdinsight-hadoop-giraph-install\giraph-graph-out.png) 
 
 
-## <a name="usingPS"></a>Install Giraph on HDInsight Hadoop clusters using PowerShell
+## <a name="usingPS"></a>Install Giraph on HDInsight Hadoop clusters by using Azure PowerShell
 
-In this section we use the **<a href = "http://msdn.microsoft.com/library/dn858088.aspx" target="_blank">Add-AzureHDInsightScriptAction</a>** cmdlet to invoke scripts using Script Action to customize a cluster. Before proceeding, make sure you have installed and configured PowerShell. For information on configuring a workstation to run HDInsight Powershell cmdlets, see [Install and configure Azure PowerShell][powershell-install-configure].
+In this section, we use the **<a href = "http://msdn.microsoft.com/library/dn858088.aspx" target="_blank">Add-AzureHDInsightScriptAction</a>** cmdlet to invoke scripts by using Script Action to customize a cluster. Before proceeding, make sure you have installed and configured Azure PowerShell. For information on configuring a workstation to run Azure Powershell cmdlets for HDInsight, see [Install and configure Azure PowerShell][powershell-install-configure].
 
 Perform the following steps:
 
 1. Open an Azure PowerShell window and declare the following variables:
 
-		# PROVIDE VALUES FOR THESE VARIABLES
+		# Provide values for these variables
 		$subscriptionName = "<SubscriptionName>"		# Name of the Azure subscription
-		$clusterName = "<HDInsightClusterName>"			# The HDInsight cluster name
-		$storageAccountName = "<StorageAccountName>"	# Azure storage account that hosts the default container
-		$storageAccountKey = "<StorageAccountKey>"      # Key for the storage account
+		$clusterName = "<HDInsightClusterName>"			# HDInsight cluster name
+		$storageAccountName = "<StorageAccountName>"	# Azure Storage account that hosts the default container
+		$storageAccountKey = "<StorageAccountKey>"      # Key for the Storage account
 		$containerName = $clusterName
-		$location = "<MicrosoftDataCenter>"				# The location of the HDInsight cluster. It must in the same data center as the storage account.
-		$clusterNodes = <ClusterSizeInNumbers>			# The number of nodes in the HDInsight cluster.
-		$version = "<HDInsightClusterVersion>"          # For example "3.1"
+		$location = "<MicrosoftDataCenter>"				# Location of the HDInsight cluster. It must be in the same data center as the Storage account.
+		$clusterNodes = <ClusterSizeInNumbers>			# Number of nodes in the HDInsight cluster
+		$version = "<HDInsightClusterVersion>"          # For example, "3.1"
 	
-2. Specify the configuration values such as nodes in the cluster and the default storage to be used.
+2. Specify the configuration values, such as nodes in the cluster and the default storage to be used:
 
-		# SPECIFY THE CONFIGURATION OPTIONS
+		# Specify the configuration options
 		Select-AzureSubscription $subscriptionName
 		$config = New-AzureHDInsightClusterConfig -ClusterSizeInNodes $clusterNodes
 		$config.DefaultStorageAccount.StorageAccountName="$storageAccountName.blob.core.windows.net"
 		$config.DefaultStorageAccount.StorageAccountKey=$storageAccountKey
 		$config.DefaultStorageAccount.StorageContainerName=$containerName
 	
-3. Use **Add-AzureHDInsightScriptAction** cmdlet to to add Script Action to cluster configuration. Later, when the cluster is being created, the Script Action gets executed. 
+3. Use the **Add-AzureHDInsightScriptAction** cmdlet to add a script action to the cluster configuration. Later, when the cluster is being created, the script action gets executed. 
 
-		# ADD SCRIPT ACTION TO CLUSTER CONFIGURATION
+		# Add a script action to the cluster configuration
 		$config = Add-AzureHDInsightScriptAction -Config $config -Name "Install Giraph" -ClusterRoleCollection HeadNode -Uri https://hdiconfigactions.blob.core.windows.net/giraphconfigactionv01/giraph-installer-v01.ps1
 
-	**Add-AzureHDInsightScriptAction** cmdlet takes the following parameters:
+	The **Add-AzureHDInsightScriptAction** cmdlet takes the following parameters:
 
 	<table style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse;">
 	<tr>
@@ -190,43 +190,43 @@ Perform the following steps:
 	<th style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; width:550px; padding-left:5px; padding-right:5px;">Definition</th></tr>
 	<tr>
 	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">Config</td>
-	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px; padding-right:5px;">The configuration object to which script action information is added</td></tr>
+	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px; padding-right:5px;">Configuration object to which script action information is added.</td></tr>
 	<tr>
 	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">Name</td>
-	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">Name of the script action</td></tr>
+	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">Name of the script action.</td></tr>
 	<tr>
 	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">ClusterRoleCollection</td>
-	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">Specifies the nodes on which the customization script is run. The valid values are HeadNode (to install on the headnode) or DataNode (to install on all the datanodes). You can use either or both values.</td></tr>
+	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">Nodes on which the customization script is run. The valid values are HeadNode (to install on the head node) or DataNode (to install on all the data nodes). You can use either or both values.</td></tr>
 	<tr>
 	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">Uri</td>
-	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">Specifies the URI to the script that is executed</td></tr>
+	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">URI to the script that is executed.</td></tr>
 	<tr>
 	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">Parameters</td>
 	<td style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse; padding-left:5px;">Parameters required by the script. The sample script used in this topic does not require any parameters, and hence you do not see this parameter in the snippet above.
 	</td></tr>
 	</table>
 	
-4. Finally, start provisioning a customized cluster with Giraph installed.  
+4. Finally, start provisioning a customized cluster with Giraph installed:  
 	
-		# START PROVISIONING A CLUSTER WITH GIRAPH INSTALLED
+		# Start provisioning a cluster with Giraph installed
 		New-AzureHDInsightCluster -Config $config -Name $clusterName -Location $location -Version $version 
 
 When prompted, enter the credentials for the cluster. It can take several minutes before the cluster is created.
 
 
-## <a name="usingSDK"></a>Install Giraph on HDInsight Hadoop clusters using the .NET SDK
+## <a name="usingSDK"></a>Install Giraph on HDInsight Hadoop clusters by using the .NET SDK
 
-The HDInsight .NET SDK provides .NET client libraries that makes it easier to work with HDInsight from a .NET application. This section provides instructions on how to use Script Action from the SDK to provision a cluster that has Giraph installed. The following procedures must be performed:
+The HDInsight .NET SDK provides .NET client libraries that make it easier to work with HDInsight from a .NET Framework application. This section provides instructions on how to use Script Action from the SDK to provision a cluster that has Giraph installed. The following procedures must be performed:
 
-- Install HDInsight .NET SDK
+- Install the HDInsight .NET SDK
 - Create a self-signed certificate
 - Create a console application
 - Run the application
 
 
-**To install HDInsight .NET SDK**
+**To install the HDInsight .NET SDK**
 
-You can install latest published build of the SDK from [NuGet](http://nuget.codeplex.com/wikipage?title=Getting%20Started). The instructions will be shown in the next procedure.
+You can install the latest published build of the SDK from [NuGet](http://nuget.codeplex.com/wikipage?title=Getting%20Started). The instructions will be shown in the next procedure.
 
 **To create a self-signed certificate**
 
@@ -237,9 +237,9 @@ Create a self-signed certificate, install it on your workstation, and upload it 
 
 1. Open Visual Studio 2013.
 
-2. From the File menu, click **New**, and then click **Project**.
+2. From the **File** menu, click **New**, and then click **Project**.
 
-3. From New Project, type or select the following values:
+3. From **New Project**, type or select the following values:
 	
 	<table style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse;">
 	<tr>
@@ -260,7 +260,7 @@ Create a self-signed certificate, install it on your workstation, and upload it 
 
 5. From the **Tools** menu, click **Nuget Package Manager**, and then click **Package Manager Console**.
 
-6. Run the following commands in the console to install the package.
+6. Run the following command in the console to install the package:
 
 		Install-Package Microsoft.WindowsAzure.Management.HDInsight
 
@@ -275,11 +275,11 @@ Create a self-signed certificate, install it on your workstation, and upload it 
 		using Microsoft.WindowsAzure.Management.HDInsight.ClusterProvisioning;
 		using Microsoft.WindowsAzure.Management.HDInsight.Framework.Logging;
 	
-9. In the Main() function, copy and paste the following code, and provide values for the variables :
+9. In the Main() function, copy and paste the following code, and provide values for the variables:
 		
         var clusterName = args[0];
 
-        // PROVIDE VALUES FOR THE VARIABLES
+        // Provide values for the variables
         string thumbprint = "<CertificateThumbprint>";  
         string subscriptionId = "<AzureSubscriptionID>";
         string location = "<MicrosoftDataCenterLocation>";
@@ -289,17 +289,17 @@ Create a self-signed certificate, install it on your workstation, and upload it 
         string password = "<HDInsightUserPassword>";
         int clustersize = <NumberOfNodesInTheCluster>;
 
-        // PROVIDE THE CERTIFICATE THUMBPRINT TO RETRIEVE THE CERTIFICATE FROM THE CERTIFICATE STORE 
+        // Provide the certificate thumbprint to retrieve the certificate from the certificate store 
         X509Store store = new X509Store();
         store.Open(OpenFlags.ReadOnly);
         X509Certificate2 cert = store.Certificates.Cast<X509Certificate2>().First(item => item.Thumbprint == thumbprint);
 
-        // CREATE AN HDINSIGHT CLIENT OBJECT
+        // Create an HDInsight client object
         HDInsightCertificateCredential creds = new HDInsightCertificateCredential(new Guid(subscriptionId), cert);
         var client = HDInsightClient.Connect(creds);
 		client.IgnoreSslErrors = true;
         
-        // PROVIDE THE CLUSTER INFORMATION
+        // Provide the cluster information
 		var clusterInfo = new ClusterCreateParameters()
         {
             Name = clusterName,
@@ -313,25 +313,25 @@ Create a self-signed certificate, install it on your workstation, and upload it 
             Version = "3.1"
         };        
 
-10. Append the following code to the Main() function to use the [ScriptAction](http://msdn.microsoft.com/library/microsoft.windowsazure.management.hdinsight.clusterprovisioning.data.scriptaction.aspx) class to invoke a custom script to install Giraph.
+10. Append the following code to the Main() function to use the [ScriptAction](http://msdn.microsoft.com/library/microsoft.windowsazure.management.hdinsight.clusterprovisioning.data.scriptaction.aspx) class to invoke a custom script to install Giraph:
 
-		// ADD THE SCRIPT ACTION TO INSTALL GIRAPH
+		// Add the script action to install Giraph
         clusterInfo.ConfigActions.Add(new ScriptAction(
           "Install Giraph", // Name of the config action
           new ClusterNodeType[] { ClusterNodeType.HeadNode }, // List of nodes to install Giraph on
           new Uri("https://hdiconfigactions.blob.core.windows.net/giraphconfigactionv01/giraph-installer-v01.ps1"), // Location of the script to install Giraph
-		  null //because the script used does not require any parameters.
+		  null //Because the script used does not require any parameters
         ));
 
-11. Finally, create the cluster.
+11. Finally, create the cluster:
 
 		client.CreateCluster(clusterInfo);
 
-11. Save changes to the application and build the solution. 
+12. Save changes to the application and build the solution. 
 
 **To run the application**
 
-Open a PowerShell console, navigate to the location where you saved the Visual Studio project, navigate to the \bin\debug directory within the project, and then run the following command:
+Open an Azure PowerShell console, navigate to the location where you saved the Visual Studio project, navigate to the \bin\debug directory within the project, and then run the following command:
 
 	.\CreateGiraphCluster <cluster-name>
 
@@ -339,9 +339,9 @@ Provide a cluster name and press ENTER to provision a cluster with Giraph instal
 
 
 ## See also##
-- [Install and use Spark on HDInsight clusters][hdinsight-install-spark] for instructions on how to use cluster customization to install and use Spark on HDInsight Hadoop clusters. Spark is an open-source parallel processing framework that supports in-memory processing to boost the performance of big data analytic applications.
-- [Install R on HDInsight clusters][hdinsight-install-r] provides instructions on how to use cluster customization to install and use R on HDinsight Hadoop clusters. R is an open source language and environment for statistical computing and provides hundreds of build-in statistical functions and its own programming language that combines aspects of functional and object-oriented programming. It also provides extensive graphical capabilities.
-- [Install Solr on HDInsight clusters](../hdinsight-hadoop-solr-install). Use cluster customization to install Solr on HDInsight Hadoop clusters. Solr allows you to perform search powerful search operations on data stored.
+- [Install and use Spark on HDInsight clusters][hdinsight-install-spark] for instructions on how to use cluster customization to install and use Spark on HDInsight Hadoop clusters. Spark is an open-source parallel processing framework that supports in-memory processing to boost the performance of big-data analytic applications.
+- [Install R on HDInsight clusters][hdinsight-install-r] provides instructions on how to use cluster customization to install and use R on HDInsight Hadoop clusters. R is an open-source language and environment for statistical computing. It provides hundreds of built-in statistical functions and its own programming language that combines aspects of functional and object-oriented programming. It also provides extensive graphical capabilities.
+- [Install Solr on HDInsight clusters](../hdinsight-hadoop-solr-install). Use cluster customization to install Solr on HDInsight Hadoop clusters. Solr allows you to perform powerful search operations on data stored.
 
 
 


### PR DESCRIPTION
Edit complete.

On line 37, in "Azure storage blob," if "storage" refers to a Storage account rather than storage in general, it should be initial capped.

The table after line 42 includes UI text in title case, but those items appear in all caps in the screenshot. It would be better if capitalization of UI elements mentioned in text consistently matched what the UI shows.

I'm not sure about the term "script action." It doesn't appear in the Azure terminology resources. In this document, I tried to capitalize the term as "Script Action" when it seems to refer to a specific name (of a feature or a service) but use the lowercase "script action" for generic references. Please confirm that I made the right decisions.

Per naming guidelines, I changed instances of "PowerShell" by itself to "Azure PowerShell." Please make sure that all mentions are technically accurate and shouldn't be "Windows PowerShell" instead.

The figures after line 78 and 148 aren't rendering in the preview. Please make sure there's nothing wrong with them.

Line 114 shows a folder called "wasb:///example/out/shotestpaths." The "shotestpaths" part seems to be a typo that should read "shortestpaths."

Line 229 says "You can install the latest published build of the SDK from... The instructions will be shown in the next procedure." But the procedure that immediately follows this line doesn't seem to show that. Please check this.

The "NuGet" link does go to the NuGet website, but it's not the right page (I see a "page...does not exist" error).
