### PR TITLE
Fixed broken links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thank you for your interest in Azure documentation!
 
 * [Ways to contribute](#ways-to-contribute)
-* [About your contributions to Azure content](#about-your-contributions)
+* [About your contributions to Azure content](#about-your-contributions-to-azure-content)
 * [Repository organization](#repository-organization)
 * [Use GitHub, Git, and this repository](#use-github-git-and-this-repository)
 * [How to use markdown to format your topic](#how-to-use-markdown-to-format-your-topic)
@@ -81,7 +81,7 @@ All the articles in this repository use GitHub flavored markdown.  Here's a list
 
 - [Markdown basics](https://help.github.com/articles/markdown-basics/)
 
-- [Printable markdown cheatsheet](./media/documents/markdown-cheatsheet.pptx?raw=true)
+- [Printable markdown cheatsheet](./contributor-guide/media/documents/markdown-cheatsheet.pdf?raw=true)
 
 
 


### PR DESCRIPTION
Link to `Printable markdown cheatsheet` was broken
 - Was https://github.com/Azure/azure-content/blob/master/media/documents/markdown-cheatsheet.pptx?raw=true
 - Should have been https://github.com/Azure/azure-content/blob/master/contributor-guide/media/documents/markdown-cheatsheet.pdf?raw=true

Anchor to `About your contributions to Azure content` was broken
 - Was https://github.com/Azure/azure-content/blob/master/CONTRIBUTING.md#about-your-contributions
 - Should have been https://github.com/Azure/azure-content/blob/master/CONTRIBUTING.md#about-your-contributions-to-azure-content