### PR TITLE
fix .ssh dirname and mpirun command line.

### DIFF
--- a/articles/virtual-machines/virtual-machines-linux-cluster-rdma.md
+++ b/articles/virtual-machines/virtual-machines-linux-cluster-rdma.md
@@ -137,7 +137,7 @@ Save the public key in a default location and remember the passphrase entered.
 $ cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
 ```
 
-In the /.ssh directory edit or create the ssh_config file. Provide the IP address range of the private network that you will use in Azure:
+In the ~/.ssh directory edit or create the ssh_config file. Provide the IP address range of the private network that you will use in Azure:
 
 ```
 host 10.32.0.*
@@ -256,9 +256,7 @@ private ip address2:16
 You can run the following Intel MPI commands to verify the cluster configuration by using a pingpong benchmark.
 
 ```
-/opt/intel/impi_latest/bin64/mpirun -hosts <host1>, <host2> -ppn 1 -n 2 -env I_MPI_FABRICS dapl -env I_MPI_DAPL_PROVIDER=ofa-v2-ib0 -env I_MPI_DYNAMIC_CONNECTION=0
-
-/opt/intel/impi_latest/bin64/IMB-MPI1 pingpong
+/opt/intel/impi_latest/bin64/mpirun -hosts <host1>, <host2> -ppn 1 -n 2 -env I_MPI_FABRICS dapl -env I_MPI_DAPL_PROVIDER=ofa-v2-ib0 -env I_MPI_DYNAMIC_CONNECTION=0 /opt/intel/impi_latest/bin64/IMB-MPI1 pingpong
 ```
 
 You should see output similar to the following on a working cluster with two nodes:


### PR DESCRIPTION
1. Directory name "/.ssh" should be "~/.ssh" (or simply ".ssh").
2. mpirun command for pingpong should be in 1 line but currently it is splitted 2 lines. Copy and pasting this command-line will cause failed execution.