### PR TITLE
Fix links to "Troubleshoot a web app in VS"

### DIFF
--- a/articles/app-service-web/web-sites-enable-diagnostic-log.md
+++ b/articles/app-service-web/web-sites-enable-diagnostic-log.md
@@ -22,7 +22,7 @@
 
 Azure provides built-in diagnostics to assist with debugging an [App Service web app](http://go.microsoft.com/fwlink/?LinkId=529714). In this article you'll learn how to enable diagnostic logging and add instrumentation to your application, as well as how to access the information logged by Azure.
 
-> [AZURE.NOTE] This article uses the [Azure preview portal](http://go.microsoft.com/fwlink/?LinkId=529715), Azure PowerShell, and the Azure Command-Line Interface (Azure CLI) to work with diagnostic logs. For information on working with diagnostic logs using Visual Studio, see [Troubleshooting Azure in Visual Studio](troubleshoot-web-sites-in-visual-studio.md).
+> [AZURE.NOTE] This article uses the [Azure preview portal](http://go.microsoft.com/fwlink/?LinkId=529715), Azure PowerShell, and the Azure Command-Line Interface (Azure CLI) to work with diagnostic logs. For information on working with diagnostic logs using Visual Studio, see [Troubleshooting Azure in Visual Studio](web-sites-dotnet-troubleshoot-visual-studio.md).
 
 ## <a name="whatisdiag"></a>Web server diagnostics and application diagnostics
 
@@ -42,7 +42,7 @@ Application diagnostics allows you to capture information produced by a web appl
 
 	System.Diagnostics.Trace.TraceError("If you're seeing this, something bad happened");
 
-At runtime you can retrieve these logs to help with troubleshooting. For more information, see [Troubleshooting Azure web apps in Visual Studio](../troubleshoot-web-sites-in-visual-studio.md).
+At runtime you can retrieve these logs to help with troubleshooting. For more information, see [Troubleshooting Azure web apps in Visual Studio](web-sites-dotnet-troubleshoot-visual-studio.md).
 
 App Service web apps also log deployment information when you publish content to a web app. This happens automatically and there are no configuration settings for deployment logging. Deployment logging allows you to determine why a deployment failed. For example, if you are using a custom deployment script, you might use deployment logging to determine why the script is failing.
 


### PR DESCRIPTION
Fix 2 links to 
https://github.com/Azure/azure-content/blob/master/articles/app-service-web/web-sites-dotnet-troubleshoot-visual-studio.md 
which incorrectly referenced 
https://github.com/Azure/azure-content/blob/master/articles/app-service-web/troubleshoot-web-sites-in-visual-studio.md