### PR TITLE
Fixed missing "when" in articles\documentdb\documentdb-create-collect…

### DIFF
--- a/articles/documentdb/documentdb-create-collection.md
+++ b/articles/documentdb/documentdb-create-collection.md
@@ -40,7 +40,7 @@ To use Microsoft Azure DocumentDB, you must have a [DocumentDB account](document
 
 	- **Default**. This policy is best when you’re performing equality queries against strings and using ORDER BY, range, and equality queries for numbers.  This policy has a lower index storage overhead than **Range**.
 	- **Hash**. This policy is best when you’re performing equality queries for both numbers and strings.  This policy has the lowest index storage overhead.
-	- **Range**. This policy is best you’re using ORDER BY, range and equality queries on both numbers and strings.  This policy has a higher index storage overhead than **Default** or **Hash**.
+	- **Range**. This policy is best when you’re using ORDER BY, range and equality queries on both numbers and strings.  This policy has a higher index storage overhead than **Default** or **Hash**.
 
 	For more information about the indexing policies, see [DocumentDB indexing policies](documentdb-indexing-policies.md).
 


### PR DESCRIPTION
…ion.md

Changed "This policy is best you’re using ORDER BY..." to "This policy
is best **when** you’re using ORDER BY..." for the Range indexing policy in
articles\documentdb\documentdb-create-collection.md