### PR TITLE
Edit hdinsight-administer-use-powershell.md

### DIFF
--- a/articles/hdinsight-administer-use-powershell.md
+++ b/articles/hdinsight-administer-use-powershell.md
@@ -16,31 +16,31 @@
 	ms.date="11/21/2014" 
 	ms.author="jgao"/>
 
-# Manage Hadoop clusters in HDInsight using Azure PowerShell
+# Manage Hadoop clusters in HDInsight by using Azure PowerShell
 
 ##Overview
 
-Azure PowerShell is a powerful scripting environment that you can use to control and automate the deployment and management of your workloads in Azure. In this article, you will learn how to manage Hadoop clusters in HDInsight using a local Azure PowerShell console through the use of Windows PowerShell. For the list of the HDInsight PowerShell cmdlets, see [HDInsight cmdlet reference][hdinsight-powershell-reference].
+Azure PowerShell is a powerful scripting environment that you can use to control and automate the deployment and management of your workloads in Azure. In this article, you will learn how to manage Hadoop clusters in Azure HDInsight by using a local Azure PowerShell console through the use of Windows PowerShell. For the list of the HDInsight PowerShell cmdlets, see [HDInsight cmdlet reference][hdinsight-powershell-reference].
 
 ##Prerequisites
 
 Before you begin this article, you must have the following:
 
-- An Azure subscription. Azure is a subscription-based platform. The HDInsight PowerShell cmdlets perform the tasks with your subscription. For more information about obtaining a subscription, see [Purchase Options][azure-purchase-options], [Member Offers][azure-member-offers], or [Free Trial][azure-free-trial].
+- An Azure subscription - Azure is a subscription-based platform. The Azure PowerShell cmdlets for HDInsight perform the tasks by using your subscription. For more information about obtaining a subscription, see [Purchase Options][azure-purchase-options], [Member Offers][azure-member-offers], or [Free Trial][azure-free-trial].
 
-- A workstation with Azure PowerShell. For instructions, see [Install and configure Azure PowerShell][Powershell-install-configure].
+- A workstation with Azure PowerShell - For instructions, see [Install and configure Azure PowerShell][Powershell-install-configure].
 
 
 ##Provision an HDInsight cluster
-HDInsight uses an Azure Blob Storage container as the default file system. An Azure storage account and storage container are required before you can create an HDInsight cluster. 
+HDInsight uses an Azure Blob storage container as the default file system. An Azure Storage account and a storage container are required before you can create an HDInsight cluster. 
 
 [AZURE.INCLUDE [provisioningnote](../includes/hdinsight-provisioning.md)]
 
-**To create an Azure storage account**
+**To create an Azure Storage account**
 
-After you have imported the publishsettings file, you can use the following command to create a storage account:
+After you have imported the publishsettings file, you can use the following command to create a Storage account:
 
-	# Create an Azure storage account
+	# Create an Azure Storage account
 	$storageAccountName = "<StorageAcccountName>"
 	$location = "<Microsoft data center>"           # For example, "West US"
 
@@ -50,20 +50,20 @@ After you have imported the publishsettings file, you can use the following comm
 [AZURE.INCLUDE [data center list](../includes/hdinsight-pricing-data-centers-clusters.md)]
 
 
-For information on creating an Azure storage account using the management portal, see [Create, manage, or delete a storage account](../storage-create-storage-account/).
+For information on creating an Azure Storage account by using the Azure portal, see [Create, manage, or delete a storage account](../storage-create-storage-account/).
 
-If you have already had a storage account but do not know the account name and account key, you can use the following commands to retrieve the information:
+If you have already had a Storage account but do not know the account name and account key, you can use the following commands to retrieve the information:
 
-	# List storage accounts for the current subscription
+	# List Storage accounts for the current subscription
 	Get-AzureStorageAccount
-	# List the keys for a storage account
+	# List the keys for a Storage account
 	Get-AzureStorageKey <StorageAccountName>
 
-For details on getting the information using the management portal, see the *How to: View, copy and regenerate storage access keys* section of [Create, manage, or delete a storage account](../storage-create-storage-account/).
+For details on getting the information by using the Azure portal, see the "View, copy, and regenerate storage access keys" section of [Create, manage, or delete a storage account](../storage-create-storage-account/).
 
