### PR TITLE
Edit hdinsight-hadoop-access-yarn-app-logs.md

### DIFF
--- a/articles/hdinsight-hadoop-access-yarn-app-logs.md
+++ b/articles/hdinsight-hadoop-access-yarn-app-logs.md
@@ -16,83 +16,83 @@
 	ms.date="11/21/2014" 
 	ms.author="bradsev"/>
 
-# Access HDInsight Application Logs Programmatically
+# Access HDInsight application logs programmatically
 
-This topic explains how to enumerate the YARN applications programmatically that have completed on a Hadoop cluster in HDInsight and how to access the application logs programmatically without having to RDP into your clusters. Specifically, a new component and a new API have been added:
+This topic explains how to programmatically enumerate the YARN (Yet Another Resource Negotiator) applications that have finished on a Hadoop cluster in Azure HDInsight, and how to programmatically access the application logs without having to connect to your clusters by using Remote Desktop Protocol (RDP). Specifically, a new component and a new API have been added:
 
   1. The generic application history server on HDInsight clusters has been enabled. It is a component within the YARN Timeline Server that handles the storage and retrieval of generic information about completed applications.
-  2. New APIs in the Azure HDInsight .Net SDK have been added to enable you to programmatically enumerate applications that have run on your clusters and to download the relevant application or container specific logs (in plain text) to help with debugging any application problems that occur.
+  2. New APIs in the Azure HDInsight .NET SDK have been added to enable you to programmatically enumerate applications that have run on your clusters and to download the relevant application-specific or container-specific logs (in plain text) to help with debugging any application problems that occur.
 
 
 ## Prerequisites
 
