### PR TITLE
Edit hdinsight-hadoop-collect-debug-heap-dumps.md

### DIFF
--- a/articles/hdinsight-hadoop-collect-debug-heap-dumps.md
+++ b/articles/hdinsight-hadoop-collect-debug-heap-dumps.md
@@ -16,47 +16,43 @@
 	ms.date="12/08/2014" 
 	ms.author="bradsev"/>
 
-# Collect Heap Dumps for Debugging and Analysis
+# Collect heap dumps for debugging and analysis
 
-Heap dumps can be automatically collected for Hadoop services and placed inside the blob storage account of a user under HDInsightHeapDumps/.  Dump files for a service with heaps contain a snapshot of the application's memory. This includes the values of variables at the time the dump was created.
+Heap dumps can be automatically collected for Hadoop services and placed inside the Azure Blob storage account of a user under HDInsightHeapDumps/. Dump files for a service with heaps contain a snapshot of the application's memory. This includes the values of variables at the time the dump was created.
 
-The collection of heap dumps for various services must be enabled for services on individual clusters. The default for this feature is to be off for a cluster. These heap dumps can be large in size so it is advisable to monitor the blob storage account where they are being saved once the collection has been enabled.
+The collection of heap dumps for various services must be enabled for services on individual clusters. The default for this feature is to be off for a cluster. These heap dumps can be large, so it is advisable to monitor the Blob storage account where they are being saved once the collection has been enabled.
 
 
-## <a name="whichServices"></a>For which services can heap dumps be enabled?
+## <a name="whichServices"></a>Eligible services for heap dumps
 
-The services which can have heap dumps enabled if requested are: 
+The services that can have heap dumps enabled if requested are: 
 
-*  **hcatalog**: tempelton
-*  **hive**: hiveserver2, metastore, derbyserver 
-*  **mapreduce**: jobhistoryserver 
-*  **yarn**: resourcemanager, nodemanager, timelineserver 
-*  **hdfs**: datanode, secondarynamenode, namenode
+*  **hcatalog** - tempelton
+*  **hive** - hiveserver2, metastore, derbyserver 
+*  **mapreduce** - jobhistoryserver 
+*  **yarn** - resourcemanager, nodemanager, timelineserver 
+*  **hdfs** - datanode, secondarynamenode, namenode
 
-## <a name="configuration"></a>The configuration elements that enable heap dumps
+## <a name="configuration"></a>Configuration elements that enable heap dumps
 
-In order to turn on heap dumps for a service the user needs to set the appropriate configuration elements in the section for that service, which is specified by the service_name.
+To turn on heap dumps for a service, you need to set the appropriate configuration elements in the section for that service, which is specified by **service_name**.
 
 	"javaargs.<service_name>.XX:+HeapDumpOnOutOfMemoryError" = "-XX:+HeapDumpOnOutOfMemoryError",
 	"javaargs.<service_name>.XX:HeapDumpPath" = "-XX:HeapDumpPath=c:\Dumps\<service_name>_%date:~4,2%%date:~7,2%%date:~10,2%%time:~0,2%%time:~3,2%%time:~6,2%.hprof" 
 
-The value of the <service_name> can be any of the services listed above: tempelton, hiveserver2, metastore, derbyserver, jobhistoryserver, resourcemanager, nodemanager, timelineserver, datanode, secondarynamenode, or namenode.
+The value of **service_name** can be any of the services listed above: tempelton, hiveserver2, metastore, derbyserver, jobhistoryserver, resourcemanager, nodemanager, timelineserver, datanode, secondarynamenode, or namenode.
 
-## <a name="powershell"></a>How to enable heap dumps with Azure HDInsight PowerShell
+## <a name="powershell"></a>How to enable heap dumps by using Azure PowerShell
 
-For example, to turn on heap dumps using PowerShell for the jobhistoryserver the user would do the following:
-
-Using powershell sdk:
+For example, to turn on heap dumps by using Azure PowerShell for jobhistoryserver, you would do the following:
 
 	$MapRedConfigValues = new-object 'Microsoft.WindowsAzure.Management.HDInsight.Cmdlet.DataObjects.AzureHDInsightMapReduceConfiguration'
 
 	$MapRedConfigValues.Configuration = @{ "javaargs.jobhistoryserver.XX:+HeapDumpOnOutOfMemoryError"="-XX:+HeapDumpOnOutOfMemoryError" ; "javaargs.jobhistoryserver.XX:HeapDumpPath" = "-XX:HeapDumpPath=c:\\Dumps\\jobhistoryserver_%date:~4,2%_%date:~7,2%_%date:~10,2%_%time:~0,2%_%time:~3,2%_%time:~6,2%.hprof" }
 
-## <a name="sdk"></a>How to enable heap dumps with Azure HDInsight .NET SDK
+## <a name="sdk"></a>How to enable heap dumps by using the Azure HDInsight .NET SDK
 
-For example, to turn on heap dumps using the .NET SDK for the jobhistoryserver the user would do the following:
-
-Using c# sdk:
+For example, to turn on heap dumps by using the Azure HDInsight .NET SDK for jobhistoryserver, you would do the following:
 
 	clusterInfo.MapReduceConfiguration.ConfigurationCollection.Add(new KeyValuePair<string, string>("javaargs.jobhistoryserver.XX:+HeapDumpOnOutOfMemoryError", "-XX:+HeapDumpOnOutOfMemoryError"));
 


### PR DESCRIPTION
Edit complete.

In the list that starts on line 30, service names are lowercase with no internal spacing. If there's no good reason for presenting the names like that, they should be written out in full.

I deleted the lines "Using powershell sdk:" and "Using c# sdk:" because the introductory sentences that preceded them made them seem unnecessary. If this information is important, please add it to those introductory sentences and explain further if necessary--but be sure to write out "powershell" as "Azure PowerShell," and be sure to ca​pitalize "c#" as "C#" and "sdk" as "SDK."