### PR TITLE
Update virtual-networks-multiple-nics.md

### DIFF
--- a/articles/virtual-network/virtual-networks-multiple-nics.md
+++ b/articles/virtual-network/virtual-networks-multiple-nics.md
@@ -33,6 +33,7 @@ At this time, multi NIC has the following requirements and constraints:
 - Within a single cloud service (classic deployments) or resource group (Resource Manager deployment), only the following settings are allowed: 
 	- All VMs in that cloud service must be multi NIC enabled, or 
 	- All VMs in that cloud service must each have a single NIC 
+	- Also, a virtual machine having no secondary network interfaces cannot be updated to have secondary network interfaces and vice-versa.
 
 [AZURE.INCLUDE [azure-arm-classic-important-include](../../includes/learn-about-deployment-models-rm-include.md)] classic deployment model. 
  


### PR DESCRIPTION
I am proposing the article to reflect the exact text its predecessor used to have, including the important piece of mentioning that a single-NIC VM cannot become a multinic VM.
This is creating a lot of support calls.

https://msdn.microsoft.com/en-us/library/azure/dn848315.aspx 

Multi-NIC VMs and single-NIC VMs are not supported in the same deployment. If you attempt to add a multi-NIC VM to a deployment that contains a single-NIC VM, or vice-versa, you will receive the following error: "Virtual machines with secondary network interfaces and virtual machines with no secondary network interfaces are not supported in the same deployment, also a virtual machine having no secondary network interfaces cannot be updated to have secondary network interfaces and vice-versa."