### PR TITLE
Edit hdinsight-administer-use-management-portal.md

### DIFF
--- a/articles/hdinsight-administer-use-management-portal.md
+++ b/articles/hdinsight-administer-use-management-portal.md
@@ -16,90 +16,89 @@
 	ms.date="03/12/2015" 
 	ms.author="jgao"/>
 
-#Manage Hadoop clusters in HDInsight using the Azure Management Portal
+#Manage Hadoop clusters in HDInsight by using the Azure portal
 
 ##Overview
-Using the Azure management portal, you can provision Hadoop clusters in HDInsight, change the Hadoop user password, and enable RDP so you can access the Hadoop command console on the cluster. There are also other tools available for administrating HDInsight in addition to the Management portal. 
+Using the Azure portal, you can provision Hadoop clusters in Azure HDInsight, change the Hadoop user password, and enable Remote Desktop Protocol (RDP) so you can access the Hadoop command console on the cluster. There are also other tools available for administering HDInsight in addition to the Azure portal. 
 
-- For more information on administering HDInsight using Azure PowerShell, see [Administer HDInsight Using PowerShell][hdinsight-admin-powershell].
+- For more information on administering HDInsight by using Azure PowerShell, see [Administer HDInsight Using Azure PowerShell][hdinsight-admin-powershell].
 
-- For more information on administering HDInsight using the Cross-platform Command-line Tools, see [Administer HDInsight Using Cross-platform Command-line Interface][hdinsight-admin-cross-platform]. 
+- For more information on administering HDInsight by using the cross-platform command-line tools, see [Administer HDInsight Using Cross-Platform Command-line Interface][hdinsight-admin-cross-platform]. 
 
 ##Prerequisites
 
 Before you begin this article, you must have the following:
 
-- **Azure subscription**. Azure is a subscription-based platform. For information about obtaining a subscription, see [Purchase Options][azure-purchase-options], [Member Offers][azure-member-offers], or [Free Trial][azure-free-trial].
-- **Azure storage account**. An HDInsight cluster uses an Azure Blob Storage container as the default file system. For more information about how Azure Blob Storage provides a seamless experience with HDInsight clusters, see [Use Azure Blob Storage with HDInsight][hdinsight-storage]. For details on creating an Azure storage account, see [How to Create a Storage Account][azure-create-storageaccount].
+- **Azure subscription** - Azure is a subscription-based platform. For information about obtaining a subscription, see [Purchase Options][azure-purchase-options], [Member Offers][azure-member-offers], or [Free Trial][azure-free-trial].
+- **Azure Storage account** - An HDInsight cluster uses an Azure Blob storage container as the default file system. For more information about how Azure Blob storage provides a seamless experience with HDInsight clusters, see [Use Azure Blob Storage with HDInsight][hdinsight-storage]. For details on creating an Azure Storage account, see [How to Create a Storage Account][azure-create-storageaccount].
 
 ##<a id="create"></a> Provision HDInsight clusters
 
-You can provision HDInsight clusters from the Azure Management Portal using the Quick Create or Custom Create options. See the following links for instructions
+You can provision HDInsight clusters from the Azure portal by using the Quick Create or Custom Create option. See the following links for instructions:
 
