### PR TITLE
Edit hdinsight-hadoop-develop-deploy-streaming-jobs.md

### DIFF
--- a/articles/hdinsight-hadoop-develop-deploy-streaming-jobs.md
+++ b/articles/hdinsight-hadoop-develop-deploy-streaming-jobs.md
@@ -20,15 +20,15 @@
 
 # Develop C# Hadoop streaming programs for HDInsight
 
-Hadoop provides a streaming API for MapReduce that enables you to write map and reduce functions in languages other than Java. This tutorial walks you through creating a C# word count program, which counts the occurrences of a given word in the input data you provide. The following illustration shows how the MapReduce framework does a word count.
+Hadoop provides a streaming API for MapReduce that enables you to write map and reduce functions in languages other than Java. This tutorial walks you through creating a C# word-count program, which counts the occurrences of a given word in the input data you provide. The following illustration shows how the MapReduce framework does a word count:
 
 ![HDI.WordCountDiagram][image-hdi-wordcountdiagram]
 
-> [AZURE.NOTE] The steps in this article only apply to Windows-based HDInsight clusters. For an example of streaming for Linux-based HDInsight, see [Develop Python streaming programs for HDInsight](hdinsight-hadoop-streaming-python.md).
+> [AZURE.NOTE] The steps in this article apply only to Windows-based HDInsight clusters. For an example of streaming for Linux-based HDInsight, see [Develop Python streaming programs for HDInsight](hdinsight-hadoop-streaming-python.md).
 
-This topic shows you how to:
+This tutorial shows you how to:
 
-- Develop and test a Hadoop streaming MapReduce program using C# on an HDInsight emulator
+- Develop and test a Hadoop streaming MapReduce program by using C# on the HDInsight Emulator for Azure
 - Run the same MapReduce job on Azure HDInsight 
 - Retrieve the results of the MapReduce job
 
@@ -36,19 +36,19 @@ This topic shows you how to:
 
 Before you begin this tutorial, you must have done the following:
 
-- Install Azure HDInsight Emulator. For instructions, see [Get started using HDInsight Emulator][hdinsight-get-started-emulator].
-- Install Azure PowerShell on the emulator computer. For instructions, see [Install and configure Azure PowerShell][powershell-install-configure]
+- Install the HDInsight Emulator. For instructions, see [Get started using HDInsight Emulator][hdinsight-get-started-emulator].
+- Install Azure PowerShell on the emulator computer. For instructions, see [Install and configure Azure PowerShell][powershell-install-configure].
 - Obtain an Azure subscription. For instructions, see [Purchase Options][azure-purchase-options], [Member Offers][azure-member-offers], or [Free Trial][azure-free-trial].
 
 
-##<a name="develop"></a>Develop a word count Hadoop streaming program in C&#35;
+##<a name="develop"></a>Develop a word-count Hadoop streaming program in C&#35;
 
-The word count solution contains two console application projects: mapper and reducer. The mapper application streams each word into the console and the reducer application counts the number of words that are streamed from a document. Both the mapper and reducer read characters, line by line, from the standard input stream (stdin) and write to the standard output stream (stdout).
+The word-count solution contains two console application projects: mapper and reducer. The mapper application streams each word into the console, and the reducer application counts the number of words that are streamed from a document. Both the mapper and the reducer read characters, line by line, from the standard input stream (stdin) and write to the standard output stream (stdout).
 
-**To create C# console application**
+**To create a C# console application**
 
 1. Open Visual Studio 2013.
-2. Click **FILE**, **New**, and then click **Project**.
+2. Click **FILE**, click **New**, and then click **Project**.
 3. Type or select the following values:
 
 	<table border="1">
@@ -61,17 +61,17 @@ The word count solution contains two console application projects: mapper and re
 	
 4. Click **OK** to create the project.
 
-**To create the Mapper program**
+**To create the mapper program**
 
 5. In Solution Explorer, right-click **Program.cs**, and then click **Rename**.
 6. Rename the file to **WordCountMapper.cs**, and then press **ENTER**.
 7. Click **Yes** to confirm renaming all references.
 8. Double-click **WordCountMapper.cs** to open it.
