### PR TITLE
The API v1 documentation does not need to change.

### DIFF
--- a/articles/machine-learning/machine-learning-recommendation-api-documentation-v1.md
+++ b/articles/machine-learning/machine-learning-recommendation-api-documentation-v1.md
@@ -12,7 +12,7 @@
 	ms.tgt_pltfrm="na" 
 	ms.devlang="na" 
 	ms.topic="article" 
-	ms.date="04/07/2015" 
+	ms.date="07/17/2015" 
 	ms.author="v-ahgumn"/>
 
 


### PR DESCRIPTION
The API v1 documentation does not need to change. The next version documentation is up to date as well, and posted to https://azure.microsoft.com/en-us/documentation/articles/machine-learning-recommendation-api-documentation/.
Will need to discuss with the team if we should keep this page published or not. For now keep it.