-**To create Azure storage container**
+**To create an Azure storage container**
 
-PowerShell can not create a Blob container during the HDInsight provision process. You can create one using the following script:
+Azure PowerShell cannot create a Blob container during the HDInsight provisioning process. You can create one by using the following script:
 
 	$storageAccountName = "<StorageAccountName>"
 	$storageAccountKey = Get-AzureStorageKey $storageAccountName | %{ $_.Primary }
@@ -78,7 +78,7 @@ PowerShell can not create a Blob container during the HDInsight provision proces
 
 **To provision a cluster**
 
-Once you have the storage account and the blob container prepared, you are ready to create a cluster.    
+Once you have the Storage account and the Blob container prepared, you are ready to create a cluster.    
 		
 	$storageAccountName = "<StorageAccountName>"
 	$containerName = "<ContainerName>"
@@ -87,7 +87,7 @@ Once you have the storage account and the blob container prepared, you are ready
 	$location = "<MicrosoftDataCenter>"
 	$clusterNodes = <ClusterSizeInNodes>
 
-	# Get the storage account key
+	# Get the Storage account key
 	$storageAccountKey = Get-AzureStorageKey $storageAccountName | %{ $_.Primary }
 
 	# Create a new HDInsight cluster
@@ -102,13 +102,11 @@ The following screenshot shows the script execution:
 
 
 ##List and show cluster details
-Use the following commands to list and show cluster details:
-
-**To list all clusters in the current subscription**
+Use the following command to list all clusters in the current subscription:
 
 	Get-AzureHDInsightCluster 
 
-**To show details of the specific cluster in the current subscription**
+Use the following command to show details of a specific cluster in the current subscription:
 
 	Get-AzureHDInsightCluster -Name <ClusterName> 
 
@@ -119,7 +117,7 @@ Use the following command to delete a cluster:
 
 ##Grant/revoke HTTP services access
 
-HDInsight clusters have the following HTTP Web services (all of these services have RESTful endpoints):
+HDInsight clusters have the following HTTP web services (all of these services have RESTful endpoints):
 
 - ODBC
 - JDBC
