### PR TITLE
Update service-bus-dotnet-how-to-use-queues.md

### DIFF
--- a/articles/service-bus-dotnet-how-to-use-queues.md
+++ b/articles/service-bus-dotnet-how-to-use-queues.md
@@ -272,7 +272,7 @@ to process messages as they arrive into the "TestQueue".
             // Indicates a problem, unlock message in queue
             message.Abandon();
         }
-    };
+    }, options);
 
 This example configures the [`OnMessage`](https://msdn.microsoft.com/library/microsoft.servicebus.messaging.queueclient.onmessage.aspx) callback using an [`OnMessageOptions`](https://msdn.microsoft.com/library/microsoft.servicebus.messaging.onmessageoptions.aspx) object. [`AutoComplete`](https://msdn.microsoft.com/library/microsoft.servicebus.messaging.onmessageoptions.autocomplete.aspx)
 is set to **false** to enable manual control over when to call [`Complete`](https://msdn.microsoft.com/library/microsoft.servicebus.messaging.brokeredmessage.complete.aspx) on the received message.


### PR DESCRIPTION
Example usage of QueueClient.OnMessage(Action<BrokeredMessage>, OnMessageOptions) was wrong. (Didn't specify the OnMessageOptions param)