### PR TITLE
Fix invalid per user config file name for SSH.

### DIFF
--- a/articles/virtual-machines/virtual-machines-linux-cluster-rdma.md
+++ b/articles/virtual-machines/virtual-machines-linux-cluster-rdma.md
@@ -145,7 +145,7 @@ After the VM completes provisioning, SSH to the VM using the VM's external IP ad
     cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
     ```
 
-    In the ~/.ssh directory edit or create the ssh_config file. Provide the IP address range of the private network that you will use in Azure (10.32.0.0/16 in this example):
+    In the ~/.ssh directory edit or create the "config" file. Provide the IP address range of the private network that you will use in Azure (10.32.0.0/16 in this example):
 
     ```
     host 10.32.0.*


### PR DESCRIPTION
Configuration file names for SSH are:

- ~/.ssh/config (per user)
- /etc/ssh/ssh_config (system wide)

"~/.ssh/ssh_config" is invalid and ignored.