### PR TITLE
Fix "-e" option for "azure network net create".

### DIFF
--- a/articles/virtual-machines/virtual-machines-linux-cluster-rdma.md
+++ b/articles/virtual-machines/virtual-machines-linux-cluster-rdma.md
@@ -190,7 +190,7 @@ Modify the following script with appropriate values for your environment, and ru
 ### Select a region where A8 and A9 VMs are available, such as West US
 ### See Azure Pricing pages for prices and availability of A8 and A9 VMs
 
-azure network vnet create -l "West US" –e 10.32.0.0 <network-name>
+azure network vnet create -l "West US" -e 10.32.0.0 <network-name>
 
 ### Create a cloud service. All the A8 and A9 instances need to be in the same cloud service for Linux RDMA to work across InfiniBand.
 ### Note: The current maximum number of VMs in a cloud service is 50. If you need to provision more than 50 VMs in the same cloud service in your cluster, contact Azure Support.


### PR DESCRIPTION
Command line option should use "-"(ASCII: 0x2d) instead of "-"(Unicode: 0x2013: Em-Dash).
This causes following error when  this script is copied and pasted to command line.

	info:    Executing command network vnet create
	error:   The name can contain only letters, numbers and hyphens with no more than 63 characters. It must start with a letter or number