-9. Add the following using statement:
+9. Add the following **using** statement:
 
 		using System.IO;
 
-10. Replace the Main() function with the following:
+10. Replace the **Main()** function with the following:
 
 		static void Main(string[] args)
 		{
@@ -92,12 +92,12 @@ The word count solution contains two console application projects: mapper and re
 		    }
 		}
 
-11. Click **BUILD**, and then click **Build Solution** to compile the Mapper program.	
+11. Click **BUILD**, and then click **Build Solution** to compile the mapper program.	
 
 
-**To create the Reducer program**
+**To create the reducer program**
 
-1. From Visual Studio 2013, click **FILE**, click **Add** and then click **New Project**.
+1. From Visual Studio 2013, click **FILE**, click **Add**, and then click **New Project**.
 2. Type or select the following values:
 
 	<table border="1">
@@ -111,11 +111,11 @@ The word count solution contains two console application projects: mapper and re
 5. Rename the file to **WordCountReducer.cs**, and then press **ENTER**.
 7. Click **Yes** to confirm renaming all references.
 8. Double-click **WordCountReducer.cs** to open it.
-9. Add the following using statement:
+9. Add the following **using** statement:
 
 		using System.IO;
 
-10. Replace the Main() function with the following:
+10. Replace the **Main()** function with the following:
 
 		static void Main(string[] args)
 		{
@@ -145,9 +145,9 @@ The word count solution contains two console application projects: mapper and re
 		    Console.WriteLine(count);
 		}
 
-11. Click **BUILD**, and then click **Build Solution** to compile the Reducer program.	
+11. Click **BUILD**, and then click **Build Solution** to compile the reducer program.	
 
-The Mapper and the Reducer executables are located at:
+The mapper and reducer executables are located at:
 
 - C:\Tutorials\WordCount\WordCountMapper\bin\Debug\WordCountMapper.exe
 - C:\Tutorials\WordCount\WordCountReducer\bin\Debug\WordCountReducer.exe
@@ -155,21 +155,21 @@ The Mapper and the Reducer executables are located at:
 
 ##<a name="test"></a>Test the program on the emulator
 
-Do the following to test the program on Emulator:
+Do the following to test the program on the HDInsight Emulator:
 
-1. Upload data to the Emulator HDFS
-2. Upload the Mapper and Reducer applications to the Emulator HDFS
-3. Submit a word count MapReduce job
+1. Upload data to the emulator's file system
+2. Upload the mapper and reducer applications to the emulator's file system
+3. Submit a word-count MapReduce job
 4. Check the job status
 5. Retrieve the job results
 
-By default, HDInsight emulator uses HDFS as the default file system.  Optionally, you can configure the HDInsight Emulator to use Azure Blob storage. For details, see [Get started with HDInsight Emulator][hdinsight-emulator-wasb]. In this section, you will use the HDFS *copyFromLocal* command to upload the files. The next section shows you how to upload files using Azure PowerShell. For other methods, see [Upload data to HDInsight][hdinsight-upload-data].
+By default, HDInsight emulator uses Hadoop Distributed File System (HDFS) as the file system. Optionally, you can configure the HDInsight Emulator to use Azure Blob storage. For details, see [Get started with HDInsight Emulator][hdinsight-emulator-wasb]. In this section, you will use the HDFS **copyFromLocal** command to upload the files. The next section shows you how to upload files by using Azure PowerShell. For other methods, see [Upload data to HDInsight][hdinsight-upload-data].
 
 This tutorial uses the following folder structure:
 
 <table border="1">
 <tr><td>Folder</td><td>Note</td></tr>
