### PR TITLE
Reference "parameters" and "parameter file" in two articles

### DIFF
--- a/articles/resource-group-authoring-templates.md
+++ b/articles/resource-group-authoring-templates.md
@@ -148,6 +148,8 @@ The following example shows how to define parameters:
        }
     }
 
+For how to input the parameter values during deployment, see [Deploy an application with Azure Resource Manager template](resource-group-template-deploy.md/#parameter-file). 
+
 ## Variables
 
 In the variables section, you construct values that can be used to simplify template language expressions. Typically, these variables will be based on values provided from the parameters.

--- a/articles/resource-group-template-deploy.md
+++ b/articles/resource-group-template-deploy.md
@@ -264,6 +264,8 @@ If you use a parameter file to pass the parameter values to your template during
 
 The size of the parameter file cannot be more than 64 KB.
 
+For how to define parameters in template, see [Authoring templates](resource-group-authoring-templates.md/#parameters)
+
 ## Next steps
 - For an example of deploying resources through the .NET client library, see [Deploy resources using .NET libraries and a template](arm-template-deployment.md)
 - For an in-depth example of deploying an application, see [Provision and deploy microservices predictably in Azure](app-service-web/app-service-deploy-complex-application-predictably.md)


### PR DESCRIPTION
Reference "parameters" in authoring template article and "parameter file" in deploy template article to help user to understand template "parameter" better