### PR TITLE
Azure AD Apps v2: Fix broken links for related content

### DIFF
--- a/includes/active-directory-v2-quickstart-table.md
+++ b/includes/active-directory-v2-quickstart-table.md
@@ -3,7 +3,7 @@
 | Add Sign-In to an iOS App (Coming Soon) | [Add Sign-In to an AngularJS SPA (NodeJS)](active-directory-v2-devquickstarts-angular-node.md) | [Register an Application](active-directory-v2-app-registration.md) |
 | Add Sign-In to an Android App (Coming Soon) | [Add Sign-In to an AngularJS SPA (.NET)](active-directory-v2-devquickstarts-angular-dotnet.md) | [Mobile Apps with OAuth 2.0](active-directory-v2-protocols-oauth-code.md) |
 | Add Sign-In to a Windows Universal App (Coming Soon) | [Add Sign-In to a .NET MVC App](active-directory-v2-devquickstarts-dotnet-web.md) | [Web Apps with OpenID Connect](active-directory-v2-protocols-oidc.md) |
-| [Add Sign-In to a Windows Desktop App](active-directory-v2-devquickstarts-wpf.md)| [Add Sign-In to a Node JS Web App](active-directory-v2-devquickstarts-node-web.md) | [Single Page Apps with OpenID Connect](active-directory-protocols-implicit.md) 
-| [Call Office 365 Rest APIs from an app](https://www.msdn.com/office/office365/howto/authenticate-Office-365-APIs-using-v2) | [Secure a .NET Web API](active-directory-v2-devquickstarts-dotnet-api.md) | Server Side Daemons (Coming Soon) |
+| [Add Sign-In to a Windows Desktop App](active-directory-v2-devquickstarts-wpf.md)| [Add Sign-In to a Node JS Web App](active-directory-v2-devquickstarts-node-web.md) | [Single Page Apps with OpenID Connect](active-directory-v2-protocols-implicit.md) 
+| [Call Office 365 Rest APIs from an app](https://msdn.microsoft.com/en-us/office/office365/howto/authenticate-Office-365-APIs-using-v2) | [Secure a .NET Web API](active-directory-v2-devquickstarts-dotnet-api.md) | Server Side Daemons (Coming Soon) |
 |  |  [Secure a NodeJS Web API](active-directory-v2-devquickstarts-node-api.md) |
-|  | [Call Office 365 REST APIs from the web](https://www.msdn.com/office/office365/howto/authenticate-Office-365-APIs-using-v2) |
+|  | [Call Office 365 REST APIs from the web](https://msdn.microsoft.com/en-us/office/office365/howto/authenticate-Office-365-APIs-using-v2) |


### PR DESCRIPTION
A couple of broken links in the documentation for Office 365 REST API's and protocols for SPA with OpenID Connect. Also note some contradictory info around implicit flow support for v2 Apps.