### PR TITLE
Replace obsolete --disable-geoReplication with new --type switch

### DIFF
--- a/articles/virtual-machines-command-line-tools.md
+++ b/articles/virtual-machines-command-line-tools.md
@@ -1885,14 +1885,13 @@ This command supports the following additional options:
 + **-d** or **--description** &lt;description>:  The description storage account.
 + **-l** or **--location** &lt;name>: The geographic region in which to create the storage account.
 + **-a** or **--affinity-group** &lt;name>: The affinity group with which to associate the storage account.
-+ **--geoReplication**:  Indicates if geo-replication is enabled.
-+ **--disable-geoReplication**: Indicates if geo-replication is disabled.
++ **--type**:  Indicates the type of account to create: either Standard Storage with redundancy option (LRS/ZRS/GRS/RAGRS) or Premium Storage (PLRS).
 
 **storage account set [options] <name>**
 
 This command updates the specified storage account.
 
-	~$ azure storage account set mybasestorage --geoReplication
+	~$ azure storage account set mybasestorage --type GRS
 	info:    Executing command storage account set
 	+ Updating storage account
 	info:    storage account set command OK
@@ -1902,8 +1901,7 @@ This command supports the following additional options:
 + **-e** or **--label** &lt;label>: The label for the storage account.
 + **-d** or **--description** &lt;description>:  The description storage account.
 + **-l** or **--location** &lt;name>: The geographic region in which to create the storage account.
-+ **--geoReplication**:  Indicates if geo-replication is enabled.
-+ **--disable-geoReplication**: Indicates if geo-replication is disabled.
++ **--type**:  Indicates the new type of account: either Standard Storage with redundancy option (LRS/ZRS/GRS/RAGRS) or Premium Storage (PLRS).
 
 **storage account delete [options] <name>**
 


### PR DESCRIPTION
The documentation 'storage account create/set' with still referring to the obsolete --disable-geoReplication parameter.