### PR TITLE
Update link reference for exceptions in App Insights

### DIFF
--- a/articles/application-insights/app-insights-search-diagnostic-logs.md
+++ b/articles/application-insights/app-insights-search-diagnostic-logs.md
@@ -294,7 +294,7 @@ If your application sends a lot of data and you are using the Application Insigh
 
 [availability]: app-insights-monitor-web-app-availability.md
 [diagnostic]: app-insights-diagnostic-search.md
-[exceptions]: app-insights-web-failures-exceptions.md
+[exceptions]: app-insights-asp-net-exceptions.md
 [greenbrown]: app-insights-asp-net.md
 [metrics]: app-insights-metrics-explorer.md
 [qna]: app-insights-troubleshoot-faq.md


### PR DESCRIPTION
Information about exceptions in Application Insights seems to have moved from app-insights-web-failures-exceptions.md to app-insights-asp-net-exceptions.md . app-insights-web-failures-exceptions.md does not exists anymore and the links are broken.