### PR TITLE
Update resource-group-authenticate-service-principal.md

### DIFF
--- a/articles/resource-group-authenticate-service-principal.md
+++ b/articles/resource-group-authenticate-service-principal.md
@@ -143,7 +143,7 @@ First, you must set up some values in PowerShell that you will use later when cr
 
 1. For both approaches, create an X509Certificate object from your certificate and retrieve the key value. Use the path to your certificate and the password for that certificate.
 
-        $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate("C:\certificates\examplecert.pfx", "yourpassword")
+        $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate -ArgumentList @("C:\certificates\examplecert.pfx", "yourpassword")
         $keyValue = [System.Convert]::ToBase64String($cert.GetRawCertData())
 
 2. If you are using key credentials, create the key credentials object and sets its value to the `$keyValue` from the previous step.


### PR DESCRIPTION
Using the C# style constructor syntax in PowerShell often works, but it is poor form. Good PowerShell form is to use PowerShell named parameters. @tfitzmac 

Cheers,
Trevor Sullivan
Microsoft MVP: PowerShell