-- [Provision a cluster using Quick Create](hdinsight-get-started.md#provision)
-- [Provision a cluster using Custom Create](hdinsight-provision-clusters.md#portal) 
+- [Provision a cluster by using Quick Create](hdinsight-get-started.md#provision)
+- [Provision a cluster by using Custom Create](hdinsight-provision-clusters.md#portal) 
 
 [AZURE.INCLUDE [data center list](../includes/hdinsight-pricing-data-centers-clusters.md)]
 
 
 ##Customize HDInsight clusters
 
-HDInsight works with a wide range of Hadoop components. For the list of the components that have been verified and supported, see [What version of Hadoop is in Azure HDInsight][hdinsight-versions]. HDInsight customization can be done using one of the following options:
+HDInsight works with a wide range of Hadoop components. For the list of the components that have been verified and supported, see [What version of Hadoop is in Azure HDInsight][hdinsight-versions]. You can customize HDInsight by using one of the following options:
 
-- Use Script Actions to run custom scripts that can customize a cluster to either change cluster configuration or install custom components such as Giraph, Solr, etc. For more information, see [Customize HDInsight cluster using Script Action](hdinsight-hadoop-customize-cluster.md).
-- Use the cluster customization parameters in HDInsight .NET SDK or Azure PowerShell during cluster provision. By doing so, these configuration changes are preserved through lifetime of the cluster and not affected by cluster node reimages that Azure platform periodically performs for maintenance. For more information on using the cluster customization parameters, see [Provision HDInsight clusters][hdinsight-provision].
-- Some native Java components, like Mahout, Cascading, can be run on the cluster as JAR files. These JAR files can be distributed to Azure Blob storage (WASB), and submitted to HDInsight clusters using Hadoop job submission mechanisms. For more information see [Submit Hadoop jobs programmatically][hdinsight-submit-jobs]. 
+- Use Script Action to run custom scripts that can customize a cluster to either change cluster configuration or install custom components such as Giraph or Solr. For more information, see [Customize HDInsight cluster using Script Action](hdinsight-hadoop-customize-cluster.md).
+- Use the cluster customization parameters in the HDInsight .NET SDK or Azure PowerShell during cluster provisioning. These configuration changes are then preserved through the lifetime of the cluster and are not affected by cluster node reimages that Azure platform periodically performs for maintenance. For more information on using the cluster customization parameters, see [Provision HDInsight clusters][hdinsight-provision].
+- Some native Java components, like Mahout and Cascading, can be run on the cluster as JAR files. These JAR files can be distributed to Azure Blob storage, and submitted to HDInsight clusters through Hadoop job submission mechanisms. For more information, see [Submit Hadoop jobs programmatically][hdinsight-submit-jobs]. 
 
 
-	>[AZURE.NOTE] If you have issues deploying jar files to HDInsight clusters or calling jar files on HDInsight clusters, contact [Microsoft Support][hdinsight-support].
+	>[AZURE.NOTE] If you have issues deploying JAR files to HDInsight clusters or calling JAR files on HDInsight clusters, contact [Microsoft Support][hdinsight-support].
 	
 	> Cascading is not supported by HDInsight, and is not eligible for Microsoft Support. For lists of supported components, see [What's new in the cluster versions provided by HDInsight?][hdinsight-versions].
 
 
-Installation of custom software on the cluster using remote desktop connection is not supported. You should avoid storing any files on the drives of the head node as they are lost if you need to recreate the clusters. We recommend to store files on Azure Blob storage. Blob storage is persistent.
+Installation of custom software on the cluster by using Remote Desktop Connection is not supported. You should avoid storing any files on the drives of the head node, as they will be lost if you need to re-create the clusters. We recommend storing files on Azure Blob storage. Blob storage is persistent.
 
-##Change the HDInsight cluster username and password
-An HDInsight cluster can have two user accounts.  The HDInsight cluster user account is created during the provision processs.  You can also create a RDP user account for accessing the cluster via RDP. See [Enable remote desktop](#enablerdp).
+##Change the HDInsight cluster user name and password
+An HDInsight cluster can have two user accounts. The HDInsight cluster user account is created during the provisioning process. You can also create an RDP user account for accessing the cluster via RDP. See [Enable remote desktop](#enablerdp).
 
-**To change HDInsight cluster username and password**
+**To change the HDInsight cluster user name and password**
 
-1. Sign in to the [Azure Management Portal][azure-management-portal].
+1. Sign in to the [Azure portal][azure-management-portal].
 2. Click **HDINSIGHT** on the left pane. You will see a list of deployed HDInsight clusters.
-3. Click the HDInsight cluster that you want to reset the username and password.
+3. Click the HDInsight cluster that you want to reset the user name and password for.
 4. From the top of the page, click **CONFIGURATION**.
-5. Click **OFF** next  to **HADOOP SERVICES**.
-6. Click **SAVE** on the bottom of the page, and wait for the disabling to complete.
+5. Click **OFF** next to **HADOOP SERVICES**.
+6. Click **SAVE** on the bottom of the page, and wait for the disabling to finish.
 7. After the service has been disabled, click **ON** next to **HADOOP SERVICES**.
-8. Enter **USER NAME** and **NEW PASSWORD**.  These will be the new username and password for the cluster.
+8. For **USER NAME** and **NEW PASSWORD**, enter the new user name and password (respectively) for the cluster.
 8. Click **SAVE**.
 
 
-##<a id="enablerdp"></a>Connect to HDInsight clusters using RDP
+##<a id="enablerdp"></a>Connect to HDInsight clusters by using RDP
 
-The credentials for the cluster that you provided at its creation give access to the services on the cluster, but not to the cluster itself through remote desktop. Remote Desktop access is turned off by default and so direct access to the cluster using it requires some additional, post-creation configuration.
+The credentials for the cluster that you provided at its creation give access to the services on the cluster, but not to the cluster itself through Remote Desktop. Remote Desktop access is turned off by default, and so direct access to the cluster using it requires some additional, post-creation configuration.
 
-**To enable remote desktop**
+**To enable Remote Desktop**
 
-1. Sign in to the [Azure Management Portal][azure-management-portal].
+1. Sign in to the [Azure portal][azure-management-portal].
 2. Click **HDINSIGHT** on the left pane. You will see a list of deployed HDInsight clusters.
 3. Click the HDInsight cluster that you want to connect to.
 4. From the top of the page, click **CONFIGURATION**.
 5. From the bottom of the page, click **ENABLE REMOTE**.
-6. In the **Configure Remote Desktop** wizard, enter a username and password for the remote desktop. Note that the username must be different than the one used to create the cluster (*admin* by default with the Quick Create option). Enter an expiration date in the **EXPIRES ON** box. Note that the expiration date must be in the future and no more than a week from the present. The expiration time of day is assumed by default to be midnight of the specified date. Then click the check icon.
+6. In the **Configure Remote Desktop** wizard, enter a user name and password for the remote desktop. Note that the user name must be different from the one used to create the cluster (**admin** by default with the Quick Create option). Enter an expiration date in the **EXPIRES ON** box. Note that the expiration date must be in the future and no more than a week from the present. The expiration time of day is assumed by default to be midnight of the specified date. Then click the check icon.
 
 	![HDI.CreateRDPUser][image-hdi-create-rpd-user]
 
-	The expiration date must be in the future, and at most seven days from now. And the time is the midnight of the selected date.
 
-> [AZURE.NOTE] You can also use the HDInsight .NET SDK to enable remote desktop on a cluster. Use the **EnableRdp** method on the HDInsight client object in the following manner: **client.EnableRdp(clustername, location, "rdpuser", "rdppassword", DateTime.Now.AddDays(6))**. Similarly, to disable remote desktop on the cluster, you can use **client.DisableRdp(clustername, location)**. For more information on these methods, see [HDInsight .NET SDK Reference](http://go.microsoft.com/fwlink/?LinkId=529017). This is applicable only for HDInsight clusters running on Windows.
+> [AZURE.NOTE] You can also use the HDInsight .NET SDK to enable Remote Desktop on a cluster. Use the **EnableRdp** method on the HDInsight client object in the following manner: **client.EnableRdp(clustername, location, "rdpuser", "rdppassword", DateTime.Now.AddDays(6))**. Similarly, to disable Remote Desktop on the cluster, you can use **client.DisableRdp(clustername, location)**. For more information on these methods, see [HDInsight .NET SDK Reference](http://go.microsoft.com/fwlink/?LinkId=529017). This is applicable only for HDInsight clusters running on Windows.
 
 
 
 > [AZURE.NOTE] Once RDP is enabled for a cluster, you must refresh the page before you can connect to the cluster.
  
-**To connect to a cluster using RDP**
+**To connect to a cluster by using RDP**
 
-1. Sign in to the [Azure Management Portal][azure-management-portal].
+1. Sign in to the [Azure portal][azure-management-portal].
 2. Click **HDINSIGHT** on the left pane. You will see a list of deployed HDInsight clusters.
 3. Click the HDInsight cluster that you want to connect to.
 4. From the top of the page, click **CONFIGURATION**.
@@ -107,22 +106,22 @@ The credentials for the cluster that you provided at its creation give access to
 
 ##Create a self-signed certificate
 
-If you want to perform any operations on the cluster using the .NET SDK, you must create a self-signed certificate on the workstation, and also upload the certificate to your Azure subscription. This is a one-time task. You can install the same certificate on other machines, as long as the certificate is valid.
+If you want to perform any operations on the cluster by using the .NET SDK, you must create a self-signed certificate on the workstation, and also upload the certificate to your Azure subscription. This is a one-time task. You can install the same certificate on other machines, as long as the certificate is valid.
 
 **To create a self-signed certificate**
 
-1. Create a self-signed certificate that is used to authenticate the requests. You can use IIS or [makecert][makecert-info] to create the certificate.
+1. Create a self-signed certificate that is used to authenticate the requests. You can use Internet Information Services (IIS) or [makecert][makecert-info] to create the certificate.
  
 2. Browse to the location of the certificate, right-click the certificate, click **Install Certificate**, and install the certificate to the computer's personal store. Edit the certificate properties to assign it a friendly name.
 
-3. Import the certificate into the Azure Management Portal. From the portal, click **Settings** on the bottom-left of the page, and then click **Management Certificates**. From the bottom of the page, click **Upload** and follow the instructions to upload the .cer file you created in the previous step.
+3. Import the certificate into the Azure portal. From the portal, click **SETTINGS** on the bottom left of the page, and then click **MANAGEMENT CERTIFICATES**. From the bottom of the page, click **UPLOAD** and follow the instructions to upload the .cer file you created in the previous step.
 
 	![HDI.ClusterCreate.UploadCert][image-hdiclustercreate-uploadcert]
 
 
 ##Grant/revoke HTTP services access
 
-HDInsight clusters have the following HTTP Web services (all of these services have RESTful endpoints):
+HDInsight clusters have the following HTTP web services (all of these services have RESTful endpoints):
 
 - ODBC
 - JDBC
@@ -130,49 +129,49 @@ HDInsight clusters have the following HTTP Web services (all of these services h
 - Oozie
 - Templeton
 
-By default, these services are granted for access. You can revoke/grant the access from the Management portal. 
+By default, these services are granted for access. You can revoke/grant the access from the Azure portal. 
 
->[AZURE.NOTE] By granting/revoking the access, you will reset the cluster user username and password.
+>[AZURE.NOTE] By granting/revoking the access, you will reset the cluster user name and password.
 
-**To grant/revoke HTTP Web services access**
+**To grant/revoke HTTP web services access**
 
-1. Sign in to the [Azure Management Portal][azure-management-portal].
+1. Sign in to the [Azure portal][azure-management-portal].
 2. Click **HDINSIGHT** on the left pane. You will see a list of deployed HDInsight clusters.
 3. Click the HDInsight cluster that you want to configure.
 4. From the top of the page, click **CONFIGURATION**.
-5. Click **ON** or **OFF** next  to **HADOOP SERVICES**.  
-6. Enter **USER NAME** and **NEW PASSWORD**.  These will be the new username and password for the cluster.
+5. Click **ON** or **OFF** next to **HADOOP SERVICES**.  
+6. For **USER NAME** and **NEW PASSWORD**, enter the new user name and password (respectively) for the cluster.
 7. Click **SAVE**.
 
-This can also be done using the Azure PowerShell cmdlets:
+This can also be done through the Azure PowerShell cmdlets:
 
 - Grant-AzureHDInsightHttpServicesAccess
 - Revoke-AzureHDInsightHttpServicesAccess
 
-See [Administer HDInsight using PowerShell][hdinsight-admin-powershell].
+See [Administer HDInsight using Azure PowerShell][hdinsight-admin-powershell].
 
-##Open Hadoop command line
+##Open a Hadoop command line
 
-To connect to the cluster using remote desktop and use the Hadoop command line, you must first have enabled remote desktop access to the cluster as described in the previous section. 
+To connect to the cluster by using Remote Desktop and use the Hadoop command line, you must first have enabled Remote Desktop access to the cluster as described in the previous section. 
 
-**To open Hadoop command line**
+**To open a Hadoop command line**
 
-1. Sign in to the [Azure Management Portal][azure-management-portal].
+1. Sign in to the [Azure portal][azure-management-portal].
 2. Click **HDINSIGHT** on the left pane. You will see a list of deployed Hadoop clusters.
 3. Click the HDInsight cluster that you want to connect to.
 3. Click **CONFIGURATION** on the top of the page.
-4. Click **Connect** on the bottom of the page.
+4. Click **CONNECT** on the bottom of the page.
 5. Click **Open**.
-6. Enter your credentials, and then click **OK**.  Use the username and password you configured when you created the cluster.
+6. Enter your credentials, and then click **OK**. Use the user name and password you configured when you created the cluster.
 7. Click **Yes**.
 8. From the desktop, double-click **Hadoop Command Line**.
 		
 	![HDI.HadoopCommandLine][image-hadoopcommandline]
 
 
-	For more information on Hadoop command, see [Hadoop commands reference][hadoop-command-reference].
+	For more information on Hadoop commands, see [Hadoop commands reference][hadoop-command-reference].
 
-On the previous screenshot, the folder name has the Hadoop version number embedded. The version number can changed based on the version of the Hadoop components installed on the cluster. You can use Hadoop environment variables to refer to those folders.  For example:
+In the previous screenshot, the folder name has the Hadoop version number embedded. The version number can changed based on the version of the Hadoop components installed on the cluster. You can use Hadoop environment variables to refer to those folders. For example:
 
 	cd %hadoop_home%
 	cd %hive_home%
@@ -181,10 +180,10 @@ On the previous screenshot, the folder name has the Hadoop version number embedd
 	cd %hcatalog_home%
 
 ##Next steps
-In this article, you have learned how to create an HDInsight cluster using the Azure Management Portal, and how to open the Hadoop command line tool. To learn more, see the following articles:
+In this article, you have learned how to create an HDInsight cluster by using the Azure portal, and how to open the Hadoop command-line tool. To learn more, see the following articles:
 
-* [Administer HDInsight Using PowerShell][hdinsight-admin-powershell]
-* [Administer HDInsight Using Cross-platform Command-line Interface][hdinsight-admin-cross-platform]
+* [Administer HDInsight Using Azure PowerShell][hdinsight-admin-powershell]
+* [Administer HDInsight Using Cross-Platform Command-Line Interface][hdinsight-admin-cross-platform]
 * [Provision HDInsight clusters][hdinsight-provision]
 * [Submit Hadoop jobs programmatically][hdinsight-submit-jobs]
 * [Get Started with Azure HDInsight][hdinsight-get-started]


### PR DESCRIPTION
Edit complete.

On line 59, I changed "remote desktop connection" to "Remote Desktop Connection" because I assume you're referring to the Windows feature. If you're using the term generically, please use "a remote desktop connection" instead.

On line 79, "the cluster using it" should be either "the cluster that uses it" or "the cluster by using it" (whichever is accurate).

I tried to be consistent in using "Remote Desktop" (initial capped) to refer to the feature, and using "remote desktop" (lowercase) for generic references to a desktop. Please confirm that I made the right choices.

I tried to make sure that capitalization of UI items mentioned in text matches the capitalization shown in the screen shot (and is consistent). It would be ideal to confirm that all UI items mentioned in text are capitalized as they appear on the UI.