### PR TITLE
Small change to correct order of options

### DIFF
--- a/articles/sql-data-warehouse/sql-data-warehouse-develop-table-design.md
+++ b/articles/sql-data-warehouse/sql-data-warehouse-develop-table-design.md
@@ -123,8 +123,8 @@ Partial support:
 
 There are two choices for distributing data in SQL Data Warehouse:
 
-1. Distribute data based on hashing values from a single column
-2. Distribute data evenly but randomly  
+1. Distribute data evenly but randomly 
+2. Distribute data based on hashing values from a single column
 
 Data distribution is decided at the table level. All tables are distributed. You will assign distribution for each table in your SQL Data Warehouse database.
 


### PR DESCRIPTION
Changed the order of data distribution options so that they align with the later commentary on what those options mean. Chose to list Round Robin first. i.e. keep the ordering based on the ordering of the following commentary.