-<tr><td>\WordCount</td><td>The root folder for the word count project. </td></tr>
+<tr><td>\WordCount</td><td>The root folder for the word-count project. </td></tr>
 <tr><td>\WordCount\Apps</td><td>The folder for the mapper and reducer executables.</td></tr>
 <tr><td>\WordCount\Input</td><td>The MapReduce source file folder.</td></tr>
 <tr><td>\WordCount\Output</td><td>The MapReduce output file folder.</td></tr>
@@ -180,9 +180,9 @@ This tutorial uses the .txt files located in the %hadoop_home% directory.
 
 > [AZURE.NOTE] The Hadoop HDFS commands are case sensitive.
 
-**To copy the text files to the emulator HDFS**
+**To copy the text files to the emulator's file system**
 
-1. From the Hadoop command line window, run the following command to make a directory for the input files:
+1. From the Hadoop command-line window, run the following command to make a directory for the input files:
 
 		hadoop fs -mkdir /WordCount/
 		hadoop fs -mkdir /WordCount/Input
@@ -202,9 +202,9 @@ This tutorial uses the .txt files located in the %hadoop_home% directory.
 	
 
 
-**To deploy the Mapper and the Reducer to the emulator HDFS**
+**To deploy the mapper and the reducer to the emulator's file system**
 
-1. Open Hadoop command line from your desktop and create the /Apps folder in HDFS
+1. Open a Hadoop command line from your desktop and create the /Apps folder in HDFS:
 		hadoop fs -mkdir /WordCount/Apps
 
 2. Run the following commands:
@@ -212,14 +212,14 @@ This tutorial uses the .txt files located in the %hadoop_home% directory.
 		hadoop fs -copyFromLocal C:\Tutorials\WordCount\WordCountMapper\bin\Debug\WordCountMapper.exe /WordCount/Apps/WordCountMapper.exe
 		hadoop fs -copyFromLocal C:\Tutorials\WordCount\WordCountReducer\bin\Debug\WordCountReducer.exe /WordCount/Apps/WordCountReducer.exe
 
-3. Run the following command to list the uploaded files
+3. Run the following command to list the uploaded files:
 
 		hadoop fs -ls /WordCount/Apps
 
 	You shall see the two .exe files.
 
 
-**To run the MapReduce job using HDInsight PowerShell**
+**To run the MapReduce job by using Azure PowerShell**
 
 1. Open Azure PowerShell. For instructions, see [Install and configure Azure PowerShell][powershell-install-configure]. 
 3. Run the following commands to set variables:
@@ -246,14 +246,14 @@ This tutorial uses the .txt files located in the %hadoop_home% directory.
 
 		$creds = Get-Credential -Message "Enter password" -UserName "hadoop"
 
-	You will get a prompt to enter the password.  The password can be any string.  The username must be "hadoop".
+	You will get a prompt to enter the password. The password can be any string. The user name must be "hadoop".
 
-6. Run the following commands to submit the MapReduce job and wait for the job to complete:
+6. Run the following commands to submit the MapReduce job and wait for the job to finish:
 		
 		$mrJob = Start-AzureHDInsightJob -Cluster $clusterName -Credential $creds -JobDefinition $mrJobDef
 		Wait-AzureHDInsightJob -Credential $creds -job $mrJob -WaitTimeoutInSeconds 3600
 
-	When completed, you will get an output similar to the following:
+	When the job finishes, you will get an output similar to the following:
 
 		StatusDirectory : /WordCount/MRStatusOutput
 		ExitCode        : 
@@ -270,13 +270,13 @@ This tutorial uses the .txt files located in the %hadoop_home% directory.
 **To check the job status**
 
 1. From the desktop, click **Hadoop YARN Status**, or browse to **http://localhost:50030/jobtracker.jsp**.
-2. Find the job using the job id either under **RUNNING** or **FINISHED** category. 
+2. Find the job by using the job ID under either the **RUNNING** or **FINISHED** category. 
 3. If a job failed, you can find it under the **FAILED** category. You can also open the job details and find some helpful information for debugging.
 
 
 **To display the output from HDFS**
 
-1. Open Hadoop command line.
+1. Open the Hadoop command line.
 2. Run the following commands to display the output:
 
 		hadoop fs -ls /WordCount/Output/
