### PR TITLE
correcting link to load-balancer-internet-overview

### DIFF
--- a/articles/load-balancer/load-balancer-overview.md
+++ b/articles/load-balancer/load-balancer-overview.md
@@ -21,7 +21,7 @@ Azure load balancer delivers high availability and network performance to your a
  
 It can be configured to:
 
-- Load balance incoming Internet traffic to virtual machines. We refer it as [Internet facing load balancing](load-balancer-overview.md).
+- Load balance incoming Internet traffic to virtual machines. We refer it as [Internet facing load balancing](load-balancer-internet-overview.md).
 - Load balance traffic between virtual machines in a Virtual Network, between virtual machines in cloud services or between on-premises computers and virtual machines in a cross-premises virtual network. We refer it as [internal load balancing (ILB)](load-balancer-internal-overview.md).
 - 	Forward external traffic to a specific Virtual Machine instance
 


### PR DESCRIPTION
The page was linking back to itself.