### PR TITLE
Example pipeline should use On-Demand cluster

### DIFF
--- a/articles/data-factory-pig-hive-activities.md
+++ b/articles/data-factory-pig-hive-activities.md
@@ -129,7 +129,7 @@ The Azure Data Factory service supports creation of an on-demand cluster and use
 						"type": "HDInsightActivity",
 						"inputs": [],
 						"outputs": [ {"name": "HiveOutputBlobTable"} ],
-						"linkedServiceName": "HDInsightLinkedService",
+						"linkedServiceName": "HDInsightOnDemandLinkedService",
 						"transformation":
 						{
                     		"type": "Hive",


### PR DESCRIPTION
The text implies that the sample pipeline uses an on-demand cluster, but the JSON specifies a pre-existing cluster.