### PR TITLE
Invalid url formatting and broken url

### DIFF
--- a/articles/application-gateway/application-gateway-create-gateway-arm-template.md
+++ b/articles/application-gateway/application-gateway-create-gateway-arm-template.md
@@ -54,7 +54,7 @@ In this scenario you will:
 
 You can download the existing Azure Resource Manager template to create a virtual network and two subnets from GitHub, make any changes you might want, and reuse it. To do so, follow the steps below:
 
-1. Navigate to https://raw.githubusercontent.com/azure/azure-quickstart-templates/master/101-create-application-gateway/.
+1. Navigate to [Create Application Gateway] (https://github.com/Azure/azure-quickstart-templates/tree/master/101-application-gateway-create).
 2. Click **azuredeploy.json**, and then click **RAW**.
 3. Save the file to a local folder on your computer.
 4. If you are familiar with Azure Resource Manager templates, skip to step 7.


### PR DESCRIPTION
The original URL was not setup to actually be able to click, Additionally the original URL was invalid, I linked to the main portion of the template, as opposed to the raw dump of the azuredeploy.json file, which seems like better form to me.