### PR TITLE
added 'executed' for powershell cmdlet and also fixed typo

### DIFF
--- a/articles/data-factory-tutorial.md
+++ b/articles/data-factory-tutorial.md
@@ -27,7 +27,7 @@ In this walkthrough, we will collect sample logs, process and enrich them with r
 ## Getting ready for the tutorial
 1.	Read [Introduction to Azure Data Factory][adfintroduction] to get an overview of Azure Data Factory and understanding of the top level concepts.
 2.	You must have an Azure subscription to perform this tutorial. For information about obtaining a subscription, see [Purchase Options] [azure-purchase-options], [Member Offers][azure-member-offers], or [Free Trial][azure-free-trial].
-3.	You must download and install [Azure PowerShell][download-azure-powershell] on your computer. You will Data Factory cmdlets to upload sample data and pig/hive scripts to your blob storage. 
+3.	You must download and install [Azure PowerShell][download-azure-powershell] on your computer. You will execute Data Factory cmdlets to upload sample data and pig/hive scripts to your blob storage. 
 2.	**(recommended)** Review and practice the tutorial in the [Get started with Azure Data Factory][adfgetstarted] article for a simple tutorial to get familiar with the portal and cmdlets.
 3.	**(recommended)** Review and practice the walkthrough in the [Use Pig and Hive with Azure Data Factory][usepigandhive] article for a walkthrough on creating a pipeline to move data from on-premises data source to an Azure blob store.
 4.	Download [ADFWalkthrough][adfwalkthrough-download] files to **C:\ADFWalkthrough** folder **preserving the folder structure**:
@@ -200,7 +200,7 @@ In this step, you will create the following linked services:
 
 ### Create StorageLinkedService and HDInsightStorageLinkedService
 
-1.	In the **DATA FACTORY** blade, clcik **Author and deploy** tile to launch the **Editor** for the data factory.
+1.	In the **DATA FACTORY** blade, click **Author and deploy** tile to launch the **Editor** for the data factory.
 
 	![Author and Deploy Tile][image-author-deploy-tile] 
 


### PR DESCRIPTION
added a missing word which I think would be 'executed' for instructions on issuing a powershell cmdlet;
also fixed a typo for the word 'click'.