### PR TITLE
Add valid values for --vm-size on vm create and fix default value to "Small"

### DIFF
--- a/articles/virtual-machines-command-line-tools.md
+++ b/articles/virtual-machines-command-line-tools.md
@@ -199,7 +199,8 @@ The following optional parameters are supported for this command:
 **-c, --connect** create the virtual machine inside an already created deployment in a hosting service. If -vmname is not used with this option, the name of the new virtual machine will be generated automatically.<br />
 **-n, --vm-name** Specify the name of the virtual machine. This parameter takes hosting service name by default. If -vmname is not specified, the name for the new virtual machine is generated as &lt;service-name>&lt;id>, where &lt;id> is the number of existing virtual machines in the service plus 1 For example, if you use this command to add a new virtual machine to a hosting service MyService that has one existing virtual machine, the new virtual machine is named MyService2.<br />
 **-u, --blob-url** Specify the target blob storage URL at which to create the virtual machine system disk. <br />
-**-z, --vm-size** Specify the size of the virtual machine. Valid values are "extrasmall", "small", "medium", "large", "extralarge". The default value is "small". <br />
+**-z, --vm-size** Specify the size of the virtual machine. Valid values are:
+"ExtraSmall", "Small", "Medium", "Large", "ExtraLarge", "A5", "A6", "A7", "A8", "A9", "A10", "A11", "Basic_A0", "Basic_A1", "Basic_A2", "Basic_A3", "Basic_A4", "Standard_D1", "Standard_D2", "Standard_D3", "Standard_D4", "Standard_D11", "Standard_D12", "Standard_D13", "Standard_D14", "Standard_DS1", "Standard_DS2", "Standard_DS3", "Standard_DS4", "Standard_DS11", "Standard_DS12", "Standard_DS13", "Standard_DS14", "Standard_G1", "Standard_G2", "Standard_G3", "Standard_G4", "Standard_G55". The default value is "Small". <br />
 **-r** Adds RDP connectivity to a Windows virtual machine. <br />
 **-e, --ssh** Adds SSH connectivity to a Windows virtual machine. <br />
 **-t, --ssh-cert** Specifies the SSH certificate. <br />


### PR DESCRIPTION
I know that they are many values here, but I think is useful for people who wants to automate the process. I have been building an app that let's the user select the size of the machine and since I didn't see the values values in the first place I thought it wasn't possible.