### PR TITLE
Update service-fabric-reliable-services-advanced-usage.md

### DIFF
--- a/articles/service-fabric/service-fabric-reliable-services-advanced-usage.md
+++ b/articles/service-fabric/service-fabric-reliable-services-advanced-usage.md
@@ -1,5 +1,5 @@
 <properties
-   pageTitle="Advanced Usage of Service Fabric Reliable Service Programming Model"
+   pageTitle="Advanced Usage of Reliable Services Programming Model"
    description="Learn about advanced usage of Service Fabric's Reliable Service programming model for added flexibility in your services."
    services="Service-Fabric"
    documentationCenter=".net"
@@ -13,17 +13,17 @@
    ms.topic="article"
    ms.tgt_pltfrm="NA"
    ms.workload="NA"
-   ms.date="06/09/2015"
+   ms.date="08/26/2015"
    ms.author="jesseb"/>
 
 # Advanced usage of the Reliable Services programming model
 Service Fabric simplifies writing and managing reliable stateless and stateful services. This guide will talk about advanced usages of the Reliable Services programming model to gain more control and flexibility over your services. Prior to reading this guide, familiarize yourself with [the Reliable Services programming model](service-fabric-reliable-services-introduction.md).
 
 ## Stateless Service base classes
-The StatelessService base class provides CreateCommunicationListener() and RunAsync(), which is sufficient for the majority of stateless services. The StatelessServiceBase class underlies StatelessService and exposes additional service lifecycle events. See the developer reference documentation on [StatelessService](https://msdn.microsoft.com/library/azure/microsoft.servicefabric.services.statelessservice.aspx) and [StatelessServiceBase](https://msdn.microsoft.com/library/azure/microsoft.servicefabric.services.statelessservicebase.aspx) for more information.
+The StatelessService base class provides CreateCommunicationListener() and RunAsync(), which is sufficient for the majority of stateless services. The StatelessServiceBase class underlies StatelessService and exposes additional service lifecycle events. You can derive from StatelessServiceBase if you need additional control or flexibility. See the developer reference documentation on [StatelessService](https://msdn.microsoft.com/library/azure/microsoft.servicefabric.services.statelessservice.aspx) and [StatelessServiceBase](https://msdn.microsoft.com/library/azure/microsoft.servicefabric.services.statelessservicebase.aspx) for more information.
 
 - `void OnInitialize(StatelessServiceInitializiationParameters)`
-    OnInitialize is the first method called by Service Fabric. Service initialization information is provided such as service name, partition id, instance id, and code package information. No complex processing should be done here. Lengthy initialization should be done in OnOpenAsync.
+    OnInitialize is the first method called by Service Fabric. Service initialization information is provided such as the service name, partition id, instance id, and code package information. No complex processing should be done here. Lengthy initialization should be done in OnOpenAsync.
 
 - `Task OnOpenAsync(IStatelessServicePartition, CancellationToken)`
     OnOpenAsync is called when the stateless service instance is about to be used. Extended service initialization tasks can be started at this time.
@@ -35,7 +35,7 @@ The StatelessService base class provides CreateCommunicationListener() and RunAs
     OnAbort is called when the stateless service instance is being forcefully shutdown. This is generally called when a permanent fault is detected on the node, or when Service Fabric cannot reliably manage the service instance's lifecycle due to internal failures.
 
 ## Stateful Service base classes
-The StatefulService base class should be sufficient for most stateful services. Similar to stateless services, the StatefulServiceBase class underlies StatefulService and exposes additional service lifecycle events. Additionally, it allows you to provide a custom reliable state provider and optionally support communication listeners on Secondaries. See the developer reference documentation on [StatefulService](https://msdn.microsoft.com/library/azure/microsoft.servicefabric.services.statefulservice.aspx) and [StatefulServiceBase](https://msdn.microsoft.com/library/azure/microsoft.servicefabric.services.statefulservicebase.aspx) for more information.
+The StatefulService base class should be sufficient for most stateful services. Similar to stateless services, the StatefulServiceBase class underlies StatefulService and exposes additional service lifecycle events. Additionally, it allows you to provide a custom reliable state provider and optionally support communication listeners on Secondaries. You can derive from StatefulServiceBase if you need additional control or flexibility. See the developer reference documentation on [StatefulService](https://msdn.microsoft.com/library/azure/microsoft.servicefabric.services.statefulservice.aspx) and [StatefulServiceBase](https://msdn.microsoft.com/library/azure/microsoft.servicefabric.services.statefulservicebase.aspx) for more information.
 
 - `Task OnChangeRoleAsync(ReplicaRole, CancellationToken)`
     OnChangeRoleAsync is called when the stateful service is changing roles, for example to Primary or Secondary. Primary replicas are given write status (are allowed to create and write to the reliable collections), while Secondary replicas are given read status (can only read from existing reliable collections). You can start or update the background tasks in response to role changes, such as performing read-only validation, report generation, or data mining on a Secondary.
@@ -50,8 +50,8 @@ The StatefulService base class should be sufficient for most stateful services. 
 
 StatefulServiceBase also provides the same four lifecycle events as StatelessServiceBase, with the same semantics and use cases:
 
-- `void OnInitialize(StatelessServiceInitializiationParameters)`
-- `Task OnOpenAsync(IStatelessServicePartition, CancellationToken)`
+- `void OnInitialize(StatefulServiceInitializiationParameters)`
+- `Task OnOpenAsync(IStatefulServicePartition, CancellationToken)`
 - `Task OnCloseAsync(CancellationToken)`
 - `void OnAbort()`
 
@@ -60,11 +60,11 @@ For more advanced topics related to Service Fabric, see the following articles.
 
 - [Configuring Stateful Reliable Services](service-fabric-reliable-services-configuration.md)
 
-- [Service Fabric Health Introduction](../service-fabric/service-fabric-health-introduction.md)
+- [Service Fabric Health Introduction](service-fabric-health-introduction.md)
 
-- [Using System health reports for troubleshooting](../service-fabric/service-fabric-understand-and-troubleshoot-with-system-health-reports.md)
+- [Using System health reports for troubleshooting](service-fabric-understand-and-troubleshoot-with-system-health-reports.md)
 
-- [Placement Constraints Overview](../service-fabric/service-fabric-placement-constraint.md)
+- [Placement Constraints Overview](service-fabric-placement-constraint.md)
 
-- [Secure Replication traffic of Stateful Services in Azure Service Fabric](../service-fabric/service-fabric-replication-security.md)
+- [Secure Replication traffic of Stateful Services in Azure Service Fabric](service-fabric-replication-security.md)
  


### PR DESCRIPTION
- Add explicit note that "You can derive from StatelessServiceBase/StatefulServiceBase if you need additional control or flexibility." rather than simply describing the base classes.
- Slightly shorter page title (all these articles are for Service Fabric)
- Typo in Stateful service section - lifecycle APIs should use "stateful" parameter types, not "stateless" types.