### PR TITLE
Update virtual-machines-deploy-rmtemplates-powershell.md

### DIFF
--- a/articles/virtual-machines/virtual-machines-deploy-rmtemplates-powershell.md
+++ b/articles/virtual-machines/virtual-machines-deploy-rmtemplates-powershell.md
@@ -21,7 +21,6 @@
 This article shows you how to use Azure Resource Manager templates and PowerShell to automate common tasks for deploying and managing Azure Virtual Machines. For more templates you can use, see [Azure Quickstart Templates](http://azure.microsoft.com/documentation/templates/) and [App Frameworks](virtual-machines-app-frameworks.md).
 
 - [Deploy a Windows VM](#windowsvm)
-- [Create a custom VM image](#customvm)
 - [Deploy a multi-VM application that uses a virtual network and an external load balancer](#multivm)
 - [Remove a resource group](#removerg)
 - [Log on to a virtual machine](#logon)
@@ -300,131 +299,6 @@ You will see something like this:
 	Outputs           :
 
 You now have a new Windows virtual machine named MyWindowsVM in your new resource group.
-
-## <a id="customvm"></a>TASK: Create a custom VM image
-
-Use the instructions in this sections to create a custom VM image in Azure with a Resource Manager template using Azure PowerShell. This template creates a single virtual machine from a specified virtual hard disk (VHD).
-
-### Step 1: Examine the JSON file for the template.
-
-Here are the contents of the JSON file for the template.
-
-	{
-	    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json",
-	    "contentVersion": "1.0.0.0",
-	    "parameters": {
-	        "osDiskVhdUri": {
-	            "type": "string",
-	            "metadata": {
-	                "Description": "Uri of the existing VHD"
-	            }
-	        },
-	        "osType": {
-	            "type": "string",
-	            "allowedValues": [
-	                "windows",
-	                "linux"
-	            ],
-	            "metadata": {
-	                "Description": "Type of OS on the existing vhd"
-	            }
-	        },
-	        "location": {
-	            "type": "String",
-	            "defaultValue": "West US",
-	            "metadata": {
-	                "Description": "Location to create the VM in"
-	            }
-	        },
-	        "vmSize": {
-	            "type": "string",
-	            "defaultValue": "Standard_A2",
-	            "metadata": {
-	                "Description": "Size of the VM"
-	            }
-	        },
-	        "vmName": {
-	            "type": "string",
-	            "defaultValue": "myVM",
-	            "metadata": {
-	                "Description": "Name of the VM"
-	            }
-	        },
-	        "nicName": {
-	            "type": "string",
-	            "defaultValue": "myNIC",
-	            "metadata": {
-	                "Description": "NIC to attach the new VM to"
-	            }
-	        }
-	    },
-	    "resources": [{
-	        "apiVersion": "2014-12-01-preview",
-	        "type": "Microsoft.Compute/virtualMachines",
-	        "name": "[parameters('vmName')]",
-	        "location": "[parameters('location')]",
-	        "properties": {
-	            "hardwareProfile": {
-	                "vmSize": "[parameters('vmSize')]"
-	            },
-	            "storageProfile": {
-	                "osDisk": {
-	                    "name": "[concat(parameters('vmName'),'-osDisk')]",
-	                    "osType": "[parameters('osType')]",
-	                    "caching": "ReadWrite",
-	                    "vhd": {
-	                        "uri": "[parameters('osDiskVhdUri')]"
-	                    }
-	                }
-	            },
-	            "networkProfile": {
-	                "networkInterfaces": [{
-	                    "id": "[resourceId('Microsoft.Network/networkInterfaces',parameters('nicName'))]"
-	                }]
-	            }
-	        }
-	    }]
-	}
-
-### Step 2: Obtain the VHD.
-
-For a Windows-based virtual machine, see [Create and upload a Windows Server VHD to Azure](virtual-machines-create-upload-vhd-windows-server.md).
-
-For a Linux-based virtual machine, see [Create and upload a Linux VHD in Azure](virtual-machines-linux-create-upload-vhd.md).
-
-### Step 3: Create the virtual machine with the template.
-
-To create an new virtual machine based on the VHD, replace the elements within the "< >" with your specific information and run these commands:
-
-	$deployName="<deployment name>"
-	$RGName="<resource group name>"
-	$locName="<Azure location, such as West US>"
-	$templateURI="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-vm-from-specialized-vhd/azuredeploy.json"
-	New-AzureResourceGroup -Name $RGName -Location $locName
-	New-AzureResourceGroupDeployment -Name $deployName -ResourceGroupName $RGName -TemplateUri $templateURI
-
-You will be prompted to supply the values of parameters in the "parameters" section of the JSON file. When you have specified all the parameter values, Azure Resource Manager creates the resource group and the virtual machine.
-
-Here is an example:
-
-	$deployName="TestDeployment"
-	$RGName="TestRG"
-	$locname="West US"
-	$templateURI="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-vm-from-specialized-vhd/azuredeploy.json"
-	New-AzureResourceGroup -Name $RGName -Location $locName
-	New-AzureResourceGroupDeployment -Name $deployName -ResourceGroupName $RGName -TemplateUri $templateURI
-
-
-You will receive the following type of information:
-
-	cmdlet New-AzureResourceGroup at command pipeline position 1
-	Supply values for the following parameters:
-	(Type !? for Help.)
-	osDiskVhdUri: http://saacct.blob.core.windows.net/vhds/osdiskforwindows.vhd
-	osType: windows
-	location: West US
-	vmSize: Standard_A3
-	...
 
 ## <a id="multivm"></a>TASK: Deploy a multi-VM application that uses a virtual network and an external load balancer
 
@@ -762,8 +636,8 @@ Fill in an Azure deployment name, Resource Group name, Azure location, and then 
 
 When you run the New-AzureResourceGroupDeployment command, you will be prompted to supply the values of parameters of the JSON file. When you have specified all the parameter values, the command creates the resource group and the deployment.
 
-	$deployName="TestDeployment"
-	$RGName="TestRG"
+	$deployName="TestDeploy2"
+	$RGName="TestRG2"
 	$locname="West US"
 	$templateURI="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-2-vms-loadbalancer-lbrules/azuredeploy.json"
 	New-AzureResourceGroup -Name $RGName -Location $locName


### PR DESCRIPTION
Remove Section to Upload VHD.  The section instructions do not work.  It refers to a dependent blog post to create the storage account and upload the VHD.  That blog post, does not use resource manager to create the storage account. (See Windows Directions at: https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-create-upload-vhd-windows-server/)  A storage account created with these instructions can no longer be used to create a VM using Resource Manager.  This is an unsupported scenario.  It gives an error message of:  'Please use a storage account managed by Storage Resource Provider. Use of guruarm is not supported. The uploadVHD part of this script should be done in a separate post and fixed so it does not rely on another post.
  
Also, Changed the name of the ResourceGroups and Deployment  in the script (for the second section).  If you follow the blog post in sequence it will not work because when you get to creating the second section (which was UploadVHD but is now Multiple VMs) using the same ResourceGroup Name and Deployment Name it tries to do an update instead of creating the new systems.  Changing the default names will fix this behavior.
![uploadvhd-error](https://cloud.githubusercontent.com/assets/7460856/8996381/686371d8-36cc-11e5-8589-2c11c15fc094.JPG)
