### PR TITLE
Missing "--blob-url" argument in CLI command

### DIFF
--- a/articles/virtual-machines/virtual-machines-linux-create-upload-vhd.md
+++ b/articles/virtual-machines/virtual-machines-linux-create-upload-vhd.md
@@ -151,7 +151,7 @@ Use Azure AD method to login:
 
 Use the Azure CLI to upload the image. You can upload an image by using the following command:
 
-		azure vm image create <image-name> --location <location-of-the-data-center> --os Linux <source-path-to the vhd>
+		azure vm image create <image-name> --blob-url "<BlobStorageURL>/<YourImagesFolder>/<VHDName>" --location "<location-of-the-data-center>" --os Linux <source-path-to the vhd>
 
 ### If using PowerShell
 


### PR DESCRIPTION
A customer of mine reported that the sample command for uploading the VHD using the Azure CLI (ASM mode) fails. After some investigation, it seems that the reference is missing the required "--blob-url" argument.