### PR TITLE
Add Python list_blobs example for containers with more than 5000 blobs

### DIFF
--- a/articles/storage/storage-python-how-to-use-blob-storage.md
+++ b/articles/storage/storage-python-how-to-use-blob-storage.md
@@ -78,8 +78,8 @@ The following example uploads the contents of the **sunset.png** file into the *
 
 ## How to: List the Blobs in a Container
 
-To list the blobs in a container, use the **list\_blobs** method with a **for**
-loop to display the name of each blob in the container. The
+To list the blobs in a container, use the **list\_blobs** method with a
+**for** loop to display the name of each blob in the container. The
 following code outputs the **name** and **url** of each blob in a container to the
 console.
 
@@ -88,7 +88,8 @@ console.
 		print(blob.name)
 		print(blob.url)
 
-**list\_blobs** will only return a maximum of 5000 blobs.  If the container contains more than 5000 blobs use the following code.
+**list\_blobs** will only return a maximum of 5000 blobs.  If the container
+contains more than 5000 blobs use the following code.
 
 	blobs = []
 	marker = None

--- a/articles/storage/storage-python-how-to-use-blob-storage.md
+++ b/articles/storage/storage-python-how-to-use-blob-storage.md
@@ -78,12 +78,26 @@ The following example uploads the contents of the **sunset.png** file into the *
 
 ## How to: List the Blobs in a Container
 
-To list the blobs in a container, use the **list\_blobs** method with a
-**for** loop to display the name of each blob in the container. The
+To list the blobs in a container, use the **list\_blobs** method with a **for**
+loop to display the name of each blob in the container. The
 following code outputs the **name** and **url** of each blob in a container to the
 console.
 
 	blobs = blob_service.list_blobs('mycontainer')
+	for blob in blobs:
+		print(blob.name)
+		print(blob.url)
+
+**list\_blobs** will only return a maximum of 5000 blobs.  If the container contains more than 5000 blobs use the following code.
+
+	blobs = []
+	marker = None
+	while True:
+		batch = blob_service.list_blobs('mycontainer', marker=marker)
+		blobs.extend(batch)
+		if not batch.next_marker:
+			break
+		marker = batch.next_marker
 	for blob in blobs:
 		print(blob.name)
 		print(blob.url)

--- a/articles/storage/storage-python-how-to-use-blob-storage.md
+++ b/articles/storage/storage-python-how-to-use-blob-storage.md
@@ -80,13 +80,12 @@ The following example uploads the contents of the **sunset.png** file into the *
 
 To list the blobs in a container, use the **list\_blobs** method with a
 **for** loop to display the name of each blob in the container. The
-following code outputs the **name** and **url** of each blob in a container to the
+following code outputs the **name** of each blob in a container to the
 console.
 
 	blobs = blob_service.list_blobs('mycontainer')
 	for blob in blobs:
 		print(blob.name)
-		print(blob.url)
 
 **list\_blobs** will only return a maximum of 5000 blobs.  If the container
 contains more than 5000 blobs use the following code.
@@ -101,7 +100,6 @@ contains more than 5000 blobs use the following code.
 		marker = batch.next_marker
 	for blob in blobs:
 		print(blob.name)
-		print(blob.url)
 
 ## How to: Download Blobs
 


### PR DESCRIPTION
The example python code for list_blobs does not show the reader how to list all the blobs in a container with more than 5000 blobs.  This pull request adds an example that will return more than 5000 blobs from a container.