### PR TITLE
Update expressroute-locations.md

### DIFF
--- a/articles/expressroute-locations.md
+++ b/articles/expressroute-locations.md
@@ -51,8 +51,7 @@ Connectivity across geopolitical regions is not supported. You can work with you
 | **[Level 3 Communications - Exchange]( http://your.level3.com/LP=882?WT.tsrc=02192014LP882AzureVanityAzureText)**              | Chicago, Dallas, London, Seattle, Silicon Valley, Washington DC                                                                                                       |
 | **NEXTDC**                                                                                                                     | Melbourne, Sydney+                                                                                                                                                    |
 | **[TeleCity Group]( http://www.telecitygroup.com/investor-centre/news_details.htm?locid=03100500400b00d&xml)**                 | Amsterdam, London                                                                                                                                                     |
-| **[Telstra Corporation]( http://www.telstra.com.au/business-enterprise/network-services/networks/cloud-direct-connect/)**      | Melbourne+, Sydney+                      |
-
+| **[Telstra Corporation]( http://www.telstra.com.au/business-enterprise/network-services/networks/cloud-direct-connect/)**      | Melbourne+, Sydney+                                                                                                                                                   |
 | **[Zayo Group]( http://www.zayo.com/)**                                                                                        | Washington DC                                                                                                                                                         |
 
  **+** denotes coming soon


### PR DESCRIPTION

![expressroutelocations](https://cloud.githubusercontent.com/assets/12814936/8171040/9264883e-137a-11e5-919d-a30049444c40.PNG)
Cleaned up the EXP Locations table: the formatting of the last row, Zayo Group. It was not included in the table due to an extra line.