@@ -285,10 +285,10 @@ This tutorial uses the .txt files located in the %hadoop_home% directory.
 	You can append "|more" at the end of the command to get the page view.
 
 ##<a id="upload"></a>Upload data to Azure Blob storage
-Azure HDInsight uses Azure Blob storage as the default file system. You can configure an HDInsight cluster to use additional Blob storage for the data files. In this section, you will create a storage account and upload the data files to the Blob storage. The data files are the .txt files in the %hadoop_home%\share\doc\hadoop\common directory.
+Azure HDInsight uses Azure Blob storage as the default file system. You can configure an HDInsight cluster to use additional Blob storage for the data files. In this section, you will create an Azure Storage account and upload the data files to the Blob storage. The data files are the .txt files in the %hadoop_home%\share\doc\hadoop\common directory.
 
 
-**To create a Blob storage and a container**
+**To create a Storage account and a container**
 
 1. Open Azure PowerShell.
 2. Set the variables, and then run the commands:
@@ -298,12 +298,12 @@ Azure HDInsight uses Azure Blob storage as the default file system. You can conf
 		$containerName = "<ContainerName>"
 		$location = "<MicrosoftDataCenter>"  # For example, "East US"
 
-3. Run the following command to create a storage account and a Blob storage container on the account
+3. Run the following commands to create a Storage account and a Blob storage container on the account:
 
-		# Select Azure subscription
+		# Select an Azure subscription
 		Select-AzureSubscription $subscriptionName
 		
-		# Create a storage account
+		# Create a Storage account
 		New-AzureStorageAccount -StorageAccountName $storageAccountName -location $location
 				
 		# Create a Blob storage container
@@ -311,14 +311,14 @@ Azure HDInsight uses Azure Blob storage as the default file system. You can conf
 		$destContext = New-AzureStorageContext –StorageAccountName $storageAccountName –StorageAccountKey $storageAccountKey  
 		New-AzureStorageContainer -Name $containerName -Context $destContext
 
-4. Run the following commands to verify the storage account and the container:
+4. Run the following commands to verify the Storage account and the container:
 
 		Get-AzureStorageAccount -StorageAccountName $storageAccountName
 		Get-AzureStorageContainer -Context $destContext
 
 **To upload the data files**
 
-1. In the Azure PowerShell window, set the values for the local folder and destination folders.
+1. In the Azure PowerShell window, set the values for the local and destination folders:
 
 		$localFolder = "C:\hdp\hadoop-2.4.0.2.1.3.0-1981\share\doc\hadoop\common"
 		$destFolder = "WordCount/Input"
@@ -327,13 +327,13 @@ Azure HDInsight uses Azure Blob storage as the default file system. You can conf
 
 3. Run the following commands to get a list of the .txt files in the source file folder:
 
-		# Get a list of the txt files
+		# Get a list of the .txt files
 		$filesAll = Get-ChildItem $localFolder
 		$filesTxt = $filesAll | where {$_.Extension -eq ".txt"}
 		
 5. Run the following snippet to copy the files:
 
