### PR TITLE
Fix reference in DefaultRunAsPolicy

### DIFF
--- a/articles/service-fabric/service-fabric-application-runas-security.md
+++ b/articles/service-fabric/service-fabric-application-runas-security.md
@@ -270,7 +270,7 @@ The application manifest below shows many of the different settings described ab
       </Users>
    </Principals>
    <Policies>
-      <DefaultRunAsPolicy UserRef="MyDefaultAccount" />
+      <DefaultRunAsPolicy UserRef="LocalAdmin" />
    </Policies>
    <Certificates>
 	 <EndpointCertificate Name="Cert1" X509FindValue="FF EE E0 TT JJ DD JJ EE EE XX 23 4T 66 "/>


### PR DESCRIPTION
You had a reference in the DefaultRunAsPolicy to run as MyDefaultUser, but didn't define that user in the Principals.  Not sure if that'll work or not.