### PR TITLE
Edit hdinsight-analyze-flight-delay-data.md

### DIFF
--- a/articles/hdinsight-analyze-flight-delay-data.md
+++ b/articles/hdinsight-analyze-flight-delay-data.md
@@ -18,15 +18,15 @@
 
 #Analyze flight delay data by using Hadoop in HDInsight
 
-Hive provides a means of running Hadoop MapReduce jobs through a Structured Query Language (SQL)-like scripting language, called *[HiveQL][hadoop-hiveql]*, which can be applied towards summarizing, querying, and analyzing large volumes of data. 
+Hive provides a means of running Hadoop MapReduce jobs through an SQL-like scripting language called *[HiveQL][hadoop-hiveql]*, which can be applied towards summarizing, querying, and analyzing large volumes of data. 
 
-One of the major benefits of HDInsight is the separation of data storage and compute. HDInsight uses Azure Blob storage for data storage. A common MapReduce process can be broken into 3 parts:
+One of the major benefits of Azure HDInsight is the separation of data storage and compute. HDInsight uses Azure Blob storage for data storage. A common MapReduce process can be broken into 3 parts:
 
 1. **Store data in Azure Blob storage.** This can be a continuous process. For example, weather data, sensor data, web logs, and in this case, flight delay data are saved into Azure Blob storage.
 2. **Run jobs.** When it is time to process the data, you run a Windows PowerShell script (or a client application) to provision an HDInsight cluster, run jobs, and delete the cluster. The jobs save output data to Azure Blob storage. The output data is retained even after the cluster is deleted. This way, you pay for only what you have consumed. 
 3. **Retrieve the output from Azure Blob storage**, or in this tutorial, export the data to an Azure SQL database.
 
-The following diagram illustrates the scenario and the structure of this article:
+The following diagram illustrates the scenario and the structure of this tutorial:
 
 ![HDI.FlightDelays.flow][img-hdi-flightdelays-flow]
 
@@ -51,17 +51,17 @@ Before you begin this tutorial, you must have the following:
 
 ###Understand HDInsight storage
 
-Hadoop clusters in HDInsight use Azure Blob storage for data storage. It is called *WASB* or *Azure Storage - Blob*. WASB is Microsoft's implementation of Hadoop Distributed File System (HDFS) on Azure Blob storage. For more information see [Use Azure Blob storage with HDInsight][hdinsight-storage]. 
+Hadoop clusters in HDInsight use Azure Blob storage for data storage. For more information, see [Use Azure Blob storage with HDInsight][hdinsight-storage]. 
 
-When you provision an HDInsight cluster, a Blob storage container of an Azure storage account is designated as the default file system, just like in HDFS. This storage account is referred to as the *default storage account*, and the Blob container is referred to as the *default Blob container* or *default container*. The default storage account must co-locate in the same data center as the HDInsight cluster. Deleting an HDInsight cluster does not delete the default container or the default storage account.
+When you provision an HDInsight cluster, a Blob storage container of an Azure Storage account is designated as the default file system, just like in Hadoop Distributed File System (HDFS). This Storage account is referred to as the *default Storage account*, and the Blob container is referred to as the *default Blob container* or *default container*. The default Storage account must be co-located in the same datacenter as the HDInsight cluster. Deleting an HDInsight cluster does not delete the default container or the default Storage account.
 
-In addition to the default storage account, other Azure storage accounts can be bound to an HDInsight cluster during the provisioning process. The binding is to add the storage account and storage account key to the configuration file so the cluster can access those storage accounts at run time. For instructions on adding additional storage accounts, see [Provision Hadoop clusters in HDInsight][hdinsight-provision]. 
+In addition to the default Storage account, other Azure Storage accounts can be bound to an HDInsight cluster during the provisioning process. The binding is to add the Storage account and Storage account key to the configuration file so the cluster can access those Storage accounts at run time. For instructions on adding additional Storage accounts, see [Provision Hadoop clusters in HDInsight][hdinsight-provision]. 
 
-The WASB syntax is:
+The Azure Blob storage syntax is:
 
 	wasb[s]://<ContainerName>@<StorageAccountName>.blob.core.windows.net/<path>/<filename>
 
->[AZURE.NOTE] The WASB path is a virtual path. For more information see [Use Azure Blob storage with HDInsight][hdinsight-storage]. 
+>[AZURE.NOTE] The Blob storage path is a virtual path. For more information, see [Use Azure Blob storage with HDInsight][hdinsight-storage]. 
 
 Files stored in the default container can be accessed from HDInsight by using any of the following URIs (using flightdelays.hql as an example):
 
