### PR TITLE
VMs should be placed on VNet.

### DIFF
--- a/articles/virtual-machines/virtual-machines-linux-cluster-rdma.md
+++ b/articles/virtual-machines/virtual-machines-linux-cluster-rdma.md
@@ -190,7 +190,7 @@ Modify the following script with appropriate values for your environment, and ru
 ### Select a region where A8 and A9 VMs are available, such as West US
 ### See Azure Pricing pages for prices and availability of A8 and A9 VMs
 
-azure network vnet create -l "West US" -e 10.32.0.0 <network-name>
+azure network vnet create -l "West US" -e 10.32.0.0 -i 16 <network-name>
 
 ### Create a cloud service. All the A8 and A9 instances need to be in the same cloud service for Linux RDMA to work across InfiniBand.
 ### Note: The current maximum number of VMs in a cloud service is 50. If you need to provision more than 50 VMs in the same cloud service in your cluster, contact Azure Support.
@@ -208,7 +208,7 @@ portnumber=101
 ### In this cluster there will be 8 size A9 nodes, named cluster11 to cluster18. Specify your captured image in <image-name>.
 
 for (( i=11; i<19; i++ )); do
-        azure vm create -g <username> -p <password> -c <cloud-service-name> -z A9 -n $vmname$i -e $portnumber$i <image-name>
+        azure vm create -g <username> -p <password> -c <cloud-service-name> -z A9 -n $vmname$i -e $portnumber$i -w <network-name> -b Subnet-1 <image-name>
 done
 
 ### Save this script and run it at the CLI prompt to provision your cluster


### PR DESCRIPTION
VM deployment script starting from line 186 has 2 problems

1. Netmask length should be specified for "azure network vnet create"
Currently, VNet is created with "-e 10.32.0.0" option.
This seems to have assumed a 16-bit mask (10.32.0.0/16).
But, Vnet created by this command will have 8-bit mask. (10.0.0.0/8)
This is not intuitive.
Why don't you add "-i 16" options to specify 16-bit mask?
It will create "10.32.0.0/16" address space.


2. VM is not placed to VNet!
Currently, VM creation command doesn't have VNet option.
So, VMs created by this script is placed on just "region" not on VNET.
VNet created on the first command of this script is simply ignored...

We need "-w <VNET> -b <SUBNET>" options for "azure vm create" command.