### PR TITLE
Update virtual-machines-linux-diagnostic-extension.md

### DIFF
--- a/articles/virtual-machines/virtual-machines-linux-diagnostic-extension.md
+++ b/articles/virtual-machines/virtual-machines-linux-diagnostic-extension.md
@@ -35,7 +35,7 @@ For version 2.0, the data includes:
 - All system data specified in this [document](https://scx.codeplex.com/wikipage?title=xplatproviders").
 - User specified log files.
 
-[AZURE.INCLUDE [learn-about-deployment-models](../../includes/learn-about-deployment-models-classic-include.md)] Resource Manager model.
+Note this extension works with both classic and Resource Manager deployment model.
 
 
 ## How to enable the extension


### PR DESCRIPTION
Remove following warning, as this extension works under ARM model now.
[AZURE.INCLUDE [learn-about-deployment-models](../../includes/learn-about-deployment-models-classic-include.md)] Resource Manager model.

Adding a new statement clarifying that is works for both model.