@@ -69,7 +69,7 @@ Files stored in the default container can be accessed from HDInsight by using an
 	wasb:///tutorials/flightdelays/flightdelays.hql
 	/tutorials/flightdelays/flightdelays.hql
 
-For accessing the file directly from the storage account, the blob name for the file is:
+For accessing the file directly from the Storage account, the blob name for the file is:
 
 	tutorials/flightdelays/flightdelays.hql
 
@@ -77,7 +77,7 @@ Notice there is no "/" in the front of the blob name.
 
 **Files used in this tutorial**
 
-This tutorial uses the on-time performance of airline flight data from [Research and Innovative Technology Administration, Bureau of Transportation Statistics][rita-website] (RITA). The data has been uploaded to an Azure Blob storage container with the Public Blob access permission. Because it is a public Blob container, you do not need to bind this storage account to the HDInsight cluster running the Hive script. The HiveQL script is also uploaded to the same Blob container. If you want to learn how to get/upload the data to your own storage account, and how to create/upload the HiveQL script file, see [Appendix A](#appendix-a) and [Appendix B](#appendix-b).
+This tutorial uses the on-time performance of airline flight data from [Research and Innovative Technology Administration, Bureau of Transportation Statistics][rita-website] (RITA). The data has been uploaded to an Azure Blob storage container with the Public Blob access permission. Because it is a public Blob container, you do not need to bind this Storage account to the HDInsight cluster running the Hive script. The HiveQL script is also uploaded to the same Blob container. If you want to learn how to get/upload the data to your own Storage account, and how to create/upload the HiveQL script file, see [Appendix A](#appendix-a) and [Appendix B](#appendix-b).
 
 The following table lists the files used in this tutorial:
 
@@ -95,15 +95,15 @@ The following table lists the files used in this tutorial:
 
 There are a few things you need to know about the Hive internal table and external table:
 
-- The CREATE TABLE command creates an internal table. The data file must be located in the default container.
-- The CREATE TABLE command moves the data file to the /hive/warehouse/<TableName> folder.
-- The CREATE EXTERNAL TABLE command creates an external table. The data file can be located outside the default container.
-- The CREATE EXTERNAL TABLE command does not move the data file.
-- The CREATE EXTERNAL TABLE command doesn't allow any folders in the LOCATION. This is the reason why the tutorial makes a copy of the sample.log file.
+- The **CREATE TABLE** command creates an internal table. The data file must be located in the default container.
+- The **CREATE TABLE** command moves the data file to the /hive/warehouse/<TableName> folder.
+- The **CREATE EXTERNAL TABLE** command creates an external table. The data file can be located outside the default container.
+- The **CREATE EXTERNAL TABLE** command does not move the data file.
+- The **CREATE EXTERNAL TABLE** command doesn't allow any folders in the LOCATION. This is the reason why the tutorial makes a copy of the sample.log file.
 
 For more information, see [HDInsight: Hive Internal and External Tables Intro][cindygross-hive-tables].
 
-> [AZURE.NOTE] One of the HiveQL statements creates a Hive external table. The Hive external table keeps the data file in the original location. The Hive internal table moves the data file to hive\warehouse. The Hive internal table requires the data file to be located in the default container. For data stored outside default Blob container, you must use Hive external tables.
+> [AZURE.NOTE] One of the HiveQL statements creates a Hive external table. The Hive external table keeps the data file in the original location. The Hive internal table moves the data file to hive\warehouse. The Hive internal table requires the data file to be located in the default container. For data stored outside the default Blob container, you must use Hive external tables.
 
 
 
@@ -113,7 +113,7 @@ For more information, see [HDInsight: Hive Internal and External Tables Intro][c
 
 
 
-##Provision HDInsight cluster and run Hive/Sqoop jobs 
+##Provision an HDInsight cluster and run Hive/Sqoop jobs 
 
 Hadoop MapReduce is batch processing. The most cost-effective way to run a Hive job is to provision a cluster for the job, and delete the job after the job is completed. The following script covers the whole process. For more information on provisioning an HDInsight cluster and running Hive jobs, see [Provision Hadoop clusters in HDInsight][hdinsight-provision] and [Use Hive with HDInsight][hdinsight-use-hive]. 
 
@@ -125,12 +125,12 @@ Hadoop MapReduce is batch processing. The most cost-effective way to run a Hive 
 	<table border="1">
 	<tr><th>Variable Name</th><th>Notes</th></tr>
 	<tr><td>$hdinsightClusterName</td><td>The HDInsight cluster name. If the cluster doesn't exist, the script will create one with the name entered.</td></tr>
-	<tr><td>$storageAccountName</td><td>The Azure storage account that will be used as the default storage account. This value is needed only when the script needs to create an HDInsight cluster. Leave it blank if you have specified an existing HDInsight cluster name for $hdinsightClusterName. If the storage account with the value entered doesn't exist, the script will create one with the name.</td></tr>
+	<tr><td>$storageAccountName</td><td>The Azure Storage account that will be used as the default Storage account. This value is needed only when the script needs to create an HDInsight cluster. Leave it blank if you have specified an existing HDInsight cluster name for $hdinsightClusterName. If the Storage account with the value entered doesn't exist, the script will create one with the name.</td></tr>
 	<tr><td>$blobContainerName</td><td>The Blob container that will be used for the default file system. If you leave it blank, the $hdinsightClusterName value will be used. </td></tr>
 	<tr><td>$sqlDatabaseServerName</td><td>The Azure SQL database server name. It has to be an existing server. See <a href="#appendix-c">Appendix C</a> for information about creating one.</td></tr>
 	<tr><td>$sqlDatabaseUsername</td><td>The login name for the Azure SQL database server.</td></tr>
 	<tr><td>$sqlDatabasePassword</td><td>The login password for the Azure SQL database server.</td></tr>
-	<tr><td>$sqlDatabaseName</td><td>The SQL database where Sqoop will export data to. The default name is "HDISqoop". The table name for the Sqoop job output is "AvgDelays". </td></tr>
+	<tr><td>$sqlDatabaseName</td><td>The SQL database where Sqoop will export data to. The default name is HDISqoop. The table name for the Sqoop job output is AvgDelays. </td></tr>
 	</table>
 3. Open Windows PowerShell Integrated Scripting Environment (ISE).
 4. Copy and paste the following script into the script pane:
@@ -175,13 +175,13 @@ Hadoop MapReduce is batch processing. The most cost-effective way to run a Hive 
 		$ErrorActionPreference = "Stop"
 		
 		#region - HDInsight cluster variables
-		[int]$clusterSize = 1                # One data node is sufficient for this tutorial.
-		[String]$location = "Central US"     # For better performance, choose a data center near you.
+		[int]$clusterSize = 1                # One data node is sufficient for this tutorial
+		[String]$location = "Central US"     # For better performance, choose a datacenter near you
 		[String]$hadoopUserLogin = "admin"   # Use "admin" as the Hadoop login name
 		[String]$hadoopUserpw = "Pass@word1" # Use "Pass@word1" as the Hadoop login password
 		
-		[Bool]$isNewCluster = $false      # Indicates whether a new HDInsight cluster is created by the script.  
-		                                  # If this variable is true, then the script can optionally delete the cluster after running the Hive and Sqoop jobs.
+		[Bool]$isNewCluster = $false      # Indicates whether a new HDInsight cluster is created by the script  
+		                                  # If this variable is true, then the script can optionally delete the cluster after running the Hive and Sqoop jobs
 		
 		[Bool]$isNewStorageAccount = $false
 		
@@ -211,7 +211,7 @@ Hadoop MapReduce is batch processing. The most cost-effective way to run a Hive 
 		#region - Validate user input, and provision HDInsight cluster if needed
 		Write-Host "`nValidating user input ..." -ForegroundColor Green
 		
-		# Both the Azure SQL database server and database must exist.
+		# Both the Azure SQL database server and database must exist
 		if (-not (Get-AzureSqlDatabaseServer|Where-Object{$_.ServerName -eq $sqlDatabaseServerName})){
 		    Write-host "The Azure SQL database server, $sqlDatabaseServerName doesn't exist." -ForegroundColor Red
 		    Exit
@@ -228,7 +228,7 @@ Hadoop MapReduce is batch processing. The most cost-effective way to run a Hive 
 		{
 		    Write-Host "`tThe HDInsight cluster, $hdinsightClusterName, exists. This cluster will be used to run the Hive job." -ForegroundColor Cyan
 		
-		    #region - Retrieve the default storage account/container names if the cluster exists
+		    #region - Retrieve the default Storage account/container names if the cluster exists
 		    # The Hive job output will be stored in the default container. The 
 		    # information is used to download a copy of the output file from 
 		    # Blob storage to workstation for the validation purpose.
@@ -237,7 +237,7 @@ Hadoop MapReduce is batch processing. The most cost-effective way to run a Hive 
 		
 		    $hdi = Get-AzureHDInsightCluster -Name $HDInsightClusterName
 		
-		    # Use the default storage account and the default container even if the names are different from the user input
+		    # Use the default Storage account and the default container even if the names are different from the user input
 		    $storageAccountName = $hdi.DefaultStorageAccount.StorageAccountName `
 		                            -replace ".blob.core.windows.net"
 		    $blobContainerName = $hdi.DefaultStorageAccount.StorageContainerName
@@ -248,7 +248,7 @@ Hadoop MapReduce is batch processing. The most cost-effective way to run a Hive 
 		                -ForegroundColor Cyan
 		    #endregion
 		}
-		else     #If the cluster doesn't exist, a new one will be provisioned.
+		else     #If the cluster doesn't exist, a new one will be provisioned
 		{
 		    if ([string]::IsNullOrEmpty($storageAccountName))
 		    {
@@ -265,7 +265,7 @@ Hadoop MapReduce is batch processing. The most cost-effective way to run a Hive 
 		        $blobContainerName = $blobContainerName.ToLower()
 		
 		        #region - Provision HDInsight cluster
-		        # Create an Azure storage account if it doesn't exist
+		        # Create an Azure Storage account if it doesn't exist
 		        if (-not (Get-AzureStorageAccount|Where-Object{$_.Label -eq $storageAccountName}))
 		        {
 		            Write-Host "`nCreating the Azure storage account, $storageAccountName ..." -ForegroundColor Green
@@ -326,7 +326,7 @@ Hadoop MapReduce is batch processing. The most cost-effective way to run a Hive 
 		Write-Host "---------------------------------------------------------" -ForegroundColor Cyan
 		#endregion 
 		
-		#region - run Sqoop job
+		#region - Run Sqoop job
 		Write-Host "`nSubmitting the Sqoop job ..." -ForegroundColor Green
 		Write-Host "`tCurrent system time: " (get-date) -ForegroundColor Yellow
 		
@@ -357,7 +357,7 @@ Hadoop MapReduce is batch processing. The most cost-effective way to run a Hive 
 		}
 		#endregion
 		
-		#region - Delete the storage account
+		#region - Delete the Storage account
 		if ($isNewStorageAccount -eq $True)
 		{
 		    $isDelete = Read-Host 'Do you want to delete the Azure storage account ' $storageAccountName '? (Y/N)'
@@ -378,7 +378,7 @@ Hadoop MapReduce is batch processing. The most cost-effective way to run a Hive 
 
 	![HDI.FlightDelays.RunHiveJob.output][img-hdi-flightdelays-run-hive-job-output]
 		
-6. Connect to your SQL database and see average flight delays by city in the *AvgDelays* table:
+6. Connect to your SQL database and see average flight delays by city in the AvgDelays table:
 
 	![HDI.FlightDelays.AvgDelays.Dataset][image-hdi-flightdelays-avgdelays-dataset]
 
@@ -388,10 +388,10 @@ Hadoop MapReduce is batch processing. The most cost-effective way to run a Hive 
 ##<a id="appendix-a"></a>Appendix A - Upload flight delay data to Azure Blob storage
 Uploading the data file and the HiveQL script files (see [Appendix B](#appendix-b)) requires some planning. The idea is to store the data files and the HiveQL file before provisioning an HDInsight cluster and running the Hive job. You have two options:
 
-- **Use the same Azure storage account that will be used by the HDInsight cluster as the default file system.** Because the HDInsight cluster will have the storage account access key, you don't need to make any additional changes.
-- **Use a different Azure storage account from the HDInsight cluster default file system.** If this is the case, you must modify the provisioning part of the Windows PowerShell script found in [Provision HDInsight cluster and run Hive/Sqoop jobs](#runjob) to include the storage account as an additional storage account. For instructions, see [Provision Hadoop clusters in HDInsight][hdinsight-provision]. The HDInsight cluster then knows the access key for the storage account.
+- **Use the same Azure Storage account that will be used by the HDInsight cluster as the default file system.** Because the HDInsight cluster will have the Storage account access key, you don't need to make any additional changes.
+- **Use a different Azure Storage account from the HDInsight cluster default file system.** If this is the case, you must modify the provisioning part of the Windows PowerShell script found in [Provision HDInsight cluster and run Hive/Sqoop jobs](#runjob) to include the Storage account as an additional Storage account. For instructions, see [Provision Hadoop clusters in HDInsight][hdinsight-provision]. The HDInsight cluster then knows the access key for the Storage account.
 
->[AZURE.NOTE] The WASB path for the data file is hard coded in the HiveQL script file. You must update it accordingly.
+>[AZURE.NOTE] The Blob storage path for the data file is hard coded in the HiveQL script file. You must update it accordingly.
 
 **To download the flight data**
 
@@ -402,7 +402,7 @@ Uploading the data file and the HiveQL script files (see [Appendix B](#appendix-
 	<tr><th>Name</th><th>Value</th></tr>
 	<tr><td>Filter Year</td><td>2013 </td></tr>
 	<tr><td>Filter Period</td><td>January</td></tr>
-	<tr><td>Fields:</td><td>*Year*, *FlightDate*, *UniqueCarrier*, *Carrier*, *FlightNum*, *OriginAirportID*, *Origin*, *OriginCityName*, *OriginState*, *DestAirportID*, *Dest*, *DestCityName*, *DestState*, *DepDelayMinutes*, *ArrDelay*, *ArrDelayMinutes*, *CarrierDelay*, *WeatherDelay*, *NASDelay*, *SecurityDelay*, *LateAircraftDelay* (clear all other fields)</td></tr>
+	<tr><td>Fields</td><td>*Year*, *FlightDate*, *UniqueCarrier*, *Carrier*, *FlightNum*, *OriginAirportID*, *Origin*, *OriginCityName*, *OriginState*, *DestAirportID*, *Dest*, *DestCityName*, *DestState*, *DepDelayMinutes*, *ArrDelay*, *ArrDelayMinutes*, *CarrierDelay*, *WeatherDelay*, *NASDelay*, *SecurityDelay*, *LateAircraftDelay* (clear all other fields)</td></tr>
 	</table>
 
 3. Click **Download**. 
@@ -416,10 +416,10 @@ Uploading the data file and the HiveQL script files (see [Appendix B](#appendix-
 
 	<table border="1">
 	<tr><th>Variable Name</th><th>Notes</th></tr>
-	<tr><td>$storageAccountName</td><td>The Azure storage account where you want to upload the data to.</td></tr>
+	<tr><td>$storageAccountName</td><td>The Azure Storage account where you want to upload the data to.</td></tr>
 	<tr><td>$blobContainerName</td><td>The Blob container where you want to upload the data to.</td></tr>
 	</table>
-2. Open PowerShell ISE.
+2. Open Azure PowerShell ISE.
 3. Paste the following script into the script pane:
 
 		[CmdletBinding()]
@@ -435,8 +435,8 @@ Uploading the data file and the HiveQL script files (see [Appendix B](#appendix-
 		)
 		
 		#Region - Variables
-		$localFolder = "C:\Tutorials\FlightDelays\Data"  # the source folder
-		$destFolder = "tutorials/flightdelays/data"     #the blob name prefix for the files to be uploaded
+		$localFolder = "C:\Tutorials\FlightDelays\Data"  # The source folder
+		$destFolder = "tutorials/flightdelays/data"     #The blob name prefix for the files to be uploaded
 		#EndRegion
 		
 		#Region - Connect to Azure subscription
@@ -445,7 +445,7 @@ Uploading the data file and the HiveQL script files (see [Appendix B](#appendix-
 		#EndRegion
 		
 		#Region - Validate user input
-		# Validate the storage account
+		# Validate the Storage account
 		if (-not (Get-AzureStorageAccount|Where-Object{$_.Label -eq $storageAccountName}))
 		{
 		    Write-Host "The storage account, $storageAccountName, doesn't exist." -ForegroundColor Red
@@ -486,28 +486,28 @@ Uploading the data file and the HiveQL script files (see [Appendix B](#appendix-
 
 4. Press **F5** to run the script.
 
-If you choose to use a different method for uploading the files, please make sure the file path is *tutorials/flightdelays/data*. The syntax for accessing the files is:
+If you choose to use a different method for uploading the files, please make sure the file path is tutorials/flightdelays/data. The syntax for accessing the files is:
 
 	wasb://<ContainerName>@<StorageAccountName>.blob.core.windows.net/tutorials/flightdelays/data
 
-*tutorials/flightdelays/data* is the virtual folder you created when you uploaded the files. Verify that there are 12 files, one for each month.
+The path tutorials/flightdelays/data is the virtual folder you created when you uploaded the files. Verify that there are 12 files, one for each month.
 
 >[AZURE.NOTE] You must update the Hive query to read from the new location.
 
-> You must either configure the container access permission to be public or bind the storage account to the HDInsight cluster. Otherwise, the Hive query string will not be able to access the data files. 
+> You must either configure the container access permission to be public or bind the Storage account to the HDInsight cluster. Otherwise, the Hive query string will not be able to access the data files. 
 
 ---
 ##<a id="appendix-b"></a>Appendix B - Create and upload a HiveQL script
 
-Using Azure PowerShell, you can run multiple HiveQL statements one at a time, or package the HiveQL statement into a script file. This section shows you how to create a HiveQL script and upload the script to Azure Blob storage by using Azure PowerShell. Hive requires the HiveQL scripts to be stored on WASB.
+Using Azure PowerShell, you can run multiple HiveQL statements one at a time, or package the HiveQL statement into a script file. This section shows you how to create a HiveQL script and upload the script to Azure Blob storage by using Azure PowerShell. Hive requires the HiveQL scripts to be stored in Azure Blob storage.
 
 The HiveQL script will perform the following:
 
 1. **Drop the delays_raw table**, in case the table already exists.
-2. **Create the delays_raw external Hive table** pointing to the WASB location with the flight delay files. This query specifies that fields are delimited by "," and that lines are terminated by "\n". This poses a problem when field values *contain* commas because Hive cannot differentiate between a comma that is a field delimiter and a one that is part of a field value (which is the case in field values for ORIGIN\_CITY\_NAME and DEST\_CITY\_NAME). To address this, the query creates TEMP columns to hold data that is incorrectly split into columns.  
+2. **Create the delays_raw external Hive table** pointing to the Blob storage location with the flight delay files. This query specifies that fields are delimited by "," and that lines are terminated by "\n". This poses a problem when field values contain commas because Hive cannot differentiate between a comma that is a field delimiter and a one that is part of a field value (which is the case in field values for ORIGIN\_CITY\_NAME and DEST\_CITY\_NAME). To address this, the query creates TEMP columns to hold data that is incorrectly split into columns.  
 3. **Drop the delays table**, in case the table already exists.
-4. **Create the delays table**. It is helpful to clean up the data before further processing. This query creates a new table, *delays*, from the *delays_raw* table. Note that the TEMP columns (as mentioned previously) are not copied, and that the *substring* function is used to remove quotation marks from the data. 
-5. **Compute the average weather delay and groups the results by city name.** It will also output the results to WASB. Note that the query will remove apostrophes from the data and will exclude rows where the value for *weather_delay* is *null*. This is necessary because Sqoop, used later in this tutorial, doesn't handle those values gracefully by default.
+4. **Create the delays table**. It is helpful to clean up the data before further processing. This query creates a new table, *delays*, from the delays_raw table. Note that the TEMP columns (as mentioned previously) are not copied, and that the **substring** function is used to remove quotation marks from the data. 
+5. **Compute the average weather delay and groups the results by city name.** It will also output the results to Blob storage. Note that the query will remove apostrophes from the data and will exclude rows where the value for **weather_delay** is null. This is necessary because Sqoop, used later in this tutorial, doesn't handle those values gracefully by default.
 
 For a full list of the HiveQL commands, see [Hive Data Definition Language][hadoop-hiveql]. Each HiveQL command must terminate with a semicolon.
 
@@ -517,7 +517,7 @@ For a full list of the HiveQL commands, see [Hive Data Definition Language][hado
 
 	<table border="1">
 	<tr><th>Variable Name</th><th>Notes</th></tr>
-	<tr><td>$storageAccountName</td><td>The Azure storage account where you want to upload the HiveQL script to.</td></tr>
+	<tr><td>$storageAccountName</td><td>The Azure Storage account where you want to upload the HiveQL script to.</td></tr>
 	<tr><td>$blobContainerName</td><td>The Blob container where you want to upload the HiveQL script to.</td></tr>
 	</table>
 2. Open Azure PowerShell ISE.
@@ -538,24 +538,24 @@ For a full list of the HiveQL commands, see [Hive Data Definition Language][hado
 		
 		)
 		
-		#region - define variables
+		#region - Define variables
 		# Treat all errors as terminating
 		$ErrorActionPreference = "Stop"
 		
-		# the HiveQL script file is exported as this file before it's uploaded to WASB
+		# The HiveQL script file is exported as this file before it's uploaded to Blob storage
 		$hqlLocalFileName = "C:\tutorials\flightdelays\flightdelays.hql" 
 		
-		# the HiveQL script file will be upload to WASB as this blob name
+		# The HiveQL script file will be uploaded to Blob storage as this blob name
 		$hqlBlobName = "tutorials/flightdelays/flightdelays.hql" 
 		
-		# these two constants are used by the HiveQL script file
+		# These two constants are used by the HiveQL script file
 		#$srcDataFolder = "tutorials/flightdelays/data" 
 		$dstDataFolder = "/tutorials/flightdelays/output"
 		#endregion
 		
 		#region - Validate the file and file path
 		
-		# check if a file with the same file name already exists on the workstation
+		# Check if a file with the same file name already exists on the workstation
 		Write-Host "`nvalidating the folder structure on the workstation for saving the HQL script file ..."  -ForegroundColor Green
 		if (test-path $hqlLocalFileName){
 		
@@ -567,7 +567,7 @@ For a full list of the HiveQL commands, see [Hive Data Definition Language][hado
 		    }
 		}
 		
-		# create the folder if it doesn't exist
+		# Create the folder if it doesn't exist
 		$folder = split-path $hqlLocalFileName
 		if (-not (test-path $folder))
 		{
@@ -664,7 +664,7 @@ For a full list of the HiveQL commands, see [Hive Data Definition Language][hado
 		$storageAccountKey = get-azurestoragekey $storageAccountName | %{$_.Primary}
 		$destContext = New-AzureStorageContext -StorageAccountName $storageAccountName -StorageAccountKey $storageAccountKey
 		
-		# Upload the file from local workstation to WASB
+		# Upload the file from local workstation to Blob storage
 		Set-AzureStorageBlobContent -File $hqlLocalFileName -Container $blobContainerName -Blob $hqlBlobName -Context $destContext 
 		#endregion
 		
@@ -672,9 +672,9 @@ For a full list of the HiveQL commands, see [Hive Data Definition Language][hado
 
 	Here are the variables used in the script:
 
-	- **$hqlLocalFileName**: The script saves the HiveQL script file locally before uploading it to WASB. This is the file name. The default value is <u>C:\tutorials\flightdelays\flightdelays.hql</u>.
-	- **$hqlBlobName**: This is the HiveQL script file blob name used in the Azure Blob storage. The default value is <u>tutorials/flightdelays/flightdelays.hql</u>. Because the file will be written directly to Azure Blob storage, there is NOT a "/" at the beginning of the blob name. If you want to access the file from WASB, you will need to add a "/" at the beginning of the file name.
-	- **$srcDataFolder** and **$dstDataFolder**:  = "tutorials/flightdelays/data" 
+	- **$hqlLocalFileName** - The script saves the HiveQL script file locally before uploading it to Blob storage. This is the file name. The default value is <u>C:\tutorials\flightdelays\flightdelays.hql</u>.
+	- **$hqlBlobName** - This is the HiveQL script file blob name used in the Azure Blob storage. The default value is tutorials/flightdelays/flightdelays.hql. Because the file will be written directly to Azure Blob storage, there is NOT a "/" at the beginning of the blob name. If you want to access the file from Blob storage, you will need to add a "/" at the beginning of the file name.
+	- **$srcDataFolder** and **$dstDataFolder** - = "tutorials/flightdelays/data" 
  = "tutorials/flightdelays/output"
 
 
@@ -690,9 +690,9 @@ For a full list of the HiveQL commands, see [Hive Data Definition Language][hado
 	<tr><td>$sqlDatabaseUsername</td><td>The login name for the Azure SQL database server. If $sqlDatabaseServerName is an existing server, the login and login password are used to authenticate with the server. Otherwise they are used to create a new server.</td></tr>
 	<tr><td>$sqlDatabasePassword</td><td>The login password for the Azure SQL database server.</td></tr>
 	<tr><td>$sqlDatabaseLocation</td><td>This value is used only when you're creating a new Azure database server.</td></tr>
-	<tr><td>$sqlDatabaseName</td><td>The SQL database used to create the AvgDelays table for the Sqoop job. Leaving it blank will create a database called "HDISqoop". The table name for the Sqoop job output is "AvgDelays". </td></tr>
+	<tr><td>$sqlDatabaseName</td><td>The SQL database used to create the AvgDelays table for the Sqoop job. Leaving it blank will create a database called HDISqoop. The table name for the Sqoop job output is AvgDelays. </td></tr>
 	</table>
-2. Open PowerShell ISE. 
+2. Open Azure PowerShell ISE. 
 3. Copy and paste the following script into the script pane:
 	
 		[CmdletBinding()]
@@ -702,7 +702,7 @@ For a full list of the HiveQL commands, see [Hive Data Definition Language][hado
 		    [Parameter(Mandatory=$True,
 		               HelpMessage="Enter the Azure SQL Database Server Name to use an existing one. Enter nothing to create a new one.")]
 		    [AllowEmptyString()]
-		    [String]$sqlDatabaseServer,  # specify the Azure SQL database server name if you have one created. Otherwise use "".
+		    [String]$sqlDatabaseServer,  # Specify the Azure SQL database server name if you have one created. Otherwise use "".
 		
 		    [Parameter(Mandatory=$True,
 		               HelpMessage="Enter the Azure SQL Database admin user.")]
@@ -828,10 +828,10 @@ For a full list of the HiveQL commands, see [Hive Data Definition Language][hado
 
 	Here are some variables used in the script:
 
-	- **$ipAddressRestService**: The default value is <u>http://bot.whatismyipaddress.com</u>. It is a public IP address REST service for getting your external IP address. You can use other services if you want. The external IP address retrieved through the service will be used to create a firewall rule for your Azure SQL database server, so that you can access the database from your workstation (by using a Windows PowerShell script).
-	- **$fireWallRuleName**: This is the name of the firewall rule for the Azure SQL database server. The default name is <u>FlightDelay</u>. You can rename it if you want.
-	- **$sqlDatabaseMaxSizeGB**: This value is used only when you're creating a new Azure SQL database server. The default value is <u>10GB</u>. 10GB is sufficient for this tutorial.
-	- **$sqlDatabaseName**: This value is used only when you're creating a new Azure SQL database. The default value is <u>HDISqoop</u>. If you rename it, you must update the Sqoop Windows PowerShell script accordingly. 
+	- **$ipAddressRestService** - The default value is http://bot.whatismyipaddress.com. It is a public IP address REST service for getting your external IP address. You can use other services if you want. The external IP address retrieved through the service will be used to create a firewall rule for your Azure SQL database server, so that you can access the database from your workstation (by using a Windows PowerShell script).
+	- **$fireWallRuleName** - This is the name of the firewall rule for the Azure SQL database server. The default name is <u>FlightDelay</u>. You can rename it if you want.
+	- **$sqlDatabaseMaxSizeGB** - This value is used only when you're creating a new Azure SQL database server. The default value is 10GB. 10GB is sufficient for this tutorial.
+	- **$sqlDatabaseName** - This value is used only when you're creating a new Azure SQL database. The default value is HDISqoop. If you rename it, you must update the Sqoop Windows PowerShell script accordingly. 
 
 4. Press **F5** to run the script. 
 5. Validate the script output. Make sure the script ran successfully.	
@@ -839,7 +839,7 @@ For a full list of the HiveQL commands, see [Hive Data Definition Language][hado
 ##<a id="nextsteps"></a> Next steps
 Now you understand how to upload a file to Azure Blob storage, how to populate a Hive table by using the data from Azure Blob storage, how to run Hive queries, and how to use Sqoop to export data from HDFS to an Azure SQL database. To learn more, see the following articles:
 
-* [Getting Started with HDInsight][hdinsight-get-started]
+* [Getting started with HDInsight][hdinsight-get-started]
 * [Use Hive with HDInsight][hdinsight-use-hive]
 * [Use Oozie with HDInsight][hdinsight-use-oozie]
 * [Use Sqoop with HDInsight][hdinsight-use-sqoop]


### PR DESCRIPTION
Edit complete.

In the diagram at the beginning of the article, "an Hadoop" and "an Hive" should be "a Hadoop" and "a Hive."

The link "Install and configure Azure PowerShell" didn't work when I tried it.

Per naming guidelines, I changed instances of "PowerShell" by itself to "Azure PowerShell." However, this article uses a mix of "Windows PowerShell" and "Azure PowerShell," even when the acronym "ISE" immediately follows the name. This may be an inconsistency. Please check all instances of "Windows PowerShell" and "Azure PowerShell" and confirm that they're accurate in context.

Per naming guidelines, I changed instances of "storage account" to "Storage account" (except in instances of "Blob storage account," because "Blob storage" is a separate term). Please confirm that this change is accurate, even in instances of "default Storage account".

The article contains multiple references to the year 2013. This information may need an update. 

Please confirm that the screenshots don't reveal any potentially sensitive information.

The note on line 33 isn't formatted like other notes.

In the text "The CREATE EXTERNAL TABLE command doesn't allow any folders in the LOCATION" (line 102), it isn't clear what "LOCATION" refers to. If "LOCATION" was meant to be a generic word, it should be lowercase. If it was meant to be a command name, it should be bold. Some text may be missing here as well.

Please confirm that the link "Provision HDInsight cluster and run Hive/Sqoop jobs" (line 392) is rendering correctly. It doesn't seem to be formatted as link text in the GitHub preview.

In the table on line 405, the field names have a single asterisk on either side of them. That usually formats text as italic, but not in this table. (Even in the published article, the asterisks appear.) If you meant to use italic formatting, keep in mind that you don't have to apply it to these items because other items in the table don't have any special formatting. (In general, UI text is bold.)

On line 677, it would be clearer (and more consistent with previous bullet points) to replace "= "tutorials/flightdelays/data" = "tutorials/flightdelays/output"" with a complete sentence.