### PR TITLE
Wrong cluster name for SSH connection.

### DIFF
--- a/articles/hdinsight-hadoop-linux-information.md
+++ b/articles/hdinsight-hadoop-linux-information.md
@@ -22,7 +22,7 @@ Linux-based Azure HDInsight clusters provide Hadoop on a familiar Linux environm
 
 ## Domain names
 
-The fully qualified domain name (FQDN) to use when connecting to the cluster is **&lt;clustername>.azurehdinsight.net** or (for SSH only) **&lt;clustername>.aurehdinsight.net**.
+The fully qualified domain name (FQDN) to use when connecting to the cluster is **&lt;clustername>.azurehdinsight.net** or (for SSH only) **&lt;clustername-ssh>.azurehdinsight.net**.
 
 ## Remote access to services
 


### PR DESCRIPTION
Cluster name for SSH connection should be "<clustername-ssh>.azurehdinsight.net" instead of "<clustername>.aurehdinsight.net".