### PR TITLE
fixed code sample for 'receive messages from a subscription'

### DIFF
--- a/articles/service-bus/service-bus-dotnet-how-to-use-topics-subscriptions.md
+++ b/articles/service-bus/service-bus-dotnet-how-to-use-topics-subscriptions.md
@@ -252,7 +252,7 @@ in the **HighMessages** subscription.
     options.AutoComplete = false;
     options.AutoRenewTimeout = TimeSpan.FromMinutes(1);
 
-    subscriptionClientHigh.OnMessage((message) =>
+    Client.OnMessage((message) =>
     {
         try
         {


### PR DESCRIPTION
The SubscriptionClient object was named 'Client' but used as 'subscriptionClientHigh'
(no CLA, MS FTE: itays)