### PR TITLE
Edit hdinsight-hive-analyze-sensor-data.md

### DIFF
--- a/articles/hdinsight-hive-analyze-sensor-data.md
+++ b/articles/hdinsight-hive-analyze-sensor-data.md
@@ -18,36 +18,36 @@
 
 #Analyzing sensor data using Hive with HDInsight
 
-Learn how to analyze sensor data using the Hive Query Console with HDInsight (Hadoop), then visualize the data in Microsoft Excel using Power View.
+Learn how to analyze sensor data by using the Hive Query Console with HDInsight (Hadoop), then visualize the data in Microsoft Excel by using Power View.
 
-> [AZURE.NOTE] The steps in this document only work with Windows-based HDInsight clusters
+> [AZURE.NOTE] The steps in this document only work with Windows-based HDInsight clusters.
 
 In this sample, you'll use Hive to process historical data produced by heating, ventilation, and air conditioning (HVAC) systems to identify systems that are not able to reliably maintain a set temperature. You will learn how to:
 
-- Create HIVE tables to query data stored in comma separated value (CSV) files
-- Create HIVE queries to analyze the data
-- Use Microsoft Excel to connect to HDInsight (using an ODBC connection) to retrieve the analyzed data
-- Use Power View to visualize the data
+- Create HIVE tables to query data stored in comma separated value (CSV) files.
+- Create HIVE queries to analyze the data.
+- Use Microsoft Excel to connect to HDInsight (using open database connectivity (ODBC) to retrieve the analyzed data.
+- Use Power View to visualize the data.
 
 ![A diagram of the solution architecture](./media/hdinsight-use-hive-sensor-data-analysis/hvac-architecture.png)
 
-##Prerequisites:
+##Prerequisites
 
-* An HDInsight (Hadoop) cluster - see [Provision Hadoop clusters in HDInsight](hdinsight-provision-clusters.md) for information on creating a cluster
+* An HDInsight (Hadoop) cluster: See [Provision Hadoop clusters in HDInsight](hdinsight-provision-clusters.md) for information about creating a cluster.
 
 * Microsoft Excel 2013
 
-	> [AZURE.NOTE] Microsoft Excel is used for data visualization with [Power View](https://support.office.com/Article/Power-View-Explore-visualize-and-present-your-data-98268d31-97e2-42aa-a52b-a68cf460472e?ui=en-US&rs=en-US&ad=US), which is currently only available on Windows.
+	> [AZURE.NOTE] Microsoft Excel is used for data visualization with [Power View](https://support.office.com/Article/Power-View-Explore-visualize-and-present-your-data-98268d31-97e2-42aa-a52b-a68cf460472e?ui=en-US&rs=en-US&ad=US).
 
 * [Microsoft Hive ODBC Driver](http://www.microsoft.com/download/details.aspx?id=40886)
 
 ##To run the sample
 
-1. From the Azure Management Portal, click the cluster on which you want to run the sample, and then click **Query Console** from the bottom. Alternatively, you can directly open the Query Console using the following URL
+1. From the Azure Portal, click the cluster on which you want to run the sample, and then click **Query Console** at the bottom. Alternatively, you can directly open the Query Console by using the following URL:
 
 	 	https://<clustername>.azurehdinsight.net
 
-	When prompted, authenticate using the administrator user name and password you used when provisioning this cluster.
+	When prompted, authenticate by using the administrator user name and password you used when provisioning this cluster.
 
 2. From the web page that opens, click the **Getting Started Gallery** tab, and then under the **Samples** category, click the **Website Log Analysis** sample.
 


### PR DESCRIPTION
Edit complete. Also sent this to Larry:
Line 40. “Only available in Windows “ was incorrect, so I deleted it. If you want to list availability for Power View, you can repeat part of this, but I don’t think it is necessary because the reader will see it when they go to the Power View page:
This feature isn’t available in Office on a Windows RT PC. Power View and Power Pivot are available in the Office Professional Plus and Office 365 Professional Plus editions, and in the standalone edition of Excel 2013. Read Excel 2010 workbooks with Power Pivot don't work in some versions of Excel 2013. Want to see what version of Office you’re using?
Power View is an interactive data exploration, visualization, and presentation experience that encourages intuitive ad-hoc reporting. Power View is a feature of Microsoft Excel 2013, and of Microsoft SharePoint Server 2010 and 2013 as part of the SQL Server 2012 Service Pack 1 Reporting Services Add-in for Microsoft SharePoint Server Enterprise Edition. 
