### PR TITLE
durable-client-side-queue-for-iaas-not-paas

### DIFF
--- a/articles/service-bus/service-bus-outages-disasters.md
+++ b/articles/service-bus/service-bus-outages-disasters.md
@@ -91,6 +91,8 @@ If the application can tolerate a Service Bus entity being unavailable, but must
 
 A durable client-side queue preserves message order and shields the client application from exceptions in case the Service Bus entity is unavailable. It can be used with simple and distributed transactions.
 
+> [AZURE.NOTE] This sample works well in IaaS scenarios where local disk or disk for MSMQ is mapped to a storage account and messages are stored reliably with MSMQ. This is not suitable for PaaS scenarios such as Cloud Services and Web Applications.
+
 ## Next steps
 
 To learn more about disaster recovery, see these articles:


### PR DESCRIPTION
Durable client-side queue sample relies on MSMQ. That would only work with IaaS running a VM where a disk for MSMQ is mapped to a storage account. But this would not work with PaaS (cloud services). Should documentation make a note of that?