### PR TITLE
Update automation-powershell-workflow.md

### DIFF
--- a/articles/automation/automation-powershell-workflow.md
+++ b/articles/automation/automation-powershell-workflow.md
@@ -129,7 +129,7 @@ You can pass values into an InlineScript block, but you must use **$Using** scop
 		$ServiceName = "MyService"
 	
 		$Output = InlineScript {
-			$Service = Get-Service -Name $Using:MyService
+			$Service = Get-Service -Name $Using:ServiceName
 			$Service.Stop()
 			$Service
 		}


### PR DESCRIPTION
Typo on line 132, called to the variable value in stead of the variable name.