### PR TITLE
Fix typo in angle bracket

### DIFF
--- a/articles/data-factory-get-started.md
+++ b/articles/data-factory-get-started.md
@@ -214,7 +214,7 @@ A table is a rectangular dataset and has a schema. In this step, you will create
 
 	if you don't specify a **fileName** for an **input** **table**, all files/blobs from the input folder (**folderPath**) are considered as inputs. If you specify a fileName in the JSON, only the specified file/blob is considered asn input. See the sample files in the [tutorial][adf-tutorial] for examples.
  
-	If you do not specify a **fileName** for an **output table**, the generated files in the **folderPath** are named in the following format: Data.<Guid\>.txt (example: Data.0a405f8a-93ff-4c6f-b3be-f69616f1df7a.txt.).
+	If you do not specify a **fileName** for an **output table**, the generated files in the **folderPath** are named in the following format: Data.&lt;Guid\&gt;.txt (example: Data.0a405f8a-93ff-4c6f-b3be-f69616f1df7a.txt.).
 
 	To set **folderPath** and **fileName** dynamically based on the **SliceStart** time, use the **partitionedBy** property. In the following example, folderPath uses Year, Month, and Day from from the SliceStart (start time of the slice being processed) and fileName uses Hour from the SliceStart. For example, if a slice is being produced for 2014-10-20T08:00:00, the folderName is set to wikidatagateway/wikisampledataout/2014/10/20 and the fileName is set to 08.csv. 
 


### PR DESCRIPTION
In the documentation, a line that describes the automatic naming of a data file includes a placeholder for a GUID in angle brackets.  In a standard markdown editor, the angle brackets render as '<' and '>'.  On the HTML web page, however, they do not render as they are interpreted as an HTML element.

Per the markdown spec (http://daringfireball.net/projects/markdown/syntax), literal angle brackets should be written as escaped entities.

> If you want to use them [special characters] as literal characters, you must escape them as entities.

The typo is in the second to the last paragraph of the "Create Input Table" section of the tutorial.