### PR TITLE
Fix markdown syntax error in web-sites-godaddy-custom-domain-name.md

### DIFF
--- a/articles/web-sites-godaddy-custom-domain-name.md
+++ b/articles/web-sites-godaddy-custom-domain-name.md
@@ -27,7 +27,7 @@
 
 [AZURE.INCLUDE [intro](../includes/custom-dns-web-site-intro.md)]
 
-This article provides instructions on using a custom domain name that was purchased directly from [Go Daddy]https://godaddy.com) with [App Service Web Apps](http://go.microsoft.com/fwlink/?LinkId=529714).
+This article provides instructions on using a custom domain name that was purchased directly from [GoDaddy](https://godaddy.com) with [App Service Web Apps](http://go.microsoft.com/fwlink/?LinkId=529714).
 
 [AZURE.INCLUDE [introfooter](../includes/custom-dns-web-site-intro-notes.md)]
 


### PR DESCRIPTION
Fix:
* Markdown syntax error
* GoDaddy spelling as it is one word