### PR TITLE
Fixing the whitespace for the final image so it loads correctly

### DIFF
--- a/includes/documentdb-create-dbaccount.md
+++ b/includes/documentdb-create-dbaccount.md
@@ -34,11 +34,10 @@
 
 5.	After the DocumentDB account has been created, it is ready for use with the default settings.
 
-	> [AZURE.NOTE] The default consistency of the DocumentDB account will be set to Session.  You can adjust the default consistency setting via the [Azure Preview portal](https://portal.azure.com/#gallery/Microsoft.DocumentDB).  
- 
-
-    ![Screen shot of the Resource Group blade][7]  
-
+	> [AZURE.NOTE] The default consistency of the DocumentDB account will be set to Session.  You can adjust the default consistency setting via the [Azure Preview portal](https://portal.azure.com/#gallery/Microsoft.DocumentDB). 
+	
+	![Screen shot of the Resource Group blade][7]  
+   
 
 <!--Image references-->
 [1]: media/documentdb-create-dbaccount/ca1.png


### PR DESCRIPTION
Currently the final image in this (number 7) does not when imported onto other pages, for example on http://azure.microsoft.com/en-gb/documentation/articles/documentdb-get-started/ where it just shows the markup for the image. This should fix the image include on pages.