### PR TITLE
Update iot-hub-devguide.md

### DIFF
--- a/articles/iot-hub/iot-hub-devguide.md
+++ b/articles/iot-hub/iot-hub-devguide.md
@@ -418,9 +418,9 @@ The body is a JSON-serialized array of records, each with the following properti
 
 | Property | Description |
 | -------- | ----------- |
-| EnqueuedTime | Timestamp indicating when the outcome of the message happened. For example, the device completed or the message expired. |
-| CorrelationId | **MessageId** of the cloud-to-device message to which this feedback information pertains. |
-| StatusCode | **0** if success, **1** if the message expired, **2** if the maximum delivery count is exceeded, **3** if the message was rejected. |
+| EnqueuedTimeUtc | Timestamp indicating when the outcome of the message happened. For example, the device completed or the message expired. |
+| OriginalMessageId | **MessageId** of the cloud-to-device message to which this feedback information pertains. |
+message was rejected. |
 | Description | String values for the previous outcomes. |
 | DeviceId | **DeviceId** of the target device of the cloud-to-device message to which this piece of feedback pertains. |
 | DeviceGenerationId | **DeviceGenerationId** of the target device of the cloud-to-device message to which this piece of feedback pertains. |


### PR DESCRIPTION
Using AMQP .Net Lite to send command and receive feedback I see that the received AMQP feedback message has a body with a JSON format link following : 

[{"originalMessageId":"5aac3169-af00-4536-acdb-cb9ea6b3980e","description":"Success","deviceGenerationId":"635794823643795743","deviceId":"myFirstDevice","enqueuedTimeUtc":"2015-10-29T07:59:00.9772497Z"}]

There isnt' CorrelationId but the OriginalMessageId field and the EnqueuedTimeUtc instead of EnqueueTime.
There isn't the StatusCode field inside the received JSON. 
However, It's also true that using the ServiceClient class and the FeedbackReceiver from the SDK I can see the StatusCode property inside the FeedbackRecord class but I can't understand how it gets this value because I can't find in into JSON.