### PR TITLE
ADF: re-add getDebugInfo to streaming activity sample

### DIFF
--- a/articles/data-factory/data-factory-hadoop-streaming-activity.md
+++ b/articles/data-factory/data-factory-hadoop-streaming-activity.md
@@ -40,7 +40,8 @@ The HDInsight cluster is automatically populated with example programs (wc.exe a
 	                        "<nameofthecluster>/example/apps/wc.exe",
 	                        "<nameofthecluster>/example/apps/cat.exe"
 	                    ],
-	                    "fileLinkedService": "StorageLinkedService"
+	                    "fileLinkedService": "StorageLinkedService",
+	                    "getDebugInfo": "Failure"
 	                },
 	                "outputs": [
 	                    {
@@ -78,6 +79,7 @@ Note the following:
 7. In the **filePaths** section, specify the paths for the mapper and reducer executables. In the example: "adfsample/example/apps/wc.exe", adfsample is the blob container, example/apps is the folder, and wc.exe is the executable.
 8. For the **fileLinkedService** property, specify the Azure Storage linked service that represents the Azure storage that contains the files specified in the filePaths section.
 9. For the **arguments** property, specify the arguments for the streaming job.
+10. The **getDebugInfo** property is an optional element. When it is set to Failure, the logs are downloaded only on failure. When it is set to All, logs are always downloaded irrespective of the execution status.
 
 > [AZURE.NOTE] As shown in the example, you will need to specify an output dataset for the Hadoop Streaming Activity for the **outputs** property. This is just a dummy dataset that is required to drive the pipeline schedule. You do not need to specify any input dataset for the activity for the **inputs** property.  
 


### PR DESCRIPTION
* In the JSON sample for a pipeline containing an HDInsightStreaming
  activity, the "getDebugInfo" property was previously improperly
  placed as a top-level property in the activity, rather than in the
  "typeProperties" section. This restores the property to the sample.