### PR TITLE
Fix example code in how to receive messages

### DIFF
--- a/articles/service-bus-nodejs-how-to-use-queues.md
+++ b/articles/service-bus-nodejs-how-to-use-queues.md
@@ -202,19 +202,19 @@ processed using **receiveQueueMessage**. The example first receives and
 deletes a message, and then receives a message using **isPeekLock** set
 to true, then deletes the message using **deleteMessage**:
 
-    serviceBusService.receiveQueueMessage('taskqueue', function(error, receivedMessage){
+    serviceBusService.receiveQueueMessage('myqueue', function(error, receivedMessage){
         if(!error){
             // Message received and deleted
         }
     });
-    serviceBusService.receiveQueueMessage(queueName, { isPeekLock: true }, function(error, lockedMessage){
+    serviceBusService.receiveQueueMessage('myqueue', { isPeekLock: true }, function(error, lockedMessage){
         if(!error){
             // Message received and locked
             serviceBusService.deleteMessage(lockedMessage, function (deleteError){
                 if(!deleteError){
                     // Message deleted
                 }
-            }
+            });
         }
     });
 


### PR DESCRIPTION
Fixes the simple example code in how to receive messages from a queue section. 

Plus harmonize queue name to 'myqueue' all over the tutorial.