### PR TITLE
Replace Deliver() method with DeliverAsync()

### DIFF
--- a/articles/app-service-web/sendgrid-dotnet-how-to-send-email.md
+++ b/articles/app-service-web/sendgrid-dotnet-how-to-send-email.md
@@ -171,9 +171,8 @@ The following examples show how to send a message using the Web API.
     // Create an Web transport for sending email.
     var transportWeb = new Web(credentials);
 
-    // Send the email.
-    // You can also use the **DeliverAsync** method, which returns an awaitable task.
-    transportWeb.Deliver(myMessage);
+    // Send the email, which returns an awaitable task.
+    transportWeb.DeliverAsync(myMessage);
 
 ## How to: Add an attachment
 


### PR DESCRIPTION
SendGrid C# removed the non-async Deliver() method in version 6.0.0. The method to send emails is now DeliverAsync().