### PR TITLE
Fixed typo on UDR Important Info Box

### DIFF
--- a/articles/virtual-network/virtual-networks-udr-overview.md
+++ b/articles/virtual-network/virtual-networks-udr-overview.md
@@ -36,7 +36,7 @@ The figure below shows an example of user defined routes and IP forwarding to fo
 
 ![System routes in Azure](./media/virtual-networks-udr-overview/Figure2.png)
 
->[AZURE.IMPORTANT] User defined routes are only applied to traffic leaving a subnet. you cannot create routes to specify how traffic comes into a subnet from the Internet, for instance.Also, the appliance you are forwarding traffic to cannot be int eh same subnet where the traffic originates. Always create a separate subnet for your appliances. 
+>[AZURE.IMPORTANT] User defined routes are only applied to traffic leaving a subnet. you cannot create routes to specify how traffic comes into a subnet from the Internet, for instance.Also, the appliance you are forwarding traffic to cannot be in the same subnet where the traffic originates. Always create a separate subnet for your appliances. 
 
 ## Routing
 Packets are routed over a TCP/IP network based on a route table defined at each node on the physical network. A route table is a collection of individual routes used to decide where to forward packets based on the destination IP address. A route consists of the following:


### PR DESCRIPTION
Changed typo from "int eh" to "in the" in the Important UDR Info Box.