### PR TITLE
Fix AzureStorage Config Sample: CloudStorageAccount.Parse & ConnectionString

### DIFF
--- a/includes/storage-dotnet-retrieve-conn-string.md
+++ b/includes/storage-dotnet-retrieve-conn-string.md
@@ -15,4 +15,4 @@ If you are creating an application with no reference to Microsoft.WindowsAzure.C
 	using System.Configuration;
 	...
 	CloudStorageAccount storageAccount = CloudStorageAccount.Parse(
-		ConfigurationManager.ConnectionStrings["StorageConnectionString"]);
+		ConfigurationManager.ConnectionStrings["StorageConnectionString"].ConnectionString);


### PR DESCRIPTION
Parse only accepts a string - to get this sample right inject the ConnectionString property from the config, otherwise a build error will be shown.