### PR TITLE
Add node 0.12 to nodejs-specify-node-version-azure-apps.md

### DIFF
--- a/articles/nodejs-specify-node-version-azure-apps.md
+++ b/articles/nodejs-specify-node-version-azure-apps.md
@@ -14,6 +14,7 @@ When hosting a Node.js application, you may want to ensure that your application
 
 The Node.js versions provided by Azure are constantly updated. Unless otherwise specified, the latest available version will be used. Currently included are the following versions:
 
+- 0.12.x: 0.12.0
 - 0.10.x: 0.10.32, 0.10.31, 0.10.29, 0.10.28, 10.26, 0.10.24, 0.10.21, 0.10.18, 0.10.5
 - 0.8.x: 0.8.28, 0.8.27, 0.8.26, 0.8.19, 0.8.2
 - 0.6.x: 0.6.20, 0.6.17


### PR DESCRIPTION
Added node 0.12.0 to **Default versions** list, because I saw `D:\Program Files (x86)\nodejs\0.12.0\node.exe` was available for my website, and now I'm running it.