### PR TITLE
Edit hdinsight-hadoop-provision-linux-clusters.md

### DIFF
--- a/articles/hdinsight-hadoop-provision-linux-clusters.md
+++ b/articles/hdinsight-hadoop-provision-linux-clusters.md
@@ -17,26 +17,26 @@
    ms.author="nitinme"/>
 
 
-#Provision Hadoop Linux clusters in HDInsight using custom options (Preview)
+#Provision Hadoop Linux clusters in HDInsight by using custom options (preview)
 
-In this article you learn about the different ways to custom-provision an Hadoop Linux cluster on Azure HDInsight - using the Azure Management Portal, PowerShell, or the command line tools, or HDInsight .NET SDK.
+In this article, you'll learn about the different ways to custom-provision a Hadoop Linux cluster on Azure HDInsight - by using the Azure portal, Azure PowerShell, command-line tools, or the HDInsight .NET SDK.
 
 ## What is an HDInsight cluster?
 
-Have you ever wondered why we mention clusters, every time we talk about Hadoop or BigData? That's because Hadoop enables distributed processing of large data, spread across different nodes of a cluster. The cluster has a master/slave architecture with a master (also called head node or name node) and any number of slaves (also called data node). For more information, see <a href="http://go.microsoft.com/fwlink/?LinkId=510084" target="_blank">Apache Hadoop</a>.
+Have you ever wondered why we mention clusters every time we talk about Hadoop or big data? That's because Hadoop enables distributed processing of large data, spread across different nodes of a cluster. The cluster has a master/worker architecture with a master node (also called a head node or name node) and any number of worker nodes (also called data nodes). For more information, see <a href="http://go.microsoft.com/fwlink/?LinkId=510084" target="_blank">Apache Hadoop</a>.
 
 ![HDInsight Cluster][img-hdi-cluster]
 
-An HDInsight cluster abstracts the Hadoop implementation details so that you don't need to worry about how to communicate with different nodes of a cluster. When you provision an HDInsight cluster, you provision Azure compute resources that contain Hadoop and related applications. For more information, see [Introduction to Hadoop in HDInsight](hdinsight-hadoop-introduction.md). The data to be churned is stored in Azure Blob storage, also called *Azure Storage - Blob* (or WASB) in the context of HDInsight. For more information, see [Use Azure Blob Storage with HDInsight](hdinsight-use-blob-storage.md).
+An HDInsight cluster abstracts the Hadoop implementation details so that you don't need to worry about how to communicate with different nodes of a cluster. When you provision an HDInsight cluster, you provision Azure compute resources that contain Hadoop and related applications. For more information, see [Introduction to Hadoop in HDInsight](hdinsight-hadoop-introduction.md). The data to be churned is stored in Azure Blob storage. For more information, see [Use Azure Blob storage with HDInsight](hdinsight-use-blob-storage.md).
 
 This article provides instructions on the different ways to provision a cluster. If you are looking at a quick-start approach to provision a cluster, see [Get Started with Azure HDInsight on Linux](hdinsight-hadoop-linux-get-started.md).
 
-**Prerequisites:**
+**Prerequisites**
 
 Before you begin this article, you must have the following:
 
-- An Azure subscription. Azure is a subscription-based platform. The HDInsight PowerShell cmdlets perform the tasks with your subscription. For more information about obtaining a subscription, see <a href="http://azure.microsoft.com/pricing/purchase-options/" target="_blank">Purchase Options</a>, <a href="http://azure.microsoft.com/pricing/member-offers/" target="_blank">Member Offers</a>, or <a href="http://azure.microsoft.com/pricing/free-trial/" target="_blank">Free Trial</a>.
-- SSH keys. If you want to remote into a Linux cluster using SSH with a key instead of a password. Using a key is the recommended method as it is more secure. For instructions on how to generate SSH keys refer to the following articles
+- An Azure subscription. Azure is a subscription-based platform. The Azure PowerShell cmdlets for HDInsight perform the tasks with your subscription. For more information about obtaining a subscription, see <a href="http://azure.microsoft.com/pricing/purchase-options/" target="_blank">Purchase Options</a>, <a href="http://azure.microsoft.com/pricing/member-offers/" target="_blank">Member Offers</a>, or <a href="http://azure.microsoft.com/pricing/free-trial/" target="_blank">Free Trial</a>.
+- Secure Shell (SSH) keys. If you want to remote into a Linux cluster by using SSH with a key instead of a password, using a key is the recommended method as it is more secure. For instructions on how to generate SSH keys, refer to the following articles:
 	-  From a Linux computer - [Use SSH with Linux-based HDInsight (Hadoop) from Linux, Unix, or OS X](../hdinsight-hadoop-linux-use-ssh-unix).
 	-  From a Windows computer - [Use SSH with Linux-based HDInsight (Hadoop) from Windows](hdinsight-hadoop-linux-use-ssh-windows.md).
 
@@ -44,44 +44,44 @@ Before you begin this article, you must have the following:
 
 ### Clusters on Linux
 
-HDInsight provides the option of provisioning Linux clusters on Azure. Provision a Linux cluster if you are familiar with Linux or Unix, migrating from an existing Linux-based Hadoop solution, or want easy integration with Hadoop ecosystem components built for Linux. For more information on Azure HDInsight on Linux, see [Introduction to Hadoop on HDInsight](hdinsight-hadoop-introduction.md). 
+HDInsight provides the option of provisioning Linux clusters on Azure. Provision a Linux cluster if you are familiar with Linux or Unix, are migrating from an existing Linux-based Hadoop solution, or want easy integration with Hadoop ecosystem components built for Linux. For more information about Azure HDInsight on Linux, see [Introduction to Hadoop on HDInsight](hdinsight-hadoop-introduction.md). 
 
 ### Additional storage
 
-During configuration, you must specify an Azure Blob Storage account, and a default container. This is used as the default storage location by the cluster. Optionally, you can specify additional blobs that will also be associated with your cluster.
+During configuration, you must specify an Azure Blob storage account and a default container. This is used as the default storage location by the cluster. Optionally, you can specify additional blobs that will also be associated with your cluster.
 
