### PR TITLE
Provide a command-line copyable location for AzCopy

### DIFF
--- a/articles/storage/storage-use-azcopy.md
+++ b/articles/storage/storage-use-azcopy.md
@@ -34,7 +34,7 @@ We also released an open-sourced library based on the core data movement framewo
 ## Download and install AzCopy
 
 1. Download the [latest version of AzCopy](http://aka.ms/downloadazcopy), or the [latest preview version](http://aka.ms/downloadazcopypr).
-2. Run the installation. By default, the AzCopy installation creates a folder named `AzCopy` under `%ProgramFiles(x86)%\Microsoft SDKs\Azure\` (on a machine running 64-bit Windows) or `%ProgramFiles%\Microsoft SDKs\Azure\` (on a machine running 32-bit Windows). However, you can change the installation path from the setup wizard.
+2. Run the installation. By default, AzCopy is installed to `%ProgramFiles(x86)%\Microsoft SDKs\Azure\AzCopy\AzCopy.exe` (on a machine running 64-bit Windows) or `%ProgramFiles%\Microsoft SDKs\Azure\AzCopy\AzCopy.exe` (on a machine running 32-bit Windows). However, you can change the installation path from the setup wizard.
 3. If desired, you can add the AzCopy installation location to your system path.
 
 ## Understand the AzCopy command-line syntax


### PR DESCRIPTION
Provide the direct location of AzCopy so that users can 
copy it and paste into a command-line window.