### PR TITLE
Fixed link to videos, samples and tutorials

### DIFF
--- a/articles/search-howto-dotnet-sdk.md
+++ b/articles/search-howto-dotnet-sdk.md
@@ -339,7 +339,7 @@ This step completes the tutorial, but don't stop here. **Next steps** provides a
 
 ## Next Steps ##
 
-- Deepen your knowledge through [videos and other samples and tutorials]](https://msdn.microsoft.com/en-us/library/azure/dn818681.aspx).
+- Deepen your knowledge through [videos and other samples and tutorials](https://msdn.microsoft.com/en-us/library/azure/dn818681.aspx).
 - Read about features and capabilities in this version of the Azure Search SDK: [Azure Search Overview](https://msdn.microsoft.com/en-us/library/azure/dn798933.aspx)
 - Review [naming conventions](https://msdn.microsoft.com/en-us/library/azure/dn857353.aspx) to learn the rules for naming various objects.
 - Review [supported data types](https://msdn.microsoft.com/en-us/library/azure/dn798938.aspx) in Azure Search.


### PR DESCRIPTION
There was a double closing bracket and the text didn't show as a link