### PR TITLE
Update insights config sample to use builder

### DIFF
--- a/articles/application-insights/app-insights-asp-net-five.md
+++ b/articles/application-insights/app-insights-asp-net-five.md
@@ -90,16 +90,20 @@ In `startup.cs`:
 
 In the `Startup` method:
 
-    // Setup configuration sources.
-    var configuration = new Configuration()
-       .AddJsonFile("config.json")
-       .AddJsonFile($"config.{env.EnvironmentName}.json", optional: true);
-    configuration.AddEnvironmentVariables();
-    Configuration = configuration;
-
-    if (env.IsEnvironment("Development"))
+    public Startup(IHostingEnvironment env, IApplicationEnvironment appEnv)
     {
-      configuration.AddApplicationInsightsSettings(developerMode: true);
+    	// Setup configuration sources.
+    	var builder = new ConfigurationBuilder(appEnv.ApplicationBasePath)
+	   		.AddJsonFile("config.json")
+	   		.AddJsonFile($"config.{env.EnvironmentName}.json", optional: true);
+    	builder.AddEnvironmentVariables();
+
+    	if (env.IsEnvironment("Development"))
+    	{
+	    	builder.AddApplicationInsightsSettings(developerMode: true);
+    	}
+    
+    	Configuration = builder.build();
     }
 
 In the `ConfigurationServices` method:


### PR DESCRIPTION
The current sample doesn't compile with a brand new asp.net 5 app.  Using `ConfigurationBuilder` as prescribed in [the ASP.NET Docs](http://docs.asp.net/en/latest/fundamentals/configuration.html#using-the-built-in-providers) allows this to run.