### PR TITLE
Update best-practices-resource-manager-state.md

### DIFF
--- a/articles/best-practices-resource-manager-state.md
+++ b/articles/best-practices-resource-manager-state.md
@@ -385,7 +385,7 @@ The following example shows how to pass the private IP address generated in a li
 
     "outputs": {
         "masterip": {
-            "value": "[reference(concat(variables('nicName'),0)).ipConfigurations[0].properties.privateIPAddress]",
+            "value": "[reference(concat(variables('nicName'),0)).ipConfigurations[0].privateIPAddress]",
             "type": "string"
          }
     }


### PR DESCRIPTION
fixed bug in property reference - .properties segment should not exist.