### PR TITLE
Use SAS auth instead of ACS WRAP

### DIFF
--- a/articles/service-bus-java-how-to-use-topics-subscriptions.md
+++ b/articles/service-bus-java-how-to-use-topics-subscriptions.md
@@ -51,12 +51,12 @@ and delete topics. The example below shows how a **ServiceBusService** object
 can be used to create a topic named "TestTopic", with a namespace named "HowToSample":
 
     Configuration config = 
-    	ServiceBusConfiguration.configureWithWrapAuthentication(
+    	ServiceBusConfiguration.configureWithSASAuthentication(
           "HowToSample",
-          "your_service_bus_owner",
-          "your_service_bus_key",
-          ".servicebus.windows.net",
-          "-sb.accesscontrol.windows.net/WRAPv0.9");
+          "SAS_key_name",
+          "SAS_key_value",
+          ".servicebus.windows.net"
+          );
 
 	ServiceBusContract service = ServiceBusService.create(config);
     TopicInfo topicInfo = new TopicInfo("TestTopic");


### PR DESCRIPTION
ACS WRAP authentication is deprecated, and new Service Bus instances are created without an associated ACS namespace, therefore a user following the WRAP version of this tutorial will fail. So I changed the ServiceBusConfiguration part to use SAS authentication instead.