### PR TITLE
Update app-insights-release-notes-windows.md

### DIFF
--- a/articles/application-insights/app-insights-release-notes-windows.md
+++ b/articles/application-insights/app-insights-release-notes-windows.md
@@ -36,7 +36,7 @@ See [Get started with Application Insights for Windows Phone and Store apps](app
 
 ### Windows SDK
 
-- Fix a hang during crash when using the Windows Phone's Silverlight SDK. After this change crashes that happen ~2 seconds after the call to WindowsAppInitialier.InitializeAsync(...) will be persisted to disk and will be sent the next time the app is started. Crashes that happens in the ~2 seconds timeframe will be ignored. 
+- Fix a hang during crash when using the Windows Phone's Silverlight SDK. After this change, any crash that happens later than ~2 seconds after the call to WindowsAppInitialier.InitializeAsync(...) will be persisted to disk and will be sent the next time the app is started. If a crash happens before ~2 seconds after the call, it will be ignored.  
 - Set the NuGet's dependencies to a specific version of Core and Microsoft.ApplicationInsights.PersistenceChannel (v1.2.3).   
 
 ### Core SDK

--- a/articles/application-insights/app-insights-release-notes-windows.md
+++ b/articles/application-insights/app-insights-release-notes-windows.md
@@ -32,18 +32,16 @@ See [Get started with Application Insights for Windows Phone and Store apps](app
 * Compare the old and new versions of ApplicationInsights.config. Merge back any customizations you made to the old version.
 * Rebuild your solution.
 
-## Version 1.2
-
-### Core SDK
-
-- First version of Application Insights SDK shipped from [github](http://github.com/microsoft/ApplicationInsights-dotnet)
-
 ## Version 1.1.1
 
 ### Windows SDK
 
-- Fix a hang during crash when using the Windows Phone's Silverlight SDK.
+- Fix a hang during crash when using the Windows Phone's Silverlight SDK. After this change crashes that happen ~2 seconds after the call to WindowsAppInitialier.InitializeAsync(...) will be persisted to disk and will be sent the next time the app is started. Crashes that happens in the ~2 seconds timeframe will be ignored. 
 - Set the NuGet's dependencies to a specific version of Core and Microsoft.ApplicationInsights.PersistenceChannel (v1.2.3).   
+
+### Core SDK
+
+- Core is managed in github. Future release notes of the Core SDK can be found [in github](http://github.com/Microsoft/ApplicationInsights-dotnet/releases)
 
 ## Version 1.1
 


### PR DESCRIPTION
- Updating the release notes to include a known bug with Windows v1.1.1
- To avoid a weird situation where a new release note is added to as older version (1.2 is already exist and we are adding 1.1.1), move Core release note from v1.2 to v1.1.1, anyway it is just saying that future release notes for core will be in GitHub.