### PR TITLE
capitalizing bold names to match fields referenced

### DIFF
--- a/articles/web-sites-dotnet-get-started.md
+++ b/articles/web-sites-dotnet-get-started.md
@@ -91,13 +91,13 @@ The following diagram illustrates what's happening in these two steps.
 
 5. If you haven't already signed in to Azure, Visual Studio prompts you to do so. Sign in with the ID and password of the account that you use to manage your Azure subscription.
 	
-	When you're signed in, the **Configure Microsoft Azure web app settings** dialog box asks you what resources you want to create.
+	When you're signed in, the **Configure Microsoft Azure Web App Settings** dialog box asks you what resources you want to create.
 
 	![Signed in to Azure](./media/web-sites-dotnet-get-started-vs2013/configuresitesettings.png)
 
-3. Visual Studio provides a default **Web app name**, which Azure will use as the prefix for your application's URL. If you prefer, enter a different web app name.
+3. Visual Studio provides a default **Web App name**, which Azure will use as the prefix for your application's URL. If you prefer, enter a different web app name.
 
-	The complete URL will consist of what you enter here plus *.azurewebsites.net* (as shown next to the **Web app name** text box). For example, if the name is `MyExample6442`, the URL will be `MyExample6442.azurewebsites.net`. The URL has to be unique. If someone else has already used the one you entered, you'll see a red exclamation mark to the right instead of a green check mark, and you'll need to enter a different name.
+	The complete URL will consist of what you enter here plus *.azurewebsites.net* (as shown next to the **Web App name** text box). For example, if the name is `MyExample6442`, the URL will be `MyExample6442.azurewebsites.net`. The URL has to be unique. If someone else has already used the one you entered, you'll see a red exclamation mark to the right instead of a green check mark, and you'll need to enter a different name.
 
 4. In the **Region** drop-down list, choose the location that is closest to you.
 
@@ -127,7 +127,7 @@ The following diagram illustrates what's happening in these two steps.
 
 ## Deploy the application to Azure
 
-7. In the **Web Publish Activity** window, click **Publish MyExample to this web app now**.
+7. In the **Web Publish Activity** window, click **Publish MyExample to this Web App now**.
 
 	![Web app created](./media/web-sites-dotnet-get-started-vs2013/GS13sitecreated.png)
 


### PR DESCRIPTION
Capitalizing some words in bold to match the way they are in the UI (since that's what they're referencing). 

"Configure Microsoft Azure web app settings" >> "Configure Microsoft Azure Web App Settings" 
"Web app name" >> "Web App name"
(see dialog image below)
[Configure Microsoft Azure Web App dialog] (https://raw.githubusercontent.com/Azure/azure-content/master/articles/media/web-sites-dotnet-get-started-vs2013/configuresitesettings.png)

"Publish MyExample to this web app now" >> "Publish MyExample to this Web App now"
(see window image below)
[Web Publish Activity window] (https://raw.githubusercontent.com/Azure/azure-content/master/articles/media/web-sites-dotnet-get-started-vs2013/GS13sitecreated.png)