-The Azure HDInsight SDK is required to use the code presented in this topic in a .NET application. The most recently published build of the SDK is available at [NuGet](http://nuget.codeplex.com/wikipage?title=Getting%20Started). 
+The Azure HDInsight SDK is required to use the code presented in this topic in a .NET Framework application. The most recently published build of the SDK is available at [NuGet](http://nuget.codeplex.com/wikipage?title=Getting%20Started). 
 
-To install the HDInsight SDK from a Visual Studio application, go the **Tools** menu, click the **Nuget Package Manager**, and then click **Package Manager Console**. Run the following commands in the console to install the packages.
+To install the HDInsight SDK from a Visual Studio application, go the **Tools** menu, click **Nuget Package Manager**, and then click **Package Manager Console**. Run the following command in the console to install the packages:
 
 		Install-Package Microsoft.WindowsAzure.Management.HDInsight
 
-This command adds .NET libraries for HDInsight and references to them to the current Visual Studio project.
+This command adds .NET libraries for HDInsight and adds references to them to the current Visual Studio project.
 
 
 ## <a name="YARNTimelineServer"></a>YARN Timeline Server
 
 The <a href="http://hadoop.apache.org/docs/r2.4.0/hadoop-yarn/hadoop-yarn-site/TimelineServer.html" target="_blank">YARN Timeline Server</a> provides generic information on completed applications as well as framework-specific application information through two different interfaces. Specifically:
 
-* Storage and retrieval of generic application information on HDInsight clusters has been enabled with versions 3.1.1.374 or higher. 
+* Storage and retrieval of generic application information on HDInsight clusters has been enabled with version 3.1.1.374 or higher. 
 * The framework-specific application information component of the Timeline Server is not currently available on HDInsight clusters.
 
 
 Generic information on applications includes the following sorts of data: 
 
-* **ApplicationId** (a unique identifier of an application), 
-* the **user** who started the application, 
-* information on **attempts** made to complete the application, and 
-* the **containers** used by any given application attempt. 
+* The application ID, a unique identifier of an application 
+* The user who started the application 
+* Information on attempts made to complete the application 
+* The containers used by any given application attempt 
 
-On your HDInsight clusters, this information will be stored by the Resource Manager to a history store in the default container of your default storage account. This generic data on completed applications can be retrieved through a REST API:
+On your HDInsight clusters, this information will be stored by Azure Resource Manager to a history store in the default container of your default Azure Storage account. This generic data on completed applications can be retrieved through a REST API:
 
     GET on https://<cluster-dns-name>.azurehdinsight.net/ws/v1/applicationhistory/apps
 
-We have added new APIs to HDInsight .Net SDK to make it easy to retrieve this data programmatically. Note that, the generic data can also be retrieved by running YARN CLI commands directly on your cluster nodes (after connecting to the cluster using RDP).
+We have added new APIs to the HDInsight .NET SDK to make it easy to retrieve this data programmatically. Note that the generic data can also be retrieved by running YARN command-line interface (CLI) commands directly on your cluster nodes (after connecting to the cluster by using RDP).
 
-## <a name="YARNAppsAndLogs"></a>YARN Applications and Logs
+## <a name="YARNAppsAndLogs"></a>YARN applications and logs
 
-YARN (Yet Another Resource Negotiator) supports multiple programming models (MapReduce being one of them) by decoupling resource management from application scheduling/monitoring. This is done through a global *Resource Manager* (RM), per worker node *Node Managers* (NMs) and per-application *Application Masters* (AMs). The per-application AM negotiates resources (CPU, memory, disk, network) for running your application with the RM. The RM works with NMs to grant these resources, which are granted as *Containers*. The AM is responsible for tracking the progress of the containers assigned to it by the RM. An application may require many containers depending on the nature of the application. 
+YARN supports multiple programming models (MapReduce being one of them) by decoupling resource management from application scheduling/monitoring. This is done through a global *ResourceManager* (RM), per-worker-node *NodeManagers* (NMs), and per-application *ApplicationMasters* (AMs). The per-application AM negotiates resources (CPU, memory, disk, network) for running your application with the RM. The RM works with NMs to grant these resources, which are granted as *containers*. The AM is responsible for tracking the progress of the containers assigned to it by the RM. An application may require many containers depending on the nature of the application. 
 
-Furthermore, each application may consist of multiple *Application Attempts* in order to complete the application in the presence of crashes or due to the loss of communication between an AM and an RM. Hence, containers are granted to a specific attempt of an application. In a sense, a container provides the context for basic unit of work performed by a YARN application and all work that is done within the context of a container is performed on the single worker node on which the container was allocated. See [YARN Concepts][YARN-concepts] for further reference.
+Furthermore, each application may consist of multiple *application attempts* in order to finish in the presence of crashes or due to the loss of communication between an AM and an RM. Hence, containers are granted to a specific attempt of an application. In a sense, a container provides the context for basic unit of work performed by a YARN application, and all work that is done within the context of a container is performed on the single worker node on which the container was allocated. See [YARN Concepts][YARN-concepts] for further reference.
 
-Application logs (and the associated container logs) are critical in debugging problematic Hadoop applications. YARN provides a nice framework for collecting, aggregating, and storing application logs with the [Log Aggregation][log-aggregation] feature. The Log Aggregation feature makes accessing application logs more deterministic as it aggregates logs across all containers on a worker node and stores them as one aggregated log file per worker node on the default file system after an application completes. Your application may use hundreds or thousands of containers, but logs for all containers run on a single worker node will always be aggregated to a single file, resulting in one log file per worker node used by your application. Log Aggregation is enabled by default on HDInsight clusters (version 3.0 and above) and aggregated logs can be found in the default container of your cluster at the following location:
+Application logs (and the associated container logs) are critical in debugging problematic Hadoop applications. YARN provides a nice framework for collecting, aggregating, and storing application logs with the [Log Aggregation][log-aggregation] feature. The Log Aggregation feature makes accessing application logs more deterministic, as it aggregates logs across all containers on a worker node and stores them as one aggregated log file per worker node on the default file system after an application finishes. Your application may use hundreds or thousands of containers, but logs for all containers run on a single worker node will always be aggregated to a single file, resulting in one log file per worker node used by your application. Log Aggregation is enabled by default on HDInsight clusters (version 3.0 and above), and aggregated logs can be found in the default container of your cluster at the following location:
 
 	wasb:///app-logs/<user>/logs/<applicationId>
 
-where, "*user*" is the name of the user who started the application, and "*applicationId*" is the unique identifier of an application as assigned by the YARN Resource Manager.
+In that location, *user* is the name of the user who started the application, and *applicationId* is the unique identifier of an application as assigned by the YARN RM.
 
-The aggregated logs are not directly readable as they are written in a [TFile][T-file], [binary format][binary-format] indexed by Container. YARN provides CLI tools to dump these logs as plain text for applications or containers of interest. You can view these logs as plain text by running one of the following YARN commands directly on the cluster nodes (after connecting to it through RDP):
+The aggregated logs are not directly readable, as they are written in a [TFile][T-file], [binary format][binary-format] indexed by container. YARN provides CLI tools to dump these logs as plain text for applications or containers of interest. You can view these logs as plain text by running one of the following YARN commands directly on the cluster nodes (after connecting to it through RDP):
 
 	yarn logs -applicationId <applicationId> -appOwner <user-who-started-the-application>
 	yarn logs -applicationId <applicationId> -appOwner <user-who-started-the-application> -containerId <containerId> -nodeAddress <worker-node-address> 
 
-The next section talks about how application or container specific logs can be accessed programmatically, without having to RDP to your HDInsight clusters.
+The next section talks about how you can access application-specific or container-specific logs programmatically, without having to use RDP to connect to your HDInsight clusters.
 
-## <a name="enumerate-and-download"></a>Enumerating Applications and Downloading Logs Programmatically
+## <a name="enumerate-and-download"></a>Enumerating applications and downloading logs programmatically
 
-To use the following code samples, you must satisfy the prerequisites outlined above by downloading the latest version of HDInsight .Net SDK. See the instructions provided there.
+To use the following code samples, you must satisfy the prerequisites outlined above by downloading the latest version of the HDInsight .NET SDK. See the instructions provided there.
 
 The code below illustrates how to use the new APIs to enumerate applications and download the logs for completed applications.
 
-> [AZURE.NOTE] The APIs below will only work against "Running" Hadoop clusters with version 3.1.1.374 or greater. Add the following directives.
+> [AZURE.NOTE] The APIs below will work only against "Running" Hadoop clusters with version 3.1.1.374 or greater. Add the following directives:
 
 	using Microsoft.Hadoop.Client;
 	using Microsoft.WindowsAzure.Management.HDInsight;
 
-These reference the newly defined APIs in the code below. The following code snippet above creates an Application History Client against a "Running" cluster in your subscription.
+These reference the newly defined APIs in the code below. The following code snippet creates an Application History client against a "Running" cluster in your subscription:
 
 	string subscriptionId = "<your-subscription-id>";
 	string clusterName = "<your-cluster-name>";
 	string certName = "<your-subscription-management-cert-name>";
 	
-	// Create an HDInsight Client
+	// Create an HDInsight client
 	X509Store store = new X509Store(StoreName.My, StoreLocation.LocalMachine);
 	store.Open(OpenFlags.ReadOnly);
 	X509Certificate2 cert = store.Certificates.Cast<X509Certificate2>()
@@ -104,7 +104,7 @@ These reference the newly defined APIs in the code below. The following code sni
 	IHDInsightClient client = HDInsightClient.Connect(creds);
 	
 	// Get the cluster on which your applications were run
-	// The cluster needs to be in "Running" state
+	// The cluster needs to be in the "Running" state
 	ClusterDetails cluster = client.GetCluster(clusterName);
 	
 	// Create an Application History client against your cluster
@@ -112,7 +112,7 @@ These reference the newly defined APIs in the code below. The following code sni
 				cluster.CreateHDInsightApplicationHistoryClient(TimeSpan.FromMinutes(5));
 
 
- You can now use the Application History Client to list completed applications, filter applications based on your criteria, and download relevant application logs. The following code snippet shows how this is done programmatically.
+You can now use the Application History client to list completed applications, filter applications based on your criteria, and download relevant application logs. The following code snippet shows how this is done programmatically:
 
 	// Local download folder location where the logs will be placed
 	string downloadLocation = "E:\\YarnApplicationLogs";
@@ -135,16 +135,16 @@ These reference the newly defined APIs in the code below. The following code sni
 	    appHistoryClient.DownloadApplicationLogs(application, downloadLocation);
 	}
 
-The above code lists/finds applications of interest using the Application History Client, and then downloads logs for those applications to a local folder. 
+The above code lists/finds applications of interest by using the Application History client, and then downloads logs for those applications to a local folder. 
 
-Alternatively, the code snippet below downloads logs for an application whose "ApplicationId" (its unique identifier) is known. The ApplicationId is a globally unique identifier of an application as assigned to it by the Resource Manager. It is constructed by using the start time of Resource Manager along with a monotonically increasing counter for applications submitted to it. The ApplicationId is of the form "application\_&lt;RM-start-time&gt;\_&lt;Counter&gt;". Please note that ApplicationId and JobId are distinct. The JobId is a MapReduce framework specific concept whereas ApplicationId is a framework agnostic YARN concept. In YARN, a JobId identifies a specific MapReduce Job as handled by the Application Master of a MapReduce application submitted to the Resource Manager.
+Alternatively, the code snippet below downloads logs for an application whose application ID is known. The application ID is a globally unique identifier of an application, as assigned to it by the RM. It is constructed by using the start time of the RM, along with a monotonically increasing counter for applications submitted to it. The application ID is of the form "application\_&lt;RM-start-time&gt;\_&lt;Counter&gt;". Please note that the application ID and job ID are distinct. The job ID is a concept specific to the MapReduce framework, whereas the application ID is a framework-agnostic YARN concept. In YARN, a job ID identifies a specific MapReduce job, as handled by the AM of a MapReduce application submitted to the RM.
 
-	// Download application logs for an application whose application Id is known
+	// Download application logs for an application whose application ID is known
 	string applicationId = "application_1416017767088_0028";
 	ApplicationDetails someApplication = appHistoryClient.GetApplicationDetails(applicationId);
 	appHistoryClient.DownloadApplicationLogs(someApplication, downloadLocation);
 
-If needed, you can also download logs for each container (or any specific container) used by an application as shown below.
+If needed, you can also download logs for each container (or any specific container) used by an application, as shown below.
 
 	ApplicationDetails someApplication = appHistoryClient.GetApplicationDetails(applicationId);
 	
@@ -168,6 +168,6 @@ If needed, you can also download logs for each container (or any specific contai
 
 [YARN-timeline-server]:http://hadoop.apache.org/docs/r2.4.0/hadoop-yarn/hadoop-yarn-site/TimelineServer.html
 [log-aggregation]:http://hortonworks.com/blog/simplifying-user-logs-management-and-access-in-yarn/
-[T-file]:https://issues.apache.org/jira/browse/HADOOP-3315
-[binary-format]:https://issues.apache.org/jira/secure/attachment/12396286/TFile%20Specification%2020081217.pdf 
+[T-file]:https://issues.apache.org/jira/secure/attachment/12396286/TFile%20Specification%2020081217.pdf
+[binary-format]:https://issues.apache.org/jira/browse/HADOOP-3315 
 [YARN-concepts]:http://hortonworks.com/blog/apache-hadoop-yarn-concepts-and-applications/


### PR DESCRIPTION
Edit complete.

On line 53, I changed "this information will be stored by the Resource Manager" to "this information will be stored by Azure Resource Manager." Please confirm that this is correct. If "Resource Manager" was meant to refer to the YARN name, it should be "ResourceManager." (See next comment.)

In the context of YARN names, I changed "Resource Manager" to "ResourceManager," "Node Manager" to "NodeManager," and "Application Master" to "ApplicationMaster" because those seem to be the official spellings (see http://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/YARN.html). If you think those spellings are dubious, please change them back.

After first mention of "ResourceManager," I changed all mentions of "Resource Manager" to "RM." Please confirm that these mentions were meant to refer to the YARN ResourceManager and not to the Azure Resource Manager feature.