### PR TITLE
Updated sys perf section for latest NuGet package

### DIFF
--- a/articles/application-insights/app-insights-web-monitor-performance.md
+++ b/articles/application-insights/app-insights-web-monitor-performance.md
@@ -134,11 +134,17 @@ If you specify an instance, it will be collected as a property "CounterInstanceN
 
 If you prefer, you can write code to have the same effect:
 
-    var perfCollector = new PerformanceCollectorModule();
-    perfCollector.Counters.Add(new CustomPerformanceCounterCollectionRquest(
+    var perfCollectorModule = new PerformanceCollectorModule();
+    perfCollector.Counters.Add(new PerformanceCounterCollectionRequest(
       @"\Sales(electronics)\# Items Sold", "Items sold"));
-    perfCollector.Initialize(TelemetryConfiguration.Active);
-    TelemetryConfiguration.Active.TelemetryModules.Add(perfCollector);
+    perfCollectorModule.Initialize(TelemetryConfiguration.Active);
+
+In addition, if you want to collect system performance counters and push them to Application Insights, you can use the snippet below:
+
+    var perfCollectorModule = new PerformanceCollectorModule();
+    perfCollector.Counters.Add(new PerformanceCounterCollectionRequest(
+      @"\.NET CLR Memory([replace-with-application-process-name])\# GC Handles", "GC Handles")));
+    perfCollectorModule.Initialize(TelemetryConfiguration.Active);
 
 ### Exception counts
 


### PR DESCRIPTION
Using the latest version of the SDK, .Active.TelemetryModules.Add(perfCollection) no longer exists. Additionally, it might be useful for some to get a snippet of adding standard system performance counters from the article directly.