-		# Copy the file from local workstation to the Blob container        
+		# Copy the files from the local workstation to the Blob container        
 		foreach ($file in $filesTxt){
 		 
 		    $fileName = "$localFolder\$file"
@@ -350,7 +350,7 @@ Azure HDInsight uses Azure Blob storage as the default file system. You can conf
 		Get-AzureStorageBlob -Container $containerName  -Context $destContext -Prefix $destFolder
 
 
-**To upload the word count applications**
+**To upload the word-count applications**
 
 1. In the Azure PowerShell window, set the following variables:
 
@@ -375,11 +375,11 @@ Azure HDInsight uses Azure Blob storage as the default file system. You can conf
 
 ##<a name="run"></a>Run the MapReduce job on Azure HDInsight
 
-This section provides a PowerShell script that performs all the tasks related to running a MapReduce job. The list of tasks includes:
+This section provides an Azure PowerShell script that performs all the tasks related to running a MapReduce job. The list of tasks includes:
 
 1. Provision an HDInsight cluster
 	
-	1. Create a storage account that will be used as the default HDInsight cluster file system
+	1. Create a Storage account that will be used as the default HDInsight cluster file system
 	2. Create a Blob storage container 
 	3. Create an HDInsight cluster
 
@@ -387,27 +387,27 @@ This section provides a PowerShell script that performs all the tasks related to
 
 	1. Create a streaming MapReduce job definition
 	2. Submit a MapReduce job
-	3. Wait for the job to complete
+	3. Wait for the job to finish
 	4. Display standard error
 	5. Display standard output
 
 3. Delete the cluster
 
 	1. Delete the HDInsight cluster
-	2. Delete the storage account used as the default HDInsight cluster file system
+	2. Delete the Storage account used as the default HDInsight cluster file system
 
 
-**To run the PowerShell script**
+**To run the Azure PowerShell script**
 
 1. Open Notepad.
 2. Copy and paste the following code:
 		
 		# ====== STORAGE ACCOUNT AND HDINSIGHT CLUSTER VARIABLES ======
 		$subscriptionName = "<AzureSubscriptionName>"
-		$stringPrefix = "<StringForPrefix>"     ### prefix to cluster, storage account, and container names
+		$stringPrefix = "<StringForPrefix>"     ### Prefix to cluster, Storage account, and container names
 		$storageAccountName_Data = "<TheDataStorageAccountName>"
 		$containerName_Data = "<TheDataBlobStorageContainerName>"
-		$location = "<MicrosoftDataCenter>"     ### must match the data storage account location
+		$location = "<MicrosoftDataCenter>"     ### Must match the data storage account location
 		$clusterNodes = 1
 		
 		$clusterName = $stringPrefix + "hdicluster"
@@ -473,37 +473,37 @@ This section provides a PowerShell script that performs all the tasks related to
 		Write-Host "Delete the storage account" -ForegroundColor Green
 		Remove-AzureStorageAccount -StorageAccountName $storageAccountName_Default
 
-3. Set the first four variables in the script. **$stringPrefix** is used to prefix the specified string to the HDInsight cluster name, the storage account name, and the Blob storage container name. Because the names for these must be between 3 and 24 characters, make sure the string you specify and the names this script uses, together does not exceed the character limit for the name. You must use all lower case for the $stringPrefix.
+3. Set the first four variables in the script. The **$stringPrefix** variable is used to prefix the specified string to the HDInsight cluster name, the Storage account name, and the Blob storage container name. Because the names for these must be 3 to 24 characters, make sure the string you specify and the names this script uses, together, do not exceed the character limit for the name. You must use all lowercase for **$stringPrefix**.
 
-	 **$storageAccountName_Data** and **$containerName_Data** are the storage account and container that you already created in the previous steps. So, you must provide the names for those. These are used for storing the data files and the applications. $location must match the data storage account location.
+	The **$storageAccountName_Data** and **$containerName_Data** variables are the Storage account and container that you already created in the previous steps. So, you must provide the names for those. These are used for storing the data files and the applications. The **$location** variable must match the data storage account location.
 
 4. Review the rest of the variables.
 5. Save the script file.
 6. Open Azure PowerShell.
-7. Run the following command to set the execution policy to remotesigned:
+7. Run the following command to set the execution policy to RemoteSigned:
 
 		PowerShell -File <FileName> -ExecutionPolicy RemoteSigned
 
-8. When prompted, enter username and password for the HDInsight cluster. Make sure the password is at least 10 characters, contains one uppercase letter, one lowercase letter, a numbera, and a special character. If you don't want to get prompted for the credentials, see [Working with Passwords, Secure Strings and Credentials in Windows PowerShell][powershell-PSCredential]
+8. When prompted, enter the user name and password for the HDInsight cluster. Make sure the password is at least 10 characters and contains one uppercase letter, one lowercase letter, a number, and a special character. If you don't want to get prompted for the credentials, see [Working with Passwords, Secure Strings and Credentials in Windows PowerShell][powershell-PSCredential].
 
-For a HDInsight .NET SDK sample on submitting Hadoop streaming jobs, see [Submit Hadoop jobs programmatically][hdinsight-submit-jobs].
+For an HDInsight .NET SDK sample on submitting Hadoop streaming jobs, see [Submit Hadoop jobs programmatically][hdinsight-submit-jobs].
 
 
 ##<a name="retrieve"></a>Retrieve the MapReduce job output
-This section shows you how to download and display the output.  For the information on displaying the results on Excel, see [Connect Excel to HDInsight with the Microsoft Hive ODBC Driver][hdinsight-ODBC], and [Connect Excel to HDInsight with Power Query][hdinsight-power-query].
+This section shows you how to download and display the output. For information on displaying the results in Excel, see [Connect Excel to HDInsight with the Microsoft Hive ODBC Driver][hdinsight-ODBC] and [Connect Excel to HDInsight with Power Query][hdinsight-power-query].
 
 
 **To retrieve the output**
 
-1. Open Azure PowerShell window.
-2. Set the values and then run the commands:
+1. Open the Azure PowerShell window.
+2. Set the values, and then run the commands:
 
 		$subscriptionName = "<AzureSubscriptionName>"
 		$storageAccountName = "<TheDataStorageAccountName>"
 		$containerName = "<TheDataBlobStorageContainerName>"
 		$blobName = "WordCount/Output/part-00000"
 	
-3. Run the following commands to create an Azure storage context object: 
+3. Run the following commands to create an Azure Storage context object: 
 		
 		Select-AzureSubscription $subscriptionName
 		$storageAccountKey = Get-AzureStorageKey $storageAccountName | %{ $_.Primary }
@@ -517,13 +517,13 @@ This section shows you how to download and display the output.  For the informat
 	
 
 ##<a id="nextsteps"></a>Next steps
-In this tutorial, you have learned how to develop a Hadoop streaming MapReduce job, how to test the application on HDInsight emulator, and how to write a PowerShell script to provision an HDInsight cluster and run a MapReduce on the cluster. To learn more, see the following articles:
+In this tutorial, you have learned how to develop a Hadoop streaming MapReduce job, how to test the application on the HDInsight Emulator, and how to write an Azure PowerShell script to provision an HDInsight cluster and run a MapReduce job on the cluster. To learn more, see the following articles:
 
 - [Get started with Azure HDInsight](hdinsight-get-started.md)
 - [Get started with the HDInsight Emulator][hdinsight-get-started-emulator]
 - [Develop Java MapReduce programs for HDInsight][hdinsight-develop-mapreduce]
 - [Use Azure Blob storage with HDInsight][hdinsight-storage]
-- [Administer HDInsight using PowerShell][hdinsight-admin-powershell]
+- [Administer HDInsight using Azure PowerShell][hdinsight-admin-powershell]
 - [Upload data to HDInsight][hdinsight-upload-data]
 - [Use Hive with HDInsight][hdinsight-use-hive]
 - [Use Pig with HDInsight][hdinsight-use-pig]


### PR DESCRIPTION
Edit complete.

Both instances of the link "Install and configure Azure PowerShell" didn't work when I tried them.

Per naming guidelines, I changed instances of "PowerShell" by itself to "Azure PowerShell." Please make sure that all mentions are technically accurate and shouldn't be "Windows PowerShell" instead.

Per naming guidelines, I changed most instances of "storage account" to "Storage account." Please confirm that this change is accurate at every mention and shouldn't be "Blob storage account" instead. (In cases of "Blob storage account" in other articles, I haven't been capitalizing "storage" because "Blob storage" is a separate term). Note that I didn't make that change in the phrase "data storage account," because that sounds like a different type of account.

It looks like "hadoop fs -mkdir /WordCount/Apps" should be formatted as code and placed on its own line, like the commands in the other steps in that procedure.