### PR TITLE
Update azure-subscription-limits-azure-resource-manager.md

### DIFF
--- a/includes/azure-subscription-limits-azure-resource-manager.md
+++ b/includes/azure-subscription-limits-azure-resource-manager.md
@@ -4,7 +4,7 @@ Cores per [subscription](http://msdn.microsoft.com/library/azure/hh531793.aspx)|
 [Co-administrators](http://msdn.microsoft.com/library/azure/gg456328.aspx) per subscription|Unlimited|Unlimited
 [Storage accounts](storage-create-storage-account.md) per subscription|100|100<sup>2</sup>
 [Resource Groups](resource-group-overview.md) per subscription|800|800
-Resource Manager API Reads|32000 per hour|32000 per hour
+Resource Manager API Reads|15000 per hour|15000 per hour
 Resource Manager API Writes|1200 per hour|1200 per hour
 Resource Manager API request size|4194304 bytes|4194304 bytes
 [Cloud services](cloud-services-what-is.md) per subscription|Deprecated<sup>3</sup>|Deprecated<sup>3</sup>


### PR DESCRIPTION
The default and maximum limits for "Resource Manager API reads" should be 15000 instead of 32000