### PR TITLE
Update app-insights-windows-desktop.md

### DIFF
--- a/articles/application-insights/app-insights-windows-desktop.md
+++ b/articles/application-insights/app-insights-windows-desktop.md
@@ -183,7 +183,7 @@ By contrast, the persistence channel buffers telemetry in a file, before sending
 
 ### To use the persistence channel
 
-1. Import the NuGet package [Microsoft.ApplicationInsights.PersistenceChannel](https://www.nuget.org/packages/Microsoft.ApplicationInsights.PersistenceChannel).
+1. Import the NuGet package [Microsoft.ApplicationInsights.PersistenceChannel](https://www.nuget.org/packages/Microsoft.ApplicationInsights.PersistenceChannel/1.2.3).
 2. Include this code in your app, in a suitable initialization location:
  
     ```C# 
@@ -274,7 +274,7 @@ namespace ConsoleApplication1
 ```
 
 
-The code of the persistence channel is on [github](https://github.com/Microsoft/ApplicationInsights-dotnet/tree/master/src/TelemetryChannels/PersistenceChannel). 
+The code of the persistence channel is on [github](https://github.com/Microsoft/ApplicationInsights-dotnet/tree/v1.2.3/src/TelemetryChannels/PersistenceChannel). 
 
 
 ## <a name="usage"></a>Next Steps


### PR DESCRIPTION
The github link
    https://github.com/Microsoft/ApplicationInsights-dotnet/tree/master/src/TelemetryChannels/PersistenceChannel

at the bottom of this page is broken.

Reason:
Persistence Channel has been renamed to ServerPersistenceChannel and as its name suggests is only used for server side. 
v1.2.3 is the latest NuGet/Github package that is used for windows.  

Suggestion:
Change both links, the NuGet and GitHub, to point to v1.2.3 
NuGet:
   https://www.nuget.org/packages/Microsoft.ApplicationInsights.PersistenceChannel/1.2.3

GitHub:
   https://github.com/Microsoft/ApplicationInsights-dotnet/tree/v1.2.3/src/TelemetryChannels/PersistenceChannel