### PR TITLE
Contains a note about row rejection and a grammar fix

### DIFF
--- a/articles/sql-data-warehouse/sql-data-warehouse-load-with-polybase.md
+++ b/articles/sql-data-warehouse/sql-data-warehouse-load-with-polybase.md
@@ -13,7 +13,7 @@
    ms.topic="article"
    ms.tgt_pltfrm="NA"
    ms.workload="data-services"
-   ms.date="05/09/2015"
+   ms.date="09/02/2015"
    ms.author="sahajs;barbkess"/>
 
 
@@ -138,6 +138,8 @@ The external table definition is similar to a relational table definition. The k
 
 The LOCATION option specifies the path to the data from the root of the data source. In this example, the data is located at 'wasbs://mycontainer@ test.blob.core.windows.net/path/Demo/'. All the files for the same table need to be under the same logical folder in Azure BLOB.
 
+Optionally, you can also specify reject options (REJECT_TYPE, REJECT_VALUE, REJECT_SAMPLE_VALUE) that determine how PolyBase will handle dirty records it receives from the external data source.
+
 ```
 -- Creating external table pointing to file stored in Azure Storage
 CREATE EXTERNAL TABLE [ext].[CarSensor_Data] 
@@ -171,7 +173,7 @@ DROP EXTERNAL TABLE [ext].[CarSensor_Data]
 ;
 ```
 
-> [AZURE.NOTE] When dropping an external table you must use `DROP EXTERNAL TABLE` you **cannot** use `DROP TABLE`. 
+> [AZURE.NOTE] When dropping an external table you must use `DROP EXTERNAL TABLE`. You **cannot** use `DROP TABLE`. 
 
 Reference topic: [DROP EXTERNAL TABLE (Transact-SQL)][].
 
@@ -198,21 +200,17 @@ When you have migrated all your external tables to the new external data source 
 ## Query Azure blob storage data
 Queries against external tables simply use the table name as though it was a relational table. 
 
-This is an ad-hoc query that joins insurance customer data stored in SQL Data Warehouse, with automobile sensor data stored in Azure storage blob. The result shows the drivers that drive faster than others.
 
 ```
--- Join SQL Data Warehouse relational data with Azure storage data. 
-SELECT 
-      [Insured_Customers].[FirstName]
-,     [Insured_Customers].[LastName]
-,     [Insured_Customers].[YearlyIncome]
-,     [CarSensor_Data].[Speed]
-FROM  [dbo].[Insured_Customers] 
-JOIN  [ext].[CarSensor_Data]         ON [Insured_Customers].[CustomerKey] = [CarSensor_Data].[CustomerKey]
-WHERE [CarSensor_Data].[Speed] > 60 
-ORDER BY [CarSensor_Data].[Speed] DESC
+
+-- Query Azure storage resident data via external table. 
+SELECT * FROM [ext].[CarSensor_Data]
 ;
+
 ```
+
+> [AZURE.NOTE] A query on an external table can fail with the error *"Query aborted-- the maximum reject threshold was reached while reading from an external source"*. This indicates that your external data contains *dirty* records. A data record is considered 'dirty' if the actual data types/number of columns do not match the column definitions of the external table or if the data doesn't conform to the specified external file format. To fix this, ensure that your external table and external file format definitions are correct and your external data conforms to these definitions. In case a subset of external data records are dirty, you can choose to reject these records for your queries by using the reject options in CREATE EXTERNAL TABLE DDL.
+
 
 ## Load data from Azure blob storage
 This example loads data from Azure blob storage to SQL Data Warehouse database.


### PR DESCRIPTION
Simplified the query on external table; the earlier query was giving the wrong impression that polybase is intended for ad-hoc queries over external data in ASB. Adding context on row rejection since customers have been reporting a number of issues with rows being rejected during PolyBase load. Also fixing some grammar.