### PR TITLE
Event Hubs - Use async/await properly

### DIFF
--- a/includes/service-bus-event-hubs-get-started-receive-ephcs.md
+++ b/includes/service-bus-event-hubs-get-started-receive-ephcs.md
@@ -46,7 +46,7 @@ In order to use [EventProcessorHost], you must have an [Azure Storage account]:
 
 	        async Task IEventProcessor.CloseAsync(PartitionContext context, CloseReason reason)
 	        {
-	            Console.WriteLine(string.Format("Processor Shuting Down. Partition '{0}', Reason: '{1}'.", context.Lease.PartitionId, reason.ToString()));
+	            Console.WriteLine("Processor Shutting Down. Partition '{0}', Reason: '{1}'.", context.Lease.PartitionId, reason);
 	            if (reason == CloseReason.Shutdown)
 	            {
 	                await context.CheckpointAsync();
@@ -55,7 +55,7 @@ In order to use [EventProcessorHost], you must have an [Azure Storage account]:
 
 	        Task IEventProcessor.OpenAsync(PartitionContext context)
 	        {
-	            Console.WriteLine(string.Format("SimpleEventProcessor initialize.  Partition: '{0}', Offset: '{1}'", context.Lease.PartitionId, context.Lease.Offset));
+	            Console.WriteLine("SimpleEventProcessor initialized.  Partition: '{0}', Offset: '{1}'", context.Lease.PartitionId, context.Lease.Offset);
 	            this.checkpointStopWatch = new Stopwatch();
 	            this.checkpointStopWatch.Start();
 	            return Task.FromResult<object>(null);

--- a/includes/service-bus-event-hubs-get-started-send-csharp.md
+++ b/includes/service-bus-event-hubs-get-started-send-csharp.md
@@ -17,6 +17,7 @@ In this section, you'll write a Windows console app that sends events to your Ev
 
 4. Add the following `using` statement at the top of the **Program.cs** file:
 
+		using System.Threading;
 		using Microsoft.ServiceBus.Messaging;
 
 5. Add the following fields to the **Program** class, substituting the placeholder values with the name of the Event Hub you created in the previous section, and the connection string with **Send** rights:
@@ -26,7 +27,7 @@ In this section, you'll write a Windows console app that sends events to your Ev
 
 6. Add the following method to the **Program** class:
 
-		static async Task SendingRandomMessages()
+		static void SendingRandomMessages()
         {
             var eventHubClient = EventHubClient.CreateFromConnectionString(connectionString, eventHubName);
             while (true)
@@ -35,7 +36,7 @@ In this section, you'll write a Windows console app that sends events to your Ev
                 {
                     var message = Guid.NewGuid().ToString();
                     Console.WriteLine("{0} > Sending message: {1}", DateTime.Now, message);
-                    await eventHubClient.SendAsync(new EventData(Encoding.UTF8.GetBytes(message)));
+                    eventHubClient.Send(new EventData(Encoding.UTF8.GetBytes(message)));
                 }
                 catch (Exception exception)
                 {
@@ -44,7 +45,7 @@ In this section, you'll write a Windows console app that sends events to your Ev
                     Console.ResetColor();
                 }
 
-                await Task.Delay(200);
+                Thread.Sleep(200);
             }
         }
 
@@ -55,7 +56,7 @@ In this section, you'll write a Windows console app that sends events to your Ev
 		Console.WriteLine("Press Ctrl-C to stop the sender process");
         Console.WriteLine("Press Enter to start now");
         Console.ReadLine();
-        SendingRandomMessages().Wait();
+        SendingRandomMessages();
 
 
 <!-- Images -->

--- a/includes/service-bus-event-hubs-get-started-send-csharp.md
+++ b/includes/service-bus-event-hubs-get-started-send-csharp.md
@@ -34,13 +34,13 @@ In this section, you'll write a Windows console app that sends events to your Ev
                 try
                 {
                     var message = Guid.NewGuid().ToString();
-                    Console.WriteLine("{0} > Sending message: {1}", DateTime.Now.ToString(), message);
+                    Console.WriteLine("{0} > Sending message: {1}", DateTime.Now, message);
                     await eventHubClient.SendAsync(new EventData(Encoding.UTF8.GetBytes(message)));
                 }
                 catch (Exception exception)
                 {
                     Console.ForegroundColor = ConsoleColor.Red;
-                    Console.WriteLine("{0} > Exception: {1}", DateTime.Now.ToString(), exception.Message);
+                    Console.WriteLine("{0} > Exception: {1}", DateTime.Now, exception.Message);
                     Console.ResetColor();
                 }
 


### PR DESCRIPTION
The [Get started with Event Hubs](http://azure.microsoft.com/en-us/documentation/articles/service-bus-event-hubs-csharp-ephcs-getstarted/) document contains code that uses async/await patterns inefficiently.

- Asynchronous methods should not be called from a synchronous context and then blocked with `Wait` or `Result`.   See: [this Channel 9 video](http://channel9.msdn.com/Series/Three-Essential-Tips-for-Async/Async-Library-Methods-Shouldn-t-Lie).
  - In the Sender application, there is no reason to call `SendAsync` and then block with a `Wait` when the already-synchronous code can just use the synchronous `Send` method.

- Console applications do not have a synchronization context or task scheduler.  If you require use of asynchronous methods from a console application, you need to provide a message pump.  See [this MSDN article](http://blogs.msdn.com/b/pfxteam/archive/2012/01/20/10259049.aspx).
  - In the Receiver application, the `SimpleEventProcessor` class requires async/await functionality, therefore, it should not be kicked off from the `Program` class by calling it synchronously and blocking with a `Wait` call.  Instead, the `AsyncPump` class (from the MSDN article) can be added, allowing the async method to be called using the `await` keyword.

I also fixed a few minor typos and other misc items.