### PR TITLE
Add note about changing AAD tenant

### DIFF
--- a/articles/remoteapp-changetenant.md
+++ b/articles/remoteapp-changetenant.md
@@ -22,6 +22,8 @@
 
 Azure RemoteApp uses Azure Active Directory (Azure AD) to allow user access. The only Azure AD tenant that you can use is the one associated with the Azure subscription. You can view the associated subscription on the Settings page in the portal. Look at the Directory column on the Subscriptions tab. 
 
+>[AZURE.NOTE] In order for the change of the Azure Active Directory to be successful, you should first remove all users from the existing Azure Active Directory tenant from all Azure RemoteApp collections. To do this, go to the Azure Portal, go to the Azure RemoteApp tab and open every Azure RemoteApp collection. Go to the Users tab and remove users that belong to your current Azure Active Directory tenant. Repeat for all existing Azure RemoteApp collections. Without doing this, you will not be able to create or patch collections.
+
 If you want to use a different tenant, use these steps to change the association with your subscription:
 
 1. In the portal, remove any Azure AD users to which you’ve given access to Azure RemoteApp collections.


### PR DESCRIPTION
If you change the tenant and have users assigned from the existing tenant, we will not allow you to create a new collection. This documentation change addresses this issue. 

Please relay to Liza Poggemeyer.