### PR TITLE
removed "blobColumnSeparators" from the JSON

### DIFF
--- a/articles/data-factory/data-factory-azure-table-connector.md
+++ b/articles/data-factory/data-factory-azure-table-connector.md
@@ -317,8 +317,7 @@ The pipeline contains a Copy Activity that is configured to use the above input 
 	        ],
 	        "typeProperties": {
 	          "source": {
-	            "type": "BlobSource",
-	            "blobColumnSeparators": ","
+	            "type": "BlobSource"
 	          },
 	          "sink": {
 	            "type": "AzureTableSink",


### PR DESCRIPTION
This parameter is now deprecated and JSONs using with won't be accepted by ADF.