### PR TITLE
Blocklist call timout limitations

### DIFF
--- a/articles/machine-learning/machine-learning-recommendation-api-documentation.md
+++ b/articles/machine-learning/machine-learning-recommendation-api-documentation.md
@@ -803,16 +803,24 @@ d5358189-d70f-4e35-8add-34b83b4942b3, Pigs in Heaven
 </pre>
 
 
-
-
 ##7. Model Business Rules
+
 These are the types of rules supported:
-- <strong>BlockList</strong> - BlockList enables you to provide a list of items that you do not want to return in the recommendation results.
+- <strong>BlockList</strong> - BlockList enables you to provide a list of items that you do not want to return in the recommendation results. 
+
 - <strong>FeatureBlockList</strong> - Feature BlockList enables you to block items based on the values of its features.
+
+*Do not send more than 1000 items in a single blocklist rule or your call may timeout. If you need to block more than 1000 items, you can make several blocklist calls.*
+
 - <strong>Upsale</strong> - Upsale enables you to enforce items to return in the recommendation results.
+
 - <strong>WhiteList</strong> - White List enables you to only suggest recommendations from a list of items.
+
 - <strong>FeatureWhiteList</strong> - Feature White List enables you to only recommend items that have specific feature values.
+
 - <strong>PerSeedBlockList</strong> - Per Seed Block List enables you to provide per item a list of items that cannot be returned as recommendation results.
+
+
 
 
 ###7.1.	Get Model Rules


### PR DESCRIPTION
Mentioned you need to call the blocklist API more than one time if you have to block more than 1000 items.