### PR TITLE
Image documentation URL will change soon

### DIFF
--- a/articles/virtual-machines/arm-template-deployment.md
+++ b/articles/virtual-machines/arm-template-deployment.md
@@ -302,7 +302,7 @@ To specify values for the resource parameters that were defined in the template,
           }
         }
 
-    >[AZURE.NOTE] Image vhd names change regularly in the image gallery, so you need to get a current image name to deploy the virtual machine. To do this, see [Manage Images Windows using Windows PowerShell](https://msdn.microsoft.com/library/azure/dn790330.aspx), and then replace {source-image-name} with the name of the vhd file that you want to use. For example,  "a699494373c04fc0bc8f2bb1389d6106__Windows-Server-2012-R2-201412.01-en.us-127GB.vhd". Replace {subscription-id} with the identifier of your subscription.
+    >[AZURE.NOTE] Image vhd names change regularly in the image gallery, so you need to get a current image name to deploy the virtual machine. To do this, see [About images for virtual machines](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-images/), and then replace {source-image-name} with the name of the vhd file that you want to use. For example,  "a699494373c04fc0bc8f2bb1389d6106__Windows-Server-2012-R2-201412.01-en.us-127GB.vhd". Replace {subscription-id} with the identifier of your subscription.
 
 
 4.	Save the parameters file that you created.


### PR DESCRIPTION
URL to "Manage Images using Windows PowerShell" leads to a page that tells us that content will be removed and replaced by new URL. I'm suggesting we change the URL to point to the right resource directly. New resource is located at https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-images/ and is called "About images for virtual machines".