### PR TITLE
Update role-based-access-built-in-roles.md

### DIFF
--- a/articles/active-directory/role-based-access-built-in-roles.md
+++ b/articles/active-directory/role-based-access-built-in-roles.md
@@ -27,7 +27,7 @@ Click the corresponding link to see the **actions** and **not actions** properti
 
 | Role Name | Description |
 | --------- | ----------- |
-| [API-Management Service Contributor](#api-management-service-contributor) | Can manage Application Insights components |
+| [API-Management Service Contributor](#api-management-service-contributor) | Can manage API Management services |
 | [Application Insights Component Contributor](#application-insights-component-contributor) | Can manage Application Insights components |
 | [Automation Operator](#automation-operator) | Able to start, stop, suspend, and resume jobs |
 | [BizTalk Contributor](#biztalk-contributor) | Can manage BizTalk services |


### PR DESCRIPTION
Updated Build-In Roles table description for "API-Management Service Contributor".
Changed from "Can manage Application Insights components"...
To "Can manage API Management services".