### PR TITLE
Search SDK: Removing version number from HowTo article

### DIFF
--- a/articles/search-howto-dotnet-sdk.md
+++ b/articles/search-howto-dotnet-sdk.md
@@ -13,7 +13,7 @@
    ms.workload="search"
    ms.topic="article"
    ms.tgt_pltfrm="na"
-   ms.date="04/17/2015"
+   ms.date="06/15/2015"
    ms.author="brjohnst"/>
 
 # How to use Azure Search from a .NET Application #
@@ -29,7 +29,7 @@ The client library defines classes like `Index`, `Field`, and `Document`, as wel
 - [Microsoft.Azure.Search](https://msdn.microsoft.com/library/azure/microsoft.azure.search.aspx)
 - [Microsoft.Azure.Search.Models](https://msdn.microsoft.com/library/azure/microsoft.azure.search.models.aspx)
 
-The current version of the Azure Search .NET SDK is `0.10.0-preview`. This is a pre-release version of the SDK. If you would like to provide feedback for us to incorporate in the first stable version, please visit our [feedback page](http://feedback.azure.com/forums/263029-azure-search).
+The current version of the Azure Search .NET SDK is a pre-release version. If you would like to provide feedback for us to incorporate in the first stable version, please visit our [feedback page](http://feedback.azure.com/forums/263029-azure-search).
 
 The .NET SDK supports version `2015-02-28` of the Azure Search REST API, documented on [MSDN](https://msdn.microsoft.com/library/azure/dn798935.aspx). New features that are *not* part of this version, such as support for Microsoft's natural language processors or the `moreLikeThis` search parameter, are in [preview](../search-api-2015-02-28-preview/) and not yet available in the SDK. You can check back on [Search service versioning](https://msdn.microsoft.com/library/azure/dn864560.aspx) or [Latest updates to Azure Search](../search-latest-updates/) for status updates on either feature.
 


### PR DESCRIPTION
Removing the specific version since it's easy for it to get out of sync when we ship minor bug fix updates to the SDK. Users can always find the latest version on NuGet anyway.