### PR TITLE
Fix typo in IP blocking configuration comments

### DIFF
--- a/articles/cloud-services/cloud-services-startup-tasks-common.md
+++ b/articles/cloud-services/cloud-services-startup-tasks-common.md
@@ -201,9 +201,9 @@ This sample config **allows** all IPs to access the server except the two define
 ```xml
 <system.webServer>
     <security>
-    <!--Unlisted IP addresses are denied access-->
+    <!--Unlisted IP addresses are granted access-->
     <ipSecurity>
-        <!--The following IP addresses are granted access-->
+        <!--The following IP addresses are denied access-->
         <add allowed="false" ipAddress="192.168.100.1" subnetMask="255.255.0.0" />
         <add allowed="false" ipAddress="192.168.100.2" subnetMask="255.255.0.0" />
     </ipSecurity>


### PR DESCRIPTION
Corrected the comments in the first example (blocking 2 specific ip addresses).