### PR TITLE
MessageId for CBS token message

### DIFF
--- a/articles/service-bus/service-bus-sas-overview.md
+++ b/articles/service-bus/service-bus-sas-overview.md
@@ -207,7 +207,7 @@ private bool PutCbsToken(Connection connection, string sasToken)
     // construct the put-token message
     var request = new Message(sasToken);
     request.Properties = new Properties();
-    request.Properties.MessageId = "1";
+    request.Properties.MessageId = Guid.NewGuid().ToString();
     request.Properties.ReplyTo = cbsClientAddress;
     request.ApplicationProperties = new ApplicationProperties();
     request.ApplicationProperties["operation"] = "put-token";


### PR DESCRIPTION
Used a Guid for the MessageId of CBS token message instead of a simple "1".