### PR TITLE
Edit stream-analytics-dotnet-management-sdk.md

### DIFF
--- a/articles/stream-analytics-dotnet-management-sdk.md
+++ b/articles/stream-analytics-dotnet-management-sdk.md
@@ -21,7 +21,7 @@
 
 [This is prerelease documentation and is subject to change in future releases.] 
 
-Azure Stream Analytics is a fully managed service providing low latency, highly available, scalable complex event processing over streaming data in the cloud. In the preview release,  Stream Analytics enables customers to setup streaming jobs to analyze data streams, and allows customers to drive near real-time analytics.  
+Azure Stream Analytics is a fully managed service providing low-latency, highly available, scalable, complex event processing over streaming data in the cloud. In the preview release, Stream Analytics enables customers to set up streaming jobs to analyze data streams, and allows customers to drive near real-time analytics.  
 
 This article demonstrates how to use the Azure Stream Analytics Management .NET SDK.
 
@@ -29,34 +29,34 @@ This article demonstrates how to use the Azure Stream Analytics Management .NET 
 ## Prerequisites
 Before you begin this article, you must have the following:
 
-- Visual Studio 2012 or 2013.
+- Install Visual Studio 2012 or 2013.
 - Download and install [Azure .NET SDK](http://azure.microsoft.com/downloads/). 
-- Create an Azure Resource Group in your subscription. The following is a sample PowerShell script. For PowerShell information, see [Install and configure Azure PowerShell](http://azure.microsoft.com/documentation/articles/install-configure-powershell/);  
+- Create an Azure resource group in your subscription. The following is a sample Azure PowerShell script. For Azure PowerShell information, see [Install and configure Azure PowerShell](http://azure.microsoft.com/documentation/articles/install-configure-powershell/).  
 
-		# Configure the PowerShell session to access the Azure resource manager.
+		# Configure the Azure PowerShell session to access Azure Resource Manager
 		Switch-AzureMode AzureResourceManager
 
-		# Log into your Azure account.
+		# Log in to your Azure account
 		Add-AzureAccount
 
-		# Select the Azure subscription you want to use to create the resource group.
+		# Select the Azure subscription you want to use to create the resource group
 		Select-AzureSubscription -SubscriptionName <subscription name>
 
-		# Create an Azure source group	
+		# Create an Azure resource group	
 		New-AzureResourceGroup -Name <YOUR RESORUCE GROUP NAME> -Location <LOCATION>
 
-4.	This article assumes you have already set up an input source and output target to use. See [Get Started Using Azure Stream Analytics](http://azure.microsoft.com/documentation/articles/stream-analytics-get-started/) to set up a sample input and/or output to be used by this article.
+- Set up an input source and output target to use. See [Get Started Using Azure Stream Analytics](http://azure.microsoft.com/documentation/articles/stream-analytics-get-started/) to set up a sample input and/or output to be used by this article.
 
 
-## Setup a project
+## Set up a project
 
-1. Create a Visual Studio C# .Net console application.
+1. Create a Visual Studio C# .NET console application.
 2. In the Package Manager Console, run the following commands to install the NuGet packages. The first one is the Azure Stream Analytics Management .NET SDK. The second one is the Azure Active Directory client that will be used for authentication.
 
 		Install-Package Microsoft.Azure.Management.StreamAnalytics -Pre
 		Install-Package Microsoft.IdentityModel.Clients.ActiveDirectory
 
-4. Add the following appSetttings section to the App.config file.
+4. Add the following **appSettings** section to the App.config file:
 
 		<appSettings>
 		  <!--CSM Prod related values-->
@@ -70,11 +70,11 @@ Before you begin this article, you must have the following:
 		</appSettings>
 
 
-	Replace values for *SubscriptionId* and *ActiveDirectoryTenantId* with your Azure subscription and tenant IDs. You can get these values by running the following PowerShell cmdlet:
+	Replace values for **SubscriptionId** and **ActiveDirectoryTenantId** with your Azure subscription and tenant IDs. You can get these values by running the following Azure PowerShell cmdlet:
 
 		Get-AzureAccount
 
-5. Add the following using statements to the source file (Program.cs) in the project.
+5. Add the following **using** statements to the source file (Program.cs) in the project:
 
 		using System;
 		using System.Configuration;
@@ -84,7 +84,7 @@ Before you begin this article, you must have the following:
 		using Microsoft.Azure.Management.StreamAnalytics.Models;
 		using Microsoft.IdentityModel.Clients.ActiveDirectory;
 
-6.	Add an authentication helper method.
+6.	Add an authentication helper method:
 
 		public static string GetAuthorizationHeader()
 		{
@@ -125,9 +125,9 @@ Before you begin this article, you must have the following:
 
 ## Create a Stream Analytics management client
 
-A *StreamAnalyticsManagementClient* object allows you to manage the job, and the job components such as inputs, outputs, and transformation. 
+A **StreamAnalyticsManagementClient** object allows you to manage the job and the job components, such as input, output, and transformation. 
 
-Add the following code to the beginning of the Main method. 
+Add the following code to the beginning of the **Main** method: 
 
 	string resourceGroupName = "<YOUR AZURE RESOURCE GROUP NAME>";
 	string streamAnalyticsJobName = "<YOUR STREAM ANALYTICS JOB NAME>";
@@ -144,13 +144,13 @@ Add the following code to the beginning of the Main method.
 	// Create Stream Analytics management client
 	StreamAnalyticsManagementClient client = new StreamAnalyticsManagementClient(aadTokenCredentials);
 
-The resourceGroupName variable's value should be the same as the name of the resource group you created or picked in the prerequisite steps.
+The **resourceGroupName** variable's value should be the same as the name of the resource group you created or picked in the prerequisite steps.
 
-The remaining sections of this article assume that this code is at the beginning of the Main method.
+The remaining sections of this article assume that this code is at the beginning of the **Main** method.
 
-## Create a Stream Analytics Job
+## Create a Stream Analytics job
 
-The following code creates a Stream Analytics job under the resource group that you have defined. You will add inputs, output, and transformation to the job later.
+The following code creates a Stream Analytics job under the resource group that you have defined. You will add an input, output, and transformation to the job later.
 
 	// Create a Stream Analytics job
 	JobCreateOrUpdateParameters jobCreateParameters = new JobCreateOrUpdateParameters()
@@ -173,9 +173,9 @@ The following code creates a Stream Analytics job under the resource group that 
 	JobCreateOrUpdateResponse jobCreateResponse = client.StreamingJobs.CreateOrUpdate(resourceGroupName, jobCreateParameters);
 
 
-## Create a Stream Analytics Input Source
+## Create a Stream Analytics input source
 
-The following code creates a Stream Analytics input source with the Blob input source type and CSV serialization. To create an Event Hub input source, use *EventHubStreamInputDataSource* instead of *BlobStreamInputDataSource*. Similarly, you can customize the serialization type of the input source.
+The following code creates a Stream Analytics input source with the blob input source type and CSV serialization. To create an event-hub input source, use **EventHubStreamInputDataSource** instead of **BlobStreamInputDataSource**. Similarly, you can customize the serialization type of the input source.
 
 	// Create a Stream Analytics input source
 	InputCreateOrUpdateParameters jobInputCreateParameters = new InputCreateOrUpdateParameters()
@@ -216,12 +216,12 @@ The following code creates a Stream Analytics input source with the Blob input s
 	InputCreateOrUpdateResponse inputCreateResponse = 
 		client.Inputs.CreateOrUpdate(resourceGroupName, streamAnalyticsJobName, jobInputCreateParameters);
 
-Input sources are tied to a specific job. To use the same input source for different jobs, you must call the method again specifying a different job name.
+Input sources are tied to a specific job. To use the same input source for different jobs, you must call the method again and specify a different job name.
 
 
-## Test a Stream Analytics Input Source
+## Test a Stream Analytics input source
 
-The *TestConnection* method tests whether the Stream Analytics job is able to connect to the input source as well as other aspects specific to the input source type. For example, in the blob input source you created in an earlier step, the method will check that the Storage account name and key pair can be used to connect to the storage account as well as check that the container specified exists.
+The **TestConnection** method tests whether the Stream Analytics job is able to connect to the input source as well as other aspects specific to the input source type. For example, in the blob input source you created in an earlier step, the method will check that the Storage account name and key pair can be used to connect to the Storage account as well as check that the specified container exists.
 
 	// Test input source connection
 	DataSourceTestConnectionResponse inputTestResponse = 
@@ -229,9 +229,9 @@ The *TestConnection* method tests whether the Stream Analytics job is able to co
 
 ## Create a Stream Analytics output target
 
-Creating an output target is very similar to creating a Stream Analytics input source. Like input sources, output targets are tied to a specific job. To use the same output target for different jobs, you must call the method again specifying a different job name.
+Creating an output target is very similar to creating a Stream Analytics input source. Like input sources, output targets are tied to a specific job. To use the same output target for different jobs, you must call the method again and specify a different job name.
 
-The following code creates a SQL output target. You can customize the output target's data type and/or serialization type.
+The following code creates an output target (Azure SQL database). You can customize the output target's data type and/or serialization type.
 
 	// Create a Stream Analytics output target
 	OutputCreateOrUpdateParameters jobOutputCreateParameters = new OutputCreateOrUpdateParameters()
@@ -261,15 +261,15 @@ The following code creates a SQL output target. You can customize the output tar
 
 ## Test a Stream Analytics output target
 
-Stream Analytics output target also has the TestConnection method for testing connections.
+A Stream Analytics output target also has the **TestConnection** method for testing connections.
 
 	// Test output target connection
 	DataSourceTestConnectionResponse outputTestResponse = 
 		client.Outputs.TestConnection(resourceGroupName, streamAnalyticsJobName, streamAnalyticsOutputName);
 
-## Create a Stream Analytics Transformation
+## Create a Stream Analytics transformation
 
-The following code creates a Stream Analytics transformation with the query “select * from Input” and specifies to allocate one streaming unit for the Stream Analytics job. For more information on adjusting streaming unit, see [Scale Azure Stream Analytics jobs](http://azure.microsoft.com/documentation/articles/stream-analytics-scale-jobs/).
+The following code creates a Stream Analytics transformation with the query “select * from Input” and specifies to allocate one streaming unit for the Stream Analytics job. For more information on adjusting streaming units, see [Scale Azure Stream Analytics jobs](http://azure.microsoft.com/documentation/articles/stream-analytics-scale-jobs/).
 
 	// Create a Stream Analytics transformation
 	TransformationCreateOrUpdateParameters transformationCreateParameters = new TransformationCreateOrUpdateParameters()
@@ -288,12 +288,12 @@ The following code creates a Stream Analytics transformation with the query “s
 	var transformationCreateResp = 
 		client.Transformations.CreateOrUpdate(resourceGroupName, streamAnalyticsJobName, transformationCreateParameters);
 
-Like inputs and outputs, transformations are also tied to the specific Stream Analytics job it was created under.
+Like input and output, a transformations is also tied to the specific Stream Analytics job it was created under.
 
-## Start a Stream Analytics Job
-After creating a Stream Analytics job and its input(s), output(s), and transformation, you can start the job by calling the Start method. 
+## Start a Stream Analytics job
+After creating a Stream Analytics job and its input(s), output(s), and transformation, you can start the job by calling the **Start** method. 
 
-The following sample code starts a Stream Analytics job with a custom output start time set to December 12, 2012 12:12:12 UTC.
+The following sample code starts a Stream Analytics job with a custom output start time set to December 12, 2012, 12:12:12 UTC:
 
 	// Start a Stream Analytics job
 	JobStartParameters jobStartParameters = new JobStartParameters
@@ -306,14 +306,14 @@ The following sample code starts a Stream Analytics job with a custom output sta
 
 
 
-## Stop a Stream Analytics Job
-You can stop a running Stream Analytics job by calling the Stop method.
+## Stop a Stream Analytics job
+You can stop a running Stream Analytics job by calling the **Stop** method.
 
 	// Stop a Stream Analytics job
 	LongRunningOperationResponse jobStopResponse = client.StreamingJobs.Stop(resourceGroupName, streamAnalyticsJobName);
 
-## Delete a Stream Analytics Job
-The delete method will delete the job as well as the underlying sub-resources, including input(s), output(s), and  transformation of the job.
+## Delete a Stream Analytics job
+The **Delete** method will delete the job as well as the underlying sub-resources, including input(s), output(s), and transformation of the job.
 
 	// Delete a Stream Analytics job
 	LongRunningOperationResponse jobDeleteResponse = client.StreamingJobs.Delete(resourceGroupName, streamAnalyticsJobName);
@@ -325,8 +325,8 @@ The delete method will delete the job as well as the underlying sub-resources, i
 - [Get started using Azure Stream Analytics][stream.analytics.get.started]
 - [Scale Azure Stream Analytics jobs][stream.analytics.scale.jobs]
 - [Azure Stream Analytics limitations and known issues][stream.analytics.limitations]
-- [Azure Stream Analytics query language reference][stream.analytics.query.language.reference]
-- [Azure Stream Analytics management REST API reference][stream.analytics.rest.api.reference] 
+- [Azure Stream Analytics Query Language Reference][stream.analytics.query.language.reference]
+- [Azure Stream Analytics Management REST API Reference][stream.analytics.rest.api.reference] 
 
 
 


### PR DESCRIPTION
Edit complete.

You can spell out CSV as "comma-separated values (CSV)" at first mention if you think that would be helpful for the audience.

I changed the one instance of "Event Hub" to a lowercase form because it looked like you intended to refer to the generic concept and not the Azure Event Hubs service. I also changed "Blob" to "blob" for the same reason. Please make sure that these choices are correct.

Per naming guidelines, I changed instances of "PowerShell" by itself to "Azure PowerShell." Please make sure that all mentions are technically accurate and shouldn't be "Windows PowerShell" instead.

On line 234, I changed "creates a SQL output target" to "creates an output target (Azure SQL database)" for clarity. Please confirm that this change is accurate.