@@ -128,22 +126,22 @@ HDInsight clusters have the following HTTP Web services (all of these services h
 - Templeton
 
 
-By default, these services are granted for access. You can revoke/grant the access.  Here is a sample:
+By default, these services are granted for access. You can revoke/grant the access. Here is a sample:
 
 	Revoke-AzureHDInsightHttpServicesAccess -Name hdiv2 -Location "East US"
 
-In the sample <i>hdiv2</i> is an HDInsight cluster name.
+In the sample, <i>hdiv2</i> is an HDInsight cluster name.
 
->[AZURE.NOTE] By granting/revoking the access, you will reset the cluster user username and password.
+>[AZURE.NOTE] By granting/revoking the access, you will reset the cluster user name and password.
 
-This can also be done using the Azure Management portal. See [Administer HDInsight using the Management portal][hdinsight-admin-portal].
+This can also be done via the Azure portal. See [Administer HDInsight by using the Azure portal][hdinsight-admin-portal].
 
 ##Submit MapReduce jobs
 The HDInsight cluster distribution comes with some MapReduce samples. One of the samples is for counting word frequencies in source files.
 
 **To submit a MapReduce job**
 
-The following PowerShell script submits the word count sample job: 
+The following Azure PowerShell script submits the word-count sample job: 
 	
 	$clusterName = "<HDInsightClusterName>"            
 	
@@ -153,19 +151,19 @@ The following PowerShell script submits the word count sample job:
 	# Run the job and show the standard error 
 	$wordCountJobDefinition | Start-AzureHDInsightJob -Cluster $clusterName | Wait-AzureHDInsightJob -WaitTimeoutInSeconds 3600 | %{ Get-AzureHDInsightJobOutput -Cluster $clusterName -JobId $_.JobId -StandardError}
 	
-> [AZURE.NOTE] *hadoop-examples.jar* comes with version 2.1 HDInsight clusters. The file has been renamed to *hadoop-mapreduce.jar* on version 3.0 HDInsight clusters.
+> [AZURE.NOTE] The hadoop-examples.jar file comes with version 2.1 HDInsight clusters. The file has been renamed to hadoop-mapreduce.jar on version 3.0 HDInsight clusters.
 
-For information about the WASB prefix, see [Use Azure Blob storage for HDInsight][hdinsight-
+For information about the **wasb** prefix, see [Use Azure Blob storage for HDInsight][hdinsight-
 storage].
 
 **To download the MapReduce job output**
 
-The following PowerShell script retrieves the MapReduce job output from the last procedure:
+The following Azure PowerShell script retrieves the MapReduce job output from the last procedure:
 
 	$storageAccountName = "<StorageAccountName>"   
 	$containerName = "<ContainerName>"             
 		
-	# Create the storage account context object
+	# Create the Storage account context object
 	$storageAccountKey = Get-AzureStorageKey $storageAccountName | %{ $_.Primary }
 	$storageContext = New-AzureStorageContext -StorageAccountName $storageAccountName -StorageAccountKey $storageAccountKey  
 	
@@ -215,11 +213,11 @@ For more information on developing and running MapReduce jobs, see [Using MapRed
 
 
 ##Submit Hive jobs
-The HDInsight cluster distribution comes with a sample Hive table called *hivesampletable*. You can use a HiveQL "show tables;" to list the Hive tables on a cluster.
+The HDInsight cluster distribution comes with a sample Hive table called *hivesampletable*. You can use a HiveQL **SHOW TABLES** command to list the Hive tables on a cluster.
 
 **To submit a Hive job**
 
-The following script submit a hive job to list the Hive tables:
+The following script submits a Hive job to list the Hive tables:
 	
 	$clusterName = "<HDInsightClusterName>"               
 	
@@ -234,7 +232,7 @@ The following script submit a hive job to list the Hive tables:
 	Use-AzureHDInsightCluster -Name $clusterName
 	Invoke-Hive $querystring
 
-The Hive job will first show the Hive tables created on the cluster, and the data returned from the hivesampletable.
+The Hive job will first show the Hive tables created on the cluster, and the data returned from the hivesampletable table.
 
 For more information on using Hive, see [Using Hive with HDInsight][hdinsight-use-hive].
 
@@ -243,12 +241,12 @@ For more information on using Hive, see [Using Hive with HDInsight][hdinsight-us
 See [Upload data to HDInsight][hdinsight-upload-data].
 
 ##Download the MapReduce output from the Blob storage
-See the [Submit MapReduce jobs](#mapreduce) session in this article.
+See the [Submit MapReduce jobs](#mapreduce) section in this article.
 
 ## See Also
-* [HDInsight Cmdlet Reference Documentation][hdinsight-powershell-reference]
-* [Administer HDInsight using management portal][hdinsight-admin-portal]
-* [Administer HDInsight using command-line interface][hdinsight-admin-cli]
+* [HDInsight cmdlet reference documentation][hdinsight-powershell-reference]
+* [Administer HDInsight by using the Azure portal][hdinsight-admin-portal]
+* [Administer HDInsight using a command-line interface][hdinsight-admin-cli]
 * [Provision HDInsight clusters][hdinsight-provision]
 * [Upload data to HDInsight][hdinsight-upload-data]
 * [Submit Hadoop jobs programmatically][hdinsight-submit-jobs]


### PR DESCRIPTION
Edit complete.

The link "Install and configure Azure PowerShell" didn't work when I tried it.

The link "Use Azure Blob storage for HDInsight" doesn't seem to be rendering correctly.

Line 41 refers to a "publishsettings file." Please confirm that "publishsettings" is correct as is because it's a specific name. Also, some information may be missing here about what the publishsettings file is and where readers can find it.

Per naming guidelines, I changed instances of "PowerShell" by itself to "Azure PowerShell." Please make sure that all mentions are technically accurate and shouldn't be "Windows PowerShell" instead.

Please confirm that the screenshot doesn't reveal any potentially sensitive information.