-For more information on using secondary blob stores, see [Using Azure Blob Storage with HDInsight](hdinsight-use-blob-storage.md).
+For more information on using secondary blob stores, see [Using Azure Blob storage with HDInsight](hdinsight-use-blob-storage.md).
 
 ### Metastore
 
-The Metastore contains information about Hive tables, partitions, schemas, columns, etc. This information is used by Hive to locate where data is stored on HDFS (or WASB for HDInsight.) By default, Hive uses an embedded database to store this information.
+The metastore contains information about Hive tables, partitions, schemas, columns, etc. This information is used by Hive to locate where data is stored in Hadoop Distributed File System (HDFS), or Azure Blob storage for HDInsight. By default, Hive uses an embedded database to store this information.
 
-When provisioning an HDInsight cluster, you can specify a SQL Database that will contain the Metastore for Hive. This allows the metadata information to be preserved when you delete a cluster, as it is stored externally in SQL Database.
+When provisioning an HDInsight cluster, you can specify a SQL database that will contain the metastore for Hive. This allows the metadata information to be preserved when you delete a cluster, as it is stored externally in the SQL database.
 
-> [WACOM.NOTE] Currently, the option to use metastores is only available while provisioning HDInsight for Linux using .NET SDK. For instructions, see [Provision HDInsight clusters on Linux using .NET SDK](#sdk).
+> [WACOM.NOTE] Currently, the option to use metastores is available only while you're provisioning HDInsight for Linux by using the .NET SDK. For instructions, see [Provision HDInsight clusters on Linux using .NET SDK](#sdk).
 
 
 ## <a id="options"></a> Options for provisioning an HDInsight Linux cluster
 
-You can provision an HDInsight Hadoop Linux cluster from a Linux computer as well as a Windows computer. The following table provides information on the provisioning options available from the different operating systems, and links to instructions for each.
+You can provision an HDInsight Hadoop Linux cluster from a Linux computer as well as a Windows-based computer. The following table provides information on the provisioning options available from the different operating systems, and links to instructions for each.
 
-Provision Linux clusters from a computer running this OS| Using Azure Management Portal | Using Cross-platform CLI | Using .NET SDK | Using PowerShell
+Provision Linux clusters from a computer running this OS| Using the Azure portal | Using the Azure Cross-Platform Command Line Interface | Using the .NET SDK | Using Azure PowerShell
 -----------------| ------------------------| -------------------| ---------- | ---------
 Linux| Click [here](#portal) | Click [here](#cli)| Not applicable | Available soon
 Windows | Click [here](#portal) | Click [here](#cli) | Click [here](#sdk) | Available soon
 
-### <a id="portal"></a> Using Azure Management Portal
+### <a id="portal"></a> Using the Azure portal
 
-HDInsight clusters use an Azure Blob Storage container as the default file system. An Azure storage account located on the same data center is required before you can create a HDInsight cluster. For more information, see [Use Azure Blob Storage with HDInsight](hdinsight-use-blob-storage.md). For details on creating an Azure storage account, see [How to Create a Storage Account][azure-create-storageaccount].
+HDInsight clusters use an Azure Blob storage container as the default file system. An Azure Storage account located in the same datacenter is required before you can create an HDInsight cluster. For more information, see [Use Azure Blob storage with HDInsight](hdinsight-use-blob-storage.md). For details on creating an Azure Storage account, see [How to Create a Storage Account][azure-create-storageaccount].
 
 
 > [WACOM.NOTE] Currently, only the **East Asia**, **Southeast Asia**, **North Europe**, **West Europe**, **East US**, **West US**, **North Central US**, and **South Central US** regions can host HDInsight clusters.
 
-**To create an HDInsight cluster using the custom create option**
+**To create an HDInsight cluster by using the Custom Create option**
 
-1. Sign in to the [Azure Management Portal][azure-management-portal].
+1. Sign in to the [Azure portal][azure-management-portal].
 2. Click **+ NEW** on the bottom of the page, click **DATA SERVICES**, click **HDINSIGHT**, and then click **CUSTOM CREATE**.
-3. On the **Cluster Details** page, type or choose the following values:
+3. On the **Cluster Details** page, type or select the following values:
 
 	![Provide Hadoop HDInsight cluster details](./media/hdinsight-hadoop-provision-linux-clusters/HDI.CustomProvision.Page1.png)
 
@@ -90,25 +90,25 @@ HDInsight clusters use an Azure Blob Storage container as the default file syste
 		<tr><td>Cluster name</td>
 			<td><p>Name the cluster. </p>
 				<ul>
-				<li>DNS name must start and end with alpha numeric, may contain dashes.</li>
-				<li>The field must be a string between 3 to 63 characters.</li>
+				<li>Domain Name System (DNS) name must start and end with alphanumeric, and may contain dashes.</li>
+				<li>The field must be a string from 3 to 63 characters.</li>
 				</ul></td></tr>
 		<tr><td>Cluster Type</td>
-			<td>For cluster type, select <strong>Hadoop</strong>.</td></tr>
+			<td>Select <strong>Hadoop</strong>.</td></tr>
 		<tr><td>Operating System</td>
-			<td>Select <b>Ubuntu 12.04 LTS Preview</b> to provision HDInsight cluster on Linux. To provision a Windows cluster, see <a href="http://azure.microsoft.com/documentation/articles/hdinsight-provision-clusters/" target="_blank">Provision Hadoop clusters on Windows in HDInsight</a>.</td></tr>
+			<td>Select <b>Ubuntu 12.04 LTS Preview</b> to provision an HDInsight cluster on Linux. To provision a Windows cluster, see <a href="http://azure.microsoft.com/documentation/articles/hdinsight-provision-clusters/" target="_blank">Provision Hadoop clusters on Windows in HDInsight</a>.</td></tr>
 		<tr><td>HDInsight version</td>
 			<td>Choose the version. For HDInsight on Linux, the default is HDInsight version 3.2, which uses Hadoop 2.5.</td></tr>
 		</table>
 
-	Enter or select the values as shown in the table and then click the right arrow.
+	Type or select the values as shown in the table, and then click the right arrow.
 
-4. On the **Configure Cluster** page, enter or select the following values:
+4. On the **Configure Cluster** page, type or select the following values:
 
 	<table border="1">
 	<tr><th>Name</th><th>Value</th></tr>
-	<tr><td>Data nodes</td><td>Number of data nodes you want to deploy. For testing purposes, create a single node cluster. <br />The cluster size limit varies for Azure subscriptions. Contact Azure billing support to increase the limit.</td></tr>
-	<tr><td>Region/Virtual network</td><td><p>Choose the same region as the storage account you created in the last procedure. HDInsight requires the storage account located in the same region. Later in the configuration, you can only choose a storage account that is in the same region as you specified here.</p><p>The available regions are: <strong>East Asia</strong>, <strong>Southeast Asia</strong>, <strong>North Europe</strong>, <strong>West Europe</strong>, <strong>East US</strong>, <strong>West US</strong>, <strong>North Central US</strong>, <strong>South Central US</strong><br/></p></td></tr>
+	<tr><td>Data Nodes</td><td>Number of data nodes you want to deploy. For testing purposes, create a single-node cluster. <br />The cluster size limit varies for Azure subscriptions. Contact Azure billing support to increase the limit.</td></tr>
+	<tr><td>Region/Virtual Network</td><td><p>Choose the same region as the one for the Storage account you created in the last procedure. HDInsight requires the Storage account to be located in the same region. Later in the configuration, you can choose only a Storage account that is in the same region as the one you specified here.</p><p>The available regions are: <strong>East Asia</strong>, <strong>Southeast Asia</strong>, <strong>North Europe</strong>, <strong>West Europe</strong>, <strong>East US</strong>, <strong>West US</strong>, <strong>North Central US</strong>, <strong>South Central US</strong>.<br/></p></td></tr>
 	</table>
 
 
@@ -120,88 +120,88 @@ HDInsight clusters use an Azure Blob Storage container as the default file syste
     <table border='1'>
 		<tr><th>Property</th><th>Value</th></tr>
 		<tr><td>HTTP Password</td>
-			<td>Specify the password for the default HTTP user, <i>admin</i>.</td></tr>
-		<tr><td>SSH user name</td>
-			<td>Specify SSH user name. You will use this username to initiate a remote SSH session on the HDInsight cluster nodes.</td></tr>
-		<tr><td>SSH authentication type</td>
-			<td>Specify whether you want to use a password or an SSH key to authenticate an SSH user</td></tr>
+			<td>Specify the password for the default HTTP user, <strong>admin</strong>.</td></tr>
+		<tr><td>SSH User Name</td>
+			<td>Specify the SSH user name. You will use this user name to initiate a remote SSH session on the HDInsight cluster nodes.</td></tr>
+		<tr><td>SSH Authentication Type</td>
+			<td>Specify whether you want to use a password or an SSH key to authenticate an SSH user.</td></tr>
 		<tr><td>SSH Password</td>
-			<td>If you chose a password as authentication type, specify the SSH password to authenticate an SSH user. You will be prompted for this password when you try to initiate an SSH session on the remote Linux machine.</td></tr>
-		<tr><td>SSH public key</td>
-			<td>If you chose a key as authentication type, specify the SSH public key that you must have already generated. When you initiate an SSH session with a node in the Linux cluster, you will use the private key associated with this public key.<br>
-			For instructions on how to generate an SSH key on a Linux computer, see <a href="http://azure.microsoft.com/documentation/articles/hdinsight-hadoop-linux-use-ssh-unix/" target="_blank">here</a>. For instructions on how to generate an SSH key on a Windows computer, see <a href="http://azure.microsoft.com/documentation/articles/hdinsight-hadoop-linux-use-ssh-windows/" target="_blank">here</a>.
+			<td>If you chose a password as the authentication type, specify the SSH password to authenticate an SSH user. You will be prompted for this password when you try to initiate an SSH session on the remote Linux machine.</td></tr>
+		<tr><td>SSH Public Key</td>
+			<td>If you chose a key as the authentication type, specify the SSH public key that you must have already generated. When you initiate an SSH session with a node in the Linux cluster, you will use the private key associated with this public key.<br>
+			For instructions on how to generate an SSH key on a Linux computer, see <a href="http://azure.microsoft.com/documentation/articles/hdinsight-hadoop-linux-use-ssh-unix/" target="_blank">here</a>. For instructions on how to generate an SSH key on a Windows-based computer, see <a href="http://azure.microsoft.com/documentation/articles/hdinsight-hadoop-linux-use-ssh-windows/" target="_blank">here</a>.
 		</td></tr>
 		</table>
 
-	> [WACOM.NOTE] We recommend using SSH public key authentication with SSH as it is more secure than password authentication.
+	> [WACOM.NOTE] We recommend using SSH public-key authentication with SSH as it is more secure than password authentication.
 
 	Click the right arrow.
 
 
-6. On the **Storage Account** page, provide the following value:
+6. On the **Storage Account** page, provide the following values:
 
-    ![Provide storage account for Hadoop HDInsight cluster](./media/hdinsight-hadoop-provision-linux-clusters/HDI.CustomProvision.Page4.png)
+    ![Provide Storage account for Hadoop HDInsight cluster](./media/hdinsight-hadoop-provision-linux-clusters/HDI.CustomProvision.Page4.png)
 
 	<table border='1'>
 		<tr><th>Property</th><th>Value</th></tr>
 		<tr><td>Storage Account</td>
-			<td>Specify the Azure storage account that will be used as the default file system for the HDInsight cluster. You can choose one of the three options:
+			<td>Specify the Azure Storage account that will be used as the default file system for the HDInsight cluster. You can choose one of the three options:
 			<ul>
-				<li>Use Existing Storage</li>
-				<li>Create New Storage</li>
-				<li>Use Storage From Another Subscription</li>
+				<li><strong>Use Existing Storage</strong></li>
+				<li><strong>Create New Storage</strong></li>
+				<li><strong>Use Storage From Another Subscription</strong></li>
 			</ul>
 			</td></tr>
 		<tr><td>Account Name</td>
 			<td><ul>
-				<li>If you chose to use existing storage, for <strong>Account name</strong>, select an existing storage account. The drop-down only lists the storage accounts located in the same data center where you chose to provision the cluster.</li>
-				<li>If you chose <strong>Create new storage</strong> or <strong>Use storage from another subscription</strong> option, you must provide the storage account name.</li>
+				<li>If you chose to use existing storage, for <strong>Account Name</strong>, select an existing Storage account. The drop-down lists only the Storage accounts located in the same datacenter where you chose to provision the cluster.</li>
+				<li>If you chose <strong>Create New Storage</strong> or <strong>Use Storage From Another Subscription</strong> option, you must provide the Storage account name.</li>
 			</ul></td></tr>
 		<tr><td>Account Key</td>
-			<td>If you chose the <strong>Use Storage From Another Subscription</strong> option, specify the account key for that storage account.</td></tr>
-		<tr><td>Default container</td>
-			<td><p>Specifies the default container on the storage account that is used as the default file system for the HDInsight cluster. If you chose <strong>Use Existing Storage</strong> for the <strong>Storage Account</strong> field, and there are no existing containers in that account, the container is created by default with a the same name as the cluster name. If a container with the name of the cluster already exists, a sequence number will be appended to the container name. For example, mycontainer1, mycontainer2, and so on. However, if the existing storage account has a container with a name different from the cluster name you specified, you can use that container as well.</p>
+			<td>If you chose the <strong>Use Storage From Another Subscription</strong> option, specify the account key for that Storage account.</td></tr>
+		<tr><td>Default Container</td>
+			<td><p>Specify the default container on the Storage account that is used as the default file system for the HDInsight cluster. If you chose <strong>Use Existing Storage</strong> for the <strong>Storage Account</strong> field, and there are no existing containers in that account, the container is created by default with the same name as the cluster name. If a container with the name of the cluster already exists, a sequence number will be appended to the container name. For example, mycontainer1, mycontainer2, and so on. However, if the existing Storage account has a container with a name different from the cluster name you specified, you can use that container as well.</p>
             <p>If you chose to create a new storage or use storage from another Azure subscription, you must specify the default container name.</p>
         </td></tr>
 		<tr><td>Additional Storage Accounts</td>
-			<td>HDInsight supports multiple storage accounts. There is no limit on the additional storage account that can be used by a cluster. However, if you create a cluster using the Management Portal, you have a limit of seven due to the UI constraints. Each additional storage account you specify adds an extra Storage Account page to the wizard where you can specify the account information. For example, in the screenshot above, one additional storage account is selected, and hence page 5 is added to the dialog.</td></tr>
+			<td>HDInsight supports multiple Storage accounts. There is no limit on the additional Storage accounts that can be used by a cluster. However, if you create a cluster by using the Azure portal, you have a limit of seven due to the UI constraints. Each additional Storage account you specify adds an extra <strong>Storage Account</strong> page to the wizard, where you can specify the account information. For example, in the screenshot above, one additional Storage account is selected, and hence page 5 is added to the dialog.</td></tr>
 	</table>
 
 	Click the right arrow.
 
-7. If you chose to configure additional storage for the cluster, on the **Storage Account** page, enter the account information for the additional storage account:
+7. If you chose to configure additional storage for the cluster, on the **Storage Account** page, enter the account information for the additional Storage account:
 
 	![Provide additional storage details for HDInsight cluster](./media/hdinsight-hadoop-provision-linux-clusters/HDI.CustomProvision.Page5.png)
 
     Here again, you have the option to choose from existing storage, create new storage, or use storage from another Azure subscription. The procedure to provide the values is similar to the previous step.
 
-    > [WACOM.NOTE] Once an Azure storage account is chosen for your HDInsight cluster, you can neither delete the account, nor change the account to a different account.
+    > [WACOM.NOTE] Once an Azure Storage account is chosen for your HDInsight cluster, you can neither delete the account nor change the account to a different account.
 
- 	After you specified the additional storage account, click the check mark to start provisioning the cluster. 
+ 	After you have specified the additional Storage account, click the check mark to start provisioning the cluster. 
 
-###<a id="cli"></a> Using Cross-platform command line
+###<a id="cli"></a> Using the cross-platform command line
 
-Another option for provisioning an HDInsight cluster is the Cross-platform Command-line Interface. The command-line tool is implemented in Node.js. It can be used on any platform that supports Node.js including Windows, Mac and Linux. You can install the CLI from the following locations:
+Another option for provisioning an HDInsight cluster is the Azure Cross-Platform Command-Line Interface. The command-line tool is implemented in Node.js. It can be used on any platform that supports Node.js, including Windows, Mac and Linux. You can install the command-line interface from the following locations:
 
-- **Node.JS SDK** - <a href="https://www.npmjs.com/package/azure-mgmt-hdinsight" target="_blank">https://www.npmjs.com/package/azure-mgmt-hdinsight</a>
-- **Cross-platform CLI** - <a href="https://github.com/Azure/azure-xplat-cli/archive/hdinsight-February-18-2015.tar.gz" target="_blank">https://github.com/Azure/azure-xplat-cli/archive/hdinsight-February-18-2015.tar.gz</a>  
+- **Node.js SDK** - <a href="https://www.npmjs.com/package/azure-mgmt-hdinsight" target="_blank">https://www.npmjs.com/package/azure-mgmt-hdinsight</a>
+- **Azure Cross-Platform Command-Line Interface** - <a href="https://github.com/Azure/azure-xplat-cli/archive/hdinsight-February-18-2015.tar.gz" target="_blank">https://github.com/Azure/azure-xplat-cli/archive/hdinsight-February-18-2015.tar.gz</a>  
 
 For a general guide on how to use the command-line interface, see [Azure command-line tool for Mac and Linux][azure-command-line-tools].
 
 Instructions below guide you on how to install the cross-platform command line on Linux and Windows, and then how to use the command line to provision a cluster.
 
-- [Set up Azure cross-platform command line for Linux](#clilin)
-- [Set up Azure cross-platform command line for Windows](#cliwin)
-- [Provision HDInsight clusters using Azure cross-platform command-line](#cliprovision)
+- [Set up the cross-platform command line for Linux](#clilin)
+- [Set up the cross-platform command line for Windows](#cliwin)
+- [Provision HDInsight clusters by using the cross-platform command line](#cliprovision)
 
-#### <a id="clilin"></a>Set up cross-platform command line for Linux
+#### <a id="clilin"></a>Set up the cross-platform command line for Linux
 
-Perform the following procedures to set up your Linux computer to use use Azure command-line tools.
+Perform the following procedures to set up your Linux computer to use Azure command-line tools:
 
-- Install cross-platform command line using NPM
+- Install the command-line interface by using Node.js Package Manager (NPM)
 - Connect to your Azure subscription
 
-**To install the command-line interface using NPM**
+**To install the command-line interface by using NPM**
 
 1.	Open a terminal window on your Linux computer and run the following command:
 
@@ -211,7 +211,7 @@ Perform the following procedures to set up your Linux computer to use use Azure 
 
 		azure hdinsight -h
 
-	You can use the *-h* switch at different levels to display the help information. For example:
+	You can use the **-h** switch at different levels to display the help information. For example:
 
 		azure -h
 		azure hdinsight -h
@@ -220,78 +220,78 @@ Perform the following procedures to set up your Linux computer to use use Azure 
 
 **To connect to your Azure subscription**
 
-Before using the command-line interface, you must configure connectivity between your workstation and Azure. Your Azure subscription information is used by the command-line interface to connect to your account. This information can be obtained from Azure in a publish settings file. The publish settings file can then be imported as a persistent local config setting that the command-line interface will use for subsequent operations. You only need to import your publish settings once.
+Before using the command-line interface, you must configure connectivity between your workstation and Azure. Your Azure subscription information is used by the command-line interface to connect to your account. This information can be obtained from Azure in a publish settings file. The publish settings file can then be imported as a persistent local config setting that the command-line interface will use for subsequent operations. You need to import your publish settings only once.
 
-> [WACOM.NOTE] The publish settings file contains sensitive information. Microsoft recommends that you delete the file or take additional steps to encrypt the user folder that contains the file. On Windows, modify the folder properties or use BitLocker. 
+> [WACOM.NOTE] The publish settings file contains sensitive information. Microsoft recommends that you delete the file or take additional steps to encrypt the user folder that contains the file. In Windows, modify the folder properties or use BitLocker Drive Encryption. 
 
 
 1.	Open a terminal window.
-2.	Run the following command to log into your azure subscription.
+2.	Run the following command to log in to your Azure subscription:
 
 		azure account download
 
 	![HDI.Linux.CLIAccountDownloadImport](./media/hdinsight-hadoop-provision-linux-clusters/HDI.Linux.CLIAccountDownloadImport.png)
 
-	The command launches the Web page to download the publish settings file from. If the Web page does not open, click the link in the terminal window to open the browser page and log in to the portal. 
+	The command launches the webpage to download the publish settings file from. If the webpage does not open, click the link in the terminal window to open the browser page and log in to the portal. 
 
 3.	Download the publish settings file to the computer.
-5.	From the command prompt window, run the following command to import the publish settings file:
+4.	From the command prompt window, run the following command to import the publish settings file:
 
 		azure account import <path/to/the/file>
 
 	
-#### <a id="cliwin"></a>Set up cross-platform command line for Windows
+#### <a id="cliwin"></a>Set up the cross-platform command line for Windows
 
-Perform the following procedures to set up your Windows computer to use use Azure command-line tools.
+Perform the following procedures to set up your Windows computer to use Azure command-line tools:
 
-- Install cross-platform command line (using NPM or Windows installer)
+- Install the command-line interface by using NPM or Windows Installer
 - Download and import Azure account publish settings
 
 
-The command-line interface can be installed using *Node.js Package Manager (NPM)* or Windows Installer. Microsoft recommends that you install using only one of the two options.
+The command-line interface can be installed via NPM or Windows Installer. Microsoft recommends that you install it by using only one of the two options.
 
-**To install the command-line interface using NPM**
+**To install the command-line interface by using NPM**
 
 1.	Browse to **www.nodejs.org**.
-2.	Click **INSTALL** and following the instructions using the default settings.
-3.	Open **Command Prompt** (or *Azure Command Prompt*, or *Developer Command Prompt for VS2012*) from your workstation.
-4.	Run the following command in the command prompt window.
+2.	Click **INSTALL** and follow the instructions, using the default settings.
+3.	Open **Command Prompt** (or **Azure Command Prompt**, or **Developer Command Prompt for VS2012**) from your workstation.
+4.	Run the following command in the command prompt window:
 
 		npm install -g https://github.com/Azure/azure-xplat-cli/archive/hdinsight-February-18-2015.tar.gz
 
-	> [WACOM.NOTE] If you get an error saying the NPM command is not found, verify the following paths are in the PATH environment variable: <i>C:\Program Files (x86)\nodejs;C:\Users\[username]\AppData\Roaming\npm</i> or <i>C:\Program Files\nodejs;C:\Users\[username]\AppData\Roaming\npm</i>
+	> [WACOM.NOTE] If you get an error saying the NPM command is not found, verify the following paths are in the **PATH** environment variable: <i>C:\Program Files (x86)\nodejs;C:\Users\[username]\AppData\Roaming\npm</i> or <i>C:\Program Files\nodejs;C:\Users\[username]\AppData\Roaming\npm</i>
 
 5.	Run the following command to verify the installation:
 
 		azure hdinsight -h
 
-	You can use the *-h* switch at different levels to display the help information. For example:
+	You can use the **-h** switch at different levels to display the help information. For example:
 
 		azure -h
 		azure hdinsight -h
 		azure hdinsight cluster -h
 		azure hdinsight cluster create -h
 
-**To install the command-line interface using windows installer**
+**To install the command-line interface by using Windows Installer**
 
 1.	Browse to **http://azure.microsoft.com/downloads/**.
 2.	Scroll down to the **Command line tools** section, and then click **Cross-platform Command Line Interface** and follow the Web Platform Installer wizard.
 
 **To download and import publish settings**
 
-Before using the command-line interface, you must configure connectivity between your workstation and Azure. Your Azure subscription information is used by the command-line interface to connect to your account. This information can be obtained from Azure in a publish settings file. The publish settings file can then be imported as a persistent local config setting that the command-line interface will use for subsequent operations. You only need to import your publish settings once.
+Before using the command-line interface, you must configure connectivity between your workstation and Azure. Your Azure subscription information is used by the command-line interface to connect to your account. This information can be obtained from Azure in a publish settings file. The publish settings file can then be imported as a persistent local config setting that the command-line interface will use for subsequent operations. You need to import your publish settings only once.
 
-> [WACOM.NOTE] The publish settings file contains sensitive information. Microsoft recommends that you delete the file or take additional steps to encrypt the user folder that contains the file. On Windows, modify the folder properties or use BitLocker.
+> [WACOM.NOTE] The publish settings file contains sensitive information. Microsoft recommends that you delete the file or take additional steps to encrypt the user folder that contains the file. In Windows, modify the folder properties or use BitLocker.
 
 
-1.	Open a **Command Prompt**.
-2.	Run the following command to download the publish settings file.
+1.	Open a command prompt.
+2.	Run the following command to download the publish settings file:
 
 		azure account download
 
 	![HDI.CLIAccountDownloadImport][image-cli-account-download-import]
 
-	The command launches the Web page to download the publish settings file from.
+	The command launches the webpage to download the publish settings file from.
 
 3.	At the prompt to save the file, click **Save** and provide a location where the file must be saved.
 5.	From the command prompt window, run the following command to import the publish settings file:
@@ -299,9 +299,9 @@ Before using the command-line interface, you must configure connectivity between
 		azure account import <path/to/the/file>
 
 	
-#### <a id="cliprovision"></a>Provision HDInsight clusters using Azure cross-platform command-line
+#### <a id="cliprovision"></a>Provision HDInsight clusters by using the cross-platform command line
 
-The following procedures are needed to provision an HDInsight cluster using Cross-platform command line:
+The following procedures are needed to provision an HDInsight cluster by using the cross-platform command line:
 
 - Create an Azure Storage account
 - Provision a cluster
@@ -309,34 +309,34 @@ The following procedures are needed to provision an HDInsight cluster using Cros
 
 **To create an Azure storage account**
 
-HDInsight uses an Azure Blob Storage container as the default file system. An Azure storage account is required before you can create an HDInsight cluster. The storage account must be located in the same data center.
+HDInsight uses an Azure Blob storage container as the default file system. An Azure Storage account is required before you can create an HDInsight cluster. The Storage account must be located in the same datacenter.
 
-- From the command prompt window, run the following command to create an Azure storage account:
+- From the command prompt window, run the following command to create an Azure Storage account:
 
 		azure storage account create [options] <StorageAccountName>
 
-	When prompted for a location, select a location where an HDINsight cluster can be provisioned. The storage must be in the same location as the HDInsight cluster. Currently, only the **East Asia**, **Southeast Asia**, **North Europe**, **West Europe**, **East US**, **West US**, **North Central US**, and **South Central US** regions can host HDInsight clusters.  
+	When prompted for a location, select a location where an HDInsight cluster can be provisioned. The storage must be in the same location as the HDInsight cluster. Currently, only the **East Asia**, **Southeast Asia**, **North Europe**, **West Europe**, **East US**, **West US**, **North Central US**, and **South Central US** regions can host HDInsight clusters.  
 
-For information on creating an Azure storage account using Azure Management portal, see [Create, manage, or delete a storage account][azure-create-storageaccount].
+For information on creating an Azure Storage account by using the Azure portal, see [Create, manage, or delete a storage account][azure-create-storageaccount].
 
-If you already have a storage account but do not know the account name and account key, you can use the following commands to retrieve the information:
+If you already have a Storage account but do not know the account name and account key, you can use the following commands to retrieve the information:
 
-	-- lists storage accounts
+	-- Lists Storage accounts
 	azure storage account list
 
-	-- Shows information for a storage account
+	-- Shows information for a Storage account
 	azure storage account show <StorageAccountName>
 
-	-- Lists the keys for a storage account
+	-- Lists the keys for a Storage account
 	azure storage account keys list <StorageAccountName>
 
-For details on getting the information using the management portal, see the *How to: View, copy and regenerate storage access keys* section of [Create, manage, or delete a storage account][azure-create-storageaccount].
+For details on getting the information by using the Azure portal, see the "How to: View, copy and regenerate storage access keys" section of [Create, manage, or delete a storage account][azure-create-storageaccount].
 
-An HDInsight cluster also requires a container within a storage account. If the storage account you provide does not already have a container, the *azure hdinsight cluster create* prompts you for a container name and creates it as well. However, if you want to create the container beforehand, you can use the following command:
+An HDInsight cluster also requires a container within a Storage account. If the Storage account you provide does not already have a container, **azure hdinsight cluster create** prompts you for a container name and creates it as well. However, if you want to create the container beforehand, you can use the following command:
 
 	azure storage container create --account-name <StorageAccountName> --account-key <StorageAccountKey> [ContainerName]
 
-Once you have the storage account and the blob container prepared, you are ready to create a cluster.
+Once you have the Storage account and the Blob container prepared, you are ready to create a cluster.
 
 **To provision an HDInsight cluster**
 
@@ -347,7 +347,7 @@ Once you have the storage account and the blob container prepared, you are ready
 	![HDI.CLIClusterCreation][image-cli-clustercreation]
 
 
-**To provision an HDInsight cluster using a configuration file**
+**To provision an HDInsight cluster by using a configuration file**
 
 Typically, you provision an HDInsight cluster, run the jobs, and then delete the cluster to cut down the cost. The command-line interface gives you the option to save the configurations into a file, so that you can reuse it every time you provision a cluster.
 
@@ -360,14 +360,14 @@ Typically, you provision an HDInsight cluster, run the jobs, and then delete the
 		#Add commands to create a basic cluster
 		azure hdinsight cluster config set <file> --clusterName <ClusterName> --dataNodeCount <NumberOfNodes> --location "<DataCenterLocation>" --storageAccountName "<StorageAccountName>.blob.core.windows.net" --storageAccountKey "<StorageAccountKey>" --storageContainer "<BlobContainerName>" --userName "<Username>" --password "<UserPassword>" --osType linux --sshUserName <SSH username> --sshPassword <SSH user password>
 
-		#If requred, include commands to use additional blob storage with the cluster
+		#If required, include commands to use additional Blob storage with the cluster
 		azure hdinsight cluster config storage add <file> --storageAccountName "<StorageAccountName>.blob.core.windows.net"
 		       --storageAccountKey "<StorageAccountKey>"
 
-		#Run this command to create a cluster using the config file
+		#Run this command to create a cluster by using the config file
 		azure hdinsight cluster create --config <file>
 
-	>[WACOM.NOTE] The Azure SQL database used for the metastore must allow connectivity to other Azure services, including Azure HDInsight. On the Azure SQL database dashboard, on the right side click the server name. This is the server on which the SQL database instance is running. Once you are on the server view, click **Configure**, and then for **Windows Azure Services**, click **Yes**, and then click **Save**.
+	>[WACOM.NOTE] The SQL database used for the metastore must allow connectivity to other Azure services, including Azure HDInsight. On the Azure SQL Database dashboard, on the right side, click the server name. This is the server on which the SQL database instance is running. Once you are on the server view, click **Configure**, and then for **Windows Azure Services**, click **Yes**, and then click **Save**.
 
 
 	![HDI.CLIClusterCreationConfig][image-cli-clustercreation-config]
@@ -391,20 +391,20 @@ Typically, you provision an HDInsight cluster, run the jobs, and then delete the
 
 
 
-###<a id="sdk"></a> Using HDInsight .NET SDK
-The HDInsight .NET SDK provides .NET client libraries that makes it easier to work with HDInsight from a .NET application.
+###<a id="sdk"></a> Using the HDInsight .NET SDK
+The HDInsight .NET SDK provides .NET client libraries that make it easier to work with HDInsight from a .NET Framework application.
 
-The following procedures must be performed to provision an HDInsight cluster on Linux using the SDK:
+The following procedures must be performed to provision an HDInsight cluster on Linux by using the SDK:
 
-- Install HDInsight .NET SDK
+- Install the HDInsight .NET SDK
 - Create a self-signed certificate
 - Create a console application
 - Run the application
 
 
-**To install HDInsight .NET SDK**
+**To install the HDInsight .NET SDK**
 
-You can install latest published build of the SDK from [NuGet](http://nuget.codeplex.com/wikipage?title=Getting%20Started). The instructions will be shown in the next procedure.
+You can install the latest published build of the SDK from [NuGet](http://nuget.codeplex.com/wikipage?title=Getting%20Started). The instructions will be shown in the next procedure.
 
 **To create a self-signed certificate**
 
@@ -415,9 +415,9 @@ Create a self-signed certificate, install it on your workstation, and upload it 
 
 1. Open Visual Studio 2013.
 
-2. From the File menu, click **New**, and then click **Project**.
+2. From the **File** menu, click **New**, and then click **Project**.
 
-3. From New Project, type or select the following values:
+3. From **New Project**, type or select the following values:
 
 	<table style="border-color: #c6c6c6; border-width: 2px; border-style: solid; border-collapse: collapse;">
 	<tr>
@@ -438,7 +438,7 @@ Create a self-signed certificate, install it on your workstation, and upload it 
 
 5. From the **Tools** menu, click **Nuget Package Manager**, and then click **Package Manager Console**.
 
-6. Run the following commands in the console to install the packages.
+6. Run the following command in the console to install the packages:
 
 		Install-Package Microsoft.WindowsAzure.Management.HDInsight
 
@@ -453,7 +453,7 @@ Create a self-signed certificate, install it on your workstation, and upload it 
 		using Microsoft.WindowsAzure.Management.HDInsight.ClusterProvisioning;
 
 
-9. In the Main() function, copy and paste the following code:
+9. In the **Main()** function, copy and paste the following code:
 
         string thumbprint = "<CertificateThumbprint>";  
         string subscriptionid = "<AzureSubscriptionID>";
@@ -469,11 +469,11 @@ Create a self-signed certificate, install it on your workstation, and upload it 
         string sshusername = "<ssh user name>";
         string sshpublickey = "<ssh public key>;
 		
-		//if required, provide details of the Hive and Oozie metastore that you want to configure. ServerName is the name of the server on which the SQL databases are provisioned. HiveStoreSqlDatabaseName and OozieStoreSqlDatabaseName are the names of databases created on the server. You can also use the same database for both Hive and Oozie metastores
+		//If required, provide details of the Hive and Oozie metastore that you want to configure. ServerName is the name of the server on which the SQL databases are provisioned. HiveStoreSqlDatabaseName and OozieStoreSqlDatabaseName are the names of databases created on the server. You can also use the same database for both Hive and Oozie metastores.
 		Metastore hiveMetastore = new Metastore("<ServerName>.database.windows.net", "<HiveStoreSqlDatabaseName>", "<SqlDatabaseUser>", "<SqlDatabasePassword>");
         Metastore oozieMetastore = new Metastore("<ServerName>.database.windows.net", "<OozieStoreSqlDatabaseName>", "<SqlDatabaseUser>", "<SqlDatabasePassword>");
 
-        // Get the certificate object from certificate store using the friendly name to identify it
+        // Get the certificate object from certificate store by using the friendly name to identify it
         X509Store store = new X509Store();
         store.Open(OpenFlags.ReadOnly);
         X509Certificate2 cert = store.Certificates.Cast<X509Certificate2>().First(item => item.Thumbprint == thumbprint);
@@ -482,7 +482,7 @@ Create a self-signed certificate, install it on your workstation, and upload it 
         HDInsightCertificateCredential creds = new HDInsightCertificateCredential(new Guid(subscriptionid), cert);
         var client = HDInsightClient.Connect(creds);
 
-		// Supply th cluster information
+		// Supply the cluster information
         ClusterCreateParametersV2 clusterInfo = new ClusterCreateParametersV2()
         {
             Name = clustername,
@@ -497,8 +497,8 @@ Create a self-signed certificate, install it on your workstation, and upload it 
             OSType = OSType.Linux,
             SshUserName = sshusername,
             SshPublicKey = sshpublickey,
-			HiveMetastore = hiveMetastore,		//only if you created a hivemetastore object earlier
-            OozieMetastore = oozieMetastore		//only if you created an ooziemetastore object earlier
+			HiveMetastore = hiveMetastore,		//Only if you created a hivemetastore object earlier
+            OozieMetastore = oozieMetastore		//Only if you created an ooziemetastore object earlier
         };
 
 		// Configure Hive and Oozie if you opted for the metastores earlier
@@ -515,7 +515,7 @@ Create a self-signed certificate, install it on your workstation, and upload it 
         Console.WriteLine("Press ENTER to continue.");
         Console.ReadKey();
 
-10. Replace the variables at the beginning of the main() function.
+10. Replace the variables at the beginning of the **Main()** function.
 
 **To run the application**
 
@@ -526,13 +526,13 @@ While the application is open in Visual Studio, press **F5** to run the applicat
 ##<a id="nextsteps"></a> Next steps
 In this article, you have learned several ways to provision an HDInsight Hadoop cluster on Linux. To learn more, see the following articles:
 
-- [Working with HDInsight on Linux](hdinsight-hadoop-linux-information.md). Get to know the nuances of working with an HDInsight cluster on Linux.
-- [Manage HDInsight clusters using Ambari](hdinsight-hadoop-manage-ambari.md). Learn how to monitor and manage your Linux-based Hadoop on HDInsight cluster using Ambari Web, or the Ambari REST API. 
-- [Use MapReduce with HDInsight][hdinsight-use-mapreduce]. Learn about the different ways to run MapReduce jobs on a cluster.
-- [Use Hive with HDInsight][hdinsight-use-hive]. Learn about the different way of running a Hive query on a cluster.
-- [Use Pig with HDInsight][hdinsight-use-pig]. Learn about the different ways of running a Pig job on a cluster.
-- [Use Azure Blob storage with HDInsight](hdinsight-use-blob-storage.md). Learn how HDInsight uses Azure Blob storage to store data for HDInsight clusters.
-- [Upload data to HDInsight][hdinsight-upload-data]. Learn how to work with data stored in an Azure Blob storage for an HDInsight cluster.
+- [Working with HDInsight on Linux](hdinsight-hadoop-linux-information.md) - Get to know the nuances of working with an HDInsight cluster on Linux.
+- [Manage HDInsight clusters using Ambari](hdinsight-hadoop-manage-ambari.md) - Learn how to monitor and manage your Linux-based Hadoop on HDInsight cluster by using Ambari Web or the Ambari REST API. 
+- [Use MapReduce with HDInsight][hdinsight-use-mapreduce] - Learn about the different ways to run MapReduce jobs on a cluster.
+- [Use Hive with HDInsight][hdinsight-use-hive] - Learn about the different ways of running a Hive query on a cluster.
+- [Use Pig with HDInsight][hdinsight-use-pig] - Learn about the different ways of running a Pig job on a cluster.
+- [Use Azure Blob storage with HDInsight](hdinsight-use-blob-storage.md) - Learn how HDInsight uses Azure Blob storage to store data for HDInsight clusters.
+- [Upload data to HDInsight][hdinsight-upload-data] - Learn how to work with data stored in an Azure Blob storage for an HDInsight cluster.
 
 [hdinsight-use-mapreduce]: hdinsight-use-mapreduce.md
 [hdinsight-use-hive]: hdinsight-use-hive.md


### PR DESCRIPTION
Edit complete.

Per naming guidelines, I changed most instances of "storage account" to "Storage account." Please confirm that this change is accurate at every mention and shouldn't be "Blob storage account" instead. (In cases of "Blob storage account" in other articles, I haven't been capitalizing "storage" because "Blob storage" is a separate term). 

Per naming guidelines, I changed instances of "PowerShell" by itself to "Azure PowerShell." Please make sure that all mentions are technically accurate and shouldn't be "Windows PowerShell" instead.

In the first figure, "WASB - HDFS implementation on Azure Blob storage" is outdated and should be shortened to "Azure Blob storage."

It looks like "Prerequisites" (line 34) was meant to be formatted as a subheading.

Please confirm that "stored externally in the SQL database" on line 59 is accurate as a generic reference and shouldn't be "stored externally in Azure SQL Database" instead.

It looks like the official name of the Azure cross-platform CLI is "Azure Cross-Platform Command-Line Interface." I used that at a couple of mentions, and then left the generic references "command-line interface," "command-line tool" (and "...tools"), and "cross-platform command line." If it would be more accurate to replace any of these generic terms with the official name, please do so. 

In cross-references that use "here" as link text, it would be more consistent to use the actual title instead.

The screenshot in the "To connect to your Azure subscription" procedure shows your name. If your name isn't on the list of approved names, it would be safer to choose an approved fictitious name, if possible.

A couple of the screenshots show the outdated name "Windows Azure."