### PR TITLE
LightSwitch is Not Compatible with Azure SDK 2.7.1

### DIFF
--- a/articles/app-service-web/azure-sdk-dotnet-release-notes-2_7.md
+++ b/articles/app-service-web/azure-sdk-dotnet-release-notes-2_7.md
@@ -73,6 +73,7 @@ In this release the following updates were made to Web Tools Extensions. For mor
 
 Web App deployment slot nodes don’t appear under the Slots node in Server Explorer, and Web App deployment slot child nodes don’t load under Cloud Explorer. This issue has been resolved and prepared for the next SDK release. 
 
+LightSwitch projects are not compatibile with this release. This issue will be resolved with the next SDK release.
 
 ###<a id="cloud_explorer"></a>Cloud Explorer for Visual Studio 2015
 

--- a/articles/app-service-web/azure-sdk-dotnet-release-notes-2_7.md
+++ b/articles/app-service-web/azure-sdk-dotnet-release-notes-2_7.md
@@ -73,7 +73,6 @@ In this release the following updates were made to Web Tools Extensions. For mor
 
 Web App deployment slot nodes don’t appear under the Slots node in Server Explorer, and Web App deployment slot child nodes don’t load under Cloud Explorer. This issue has been resolved and prepared for the next SDK release. 
 
-LightSwitch projects are not compatibile with this release. This issue will be resolved with the next SDK release.
 
 ###<a id="cloud_explorer"></a>Cloud Explorer for Visual Studio 2015
 
@@ -151,6 +150,7 @@ For more detailed explanation about HDInsight tools updates, see [this blog](htt
 
 Installing the Azure SDK 2.6 or 2.7.1 for Visual Studio Community 2013 on a non-English OS will display a warning that the English and non-English resources of Visual Studio may be mismatched. This warning may be safely dismissed. It will only occur if the machine did not contain a prior installation of Visual Studio Community 2013 and you are installing the SDK on a non-English OS. The warning is shown after the language pack applies the RTM resources to Visual Studio, but before it applies Update 4. Dismissing the warning will allow the language pack to continue and complete applying the Update 4 version of the language pack content.
 
+LightSwitch projects are not compatibile with this release. This issue will be resolved with the next SDK release.
 
 ##Also see
 [Azure SDK 2.7.1 announcement post](http://go.microsoft.com/fwlink/?LinkId=623850)


### PR DESCRIPTION
Updated the known issues list for the Azure SDK 2.7.1 release notes to indicate that LightSwitch is not compatible with this release.