### PR TITLE
Update web-sites-java-get-started.md

### DIFF
--- a/articles/app-service-web/web-sites-java-get-started.md
+++ b/articles/app-service-web/web-sites-java-get-started.md
@@ -35,13 +35,14 @@ This tutorial shows how to create a Java [web app in Azure App Service](http://g
 
 There are several ways you can set up a Java application in an App Service web app. 
 
-1. Use a template from the Azure Marketplace.
+1. Create an app and then configure **Application settings**.
+
+	App Service provides several Tomcat and Jetty versions, with default configuration. If the application that you will be hosting will work with one of the built-in versions, this method of setting up a web container is the easiest and caters to when all you want to do is upload a war file to a web container. For this method, you create an app in the Azure Portal, and then go to the app's **Application settings** blade to choose your version of Java along with the desired Java web container. When you use this method both Java and your web container are run from Program Files.  The other methods put the web container and potentially the JVM in your disk space.  When you use this model, you don't have access to edit files in this part of the file system, which means you can't do things like configure the *server.xml* file or place library files in the */lib* folder.  For more information, see the [Create and configure a Java web app](#appsettings) section later in this tutorial.  
+	
+2. Use a template from the Azure Marketplace.
 
 	The Azure Marketplace includes templates that automatically create and configure Java web apps with Tomcat or Jetty web containers. The web containers that the templates set up are configurable. For more information, see the [Use a Java template from the Azure Marketplace](#marketplace) section of this tutorial.
  
-1. Create an app and then configure **Application settings**.
-
-	App Service provides several Tomcat and Jetty versions, with default configuration. If the application that you will be hosting will work with one of the built-in versions, this method of setting up a web container is the easiest but it lacks the configuration capabilities in other methods. For this method, you create an app in the Azure Portal, and then go to the app's **Application settings** blade to choose your version of Java along with the desired Java web container. When you use this method the app runs from the local hard drive that is used by the worker to host the app, which does not take disk space away from the tenant. When you use this model, you don't have access to edit files in this part of the file system, which means you can't do things like configure the *server.xml* file or place library files in the */lib* folder.  For more information, see the [Create and configure a Java web app](#appsettings) section later in this tutorial.  
   
 3. Create an app and then manually copy and edit configuration files 
 
@@ -53,6 +54,59 @@ There are several ways you can set up a Java application in an App Service web a
 	* You want to use a version of Java that isn’t supported in App Service and want to upload it yourself.
 
 	For cases like these, you can create an app using the Azure Portal, and then provide the appropriate runtime files manually. In this case the files will be counted against your storage space quotas for your App Service plan. For more information, see [Upload a custom Java web app to Azure](https://acom-sandbox.azurewebsites.net/en-us/documentation/articles/web-sites-java-custom-upload/).
+
+## <a name="portal"></a> Create and configure a Java web app
+
+This section shows how to create a web app and configure it for Java using the **Application settings** blade of the portal.
+
+1. Sign in to the [Azure Portal](https://portal.azure.com/).
+
+2. Click **New > Web + Mobile > Web App**.
+
+	![](./media/web-sites-java-get-started/newwebapp.png)
+
+4. Enter a name for the web app in the **Web app** box.
+
+	This name must be unique in the azurewebsites.net domain because the URL of the web app will be {name}.azurewebsites.net. If the name you enter isn't unique, a red exclamation mark appears in the text box.
+
+5. Select a **Resource Group** or create a new one.
+
+	For more information about resource groups, see [Using the Azure Portal to manage your Azure resources](../resource-group-portal.md).
+
+6. Select an **App Service plan/Location** or create a new one.
+
+	For more information about App Service plans, see [Azure App Service plans overview](../azure-web-sites-web-hosting-plans-in-depth-overview.md)
+
+7. Click **Create**.
+
+	![](./media/web-sites-java-get-started/newwebapp2.png)
+ 
+8. When the web app has been created, click **Web Apps > {your web app}**.
+ 
+	![](./media/web-sites-java-get-started/selectwebapp.png)
+
+9. In the **Web app** blade, click **Settings**.
+
+10. Click **Application settings**.
+
+11. Choose the desired **Java version**. 
+
+12. Choose the desired **Java minor version**.  If you select **Newest**, your app will use the newest minor version that is available in App Service for that Java major version.  The **Newest** item is unique to Java apps created from the the **Application settings**.  If you create your Java app from the gallery then you have to manage your own container and JVM changes.  
+
+12. Choose the desired **Web container**. If you select a container name that starts with **Newest**, your app will be kept at the latest version of that web container major version that is available in App Service. 
+
+	![](./media/web-sites-java-get-started/versions.png)
+
+13. Click **Save**.
+
+	Within a few moments, your web app will become Java-based and configured to use the web container you selected.
+
+14. Click **Web apps > {your new web app}**.
+
+15. Click the **URL** to browse to the new site.
+
+	The web page confirms that you have created a Java-based web app.
+
 
 ## <a name="marketplace"></a> Use a Java template from the Azure Marketplace
 
@@ -112,57 +166,6 @@ This section shows how to use the Azure Marketplace to create a Java web app.  T
 
 Now that you've created the web app with an app container, see the [Next steps](#next-steps) section for information about how to  upload your application to the web app.
 
-## <a name="portal"></a> Create and configure a Java web app
-
-This section shows how to create a web app and configure it for Java using the **Application settings** blade of the portal.
-
-1. Sign in to the [Azure Portal](https://portal.azure.com/).
-
-2. Click **New > Web + Mobile > Web App**.
-
-	![](./media/web-sites-java-get-started/newwebapp.png)
-
-4. Enter a name for the web app in the **Web app** box.
-
-	This name must be unique in the azurewebsites.net domain because the URL of the web app will be {name}.azurewebsites.net. If the name you enter isn't unique, a red exclamation mark appears in the text box.
-
-5. Select a **Resource Group** or create a new one.
-
-	For more information about resource groups, see [Using the Azure Portal to manage your Azure resources](../resource-group-portal.md).
-
-6. Select an **App Service plan/Location** or create a new one.
-
-	For more information about App Service plans, see [Azure App Service plans overview](../azure-web-sites-web-hosting-plans-in-depth-overview.md)
-
-7. Click **Create**.
-
-	![](./media/web-sites-java-get-started/newwebapp2.png)
- 
-8. When the web app has been created, click **Web Apps > {your web app}**.
- 
-	![](./media/web-sites-java-get-started/selectwebapp.png)
-
-9. In the **Web app** blade, click **Settings**.
-
-10. Click **Application settings**.
-
-11. Choose the desired **Java version**. 
-
-12. Choose the desired **Java minor version**.  If you select **Newest**, your app will use the newest minor version that is available in App Service for that Java major version.
-
-12. Choose the desired **Web container**. If you select a container name that starts with **Newest**, your app will be kept at the latest version of that web container major version that is available in App Service. 
-
-	![](./media/web-sites-java-get-started/versions.png)
-
-13. Click **Save**.
-
-	Within a few moments, your web app will become Java-based and configured to use the web container you selected.
-
-14. Click **Web apps > {your new web app}**.
-
-15. Click the **URL** to browse to the new site.
-
-	The web page confirms that you have created a Java-based web app.
 
 ## Next steps
 


### PR DESCRIPTION
I swapped the order of creation to match what we tell customers.  There are 3 forms of the Java feature starting with enablement from the config tab.  Next there is deploy from gallery.  Last is custom Java app.  The reason to drive people to app settings version first is to reduce the number of issues they have with managing their own container unnecessarily.  We would prefer people to use the application settings item if they can.  
I also made a few text changes.  small items.