### PR TITLE
Add Note for deploying resources to a different Subnet

### DIFF
--- a/articles/app-service-web/app-service-app-service-environment-network-architecture-overview.md
+++ b/articles/app-service-web/app-service-app-service-environment-network-architecture-overview.md
@@ -31,7 +31,7 @@ The diagram below shows an overview of the various inbound and outbound network 
 
 An App Service Environment can communicate with a variety of private customer endpoints.  For example, apps running in the App Service Environment can connect to database server(s) running on IaaS virtual machines in the same virtual network topology.
 
-[AZURE.NOTE] Looking at the network diagram, the "Other Computer Resources" are deployed in a different Subnet from the App Service Environment. __This is very important.__ Deploying resources in the same Subnet with the ASE will block connectivity from ASE to those resources (except for specific intra-ASE routing). Deploy to a different Subnet instead (in the same VNET). The App Service Environment will then be able to connect without any additional configuration.
+[AZURE.IMPORTANT] Looking at the network diagram, the "Other Computer Resources" are deployed in a different Subnet from the App Service Environment. Deploying resources in the same Subnet with the ASE will block connectivity from ASE to those resources (except for specific intra-ASE routing). Deploy to a different Subnet instead (in the same VNET). The App Service Environment will then be able to connect. No additional configuration is necessary.
 
 App Service Environments also communicate with Sql DB and Azure Storage resources necessary for managing and operating an App Service Environment.  Some of the Sql and Storage resources that an App Service Environment communicates with are located in the same region as the App Service Environment, while others are located in remote Azure regions.  As a result, outbound connectivity to the Internet is always required for an App Service Environment to function properly. 
 

--- a/articles/app-service-web/app-service-app-service-environment-network-architecture-overview.md
+++ b/articles/app-service-web/app-service-app-service-environment-network-architecture-overview.md
@@ -29,7 +29,9 @@ The diagram below shows an overview of the various inbound and outbound network 
 
 ![General Network Flows][GeneralNetworkFlows]
 
-An App Service Environment can communicate with a variety of private customer endpoints.  For example, apps running in the App Service Environment can connect to database server(s) running on IaaS virtual machines in the same virtual network topology.  
+An App Service Environment can communicate with a variety of private customer endpoints.  For example, apps running in the App Service Environment can connect to database server(s) running on IaaS virtual machines in the same virtual network topology.
+
+[AZURE.NOTE] Looking at the network diagram, the "Other Computer Resources" are deployed in a different Subnet from the App Service Environment. __This is very important.__ Deploying resources in the same Subnet with the ASE will block connectivity from ASE to those resources (except for specific intra-ASE routing). Deploy to a different Subnet instead (in the same VNET). The App Service Environment will then be able to connect without any additional configuration.
 
 App Service Environments also communicate with Sql DB and Azure Storage resources necessary for managing and operating an App Service Environment.  Some of the Sql and Storage resources that an App Service Environment communicates with are located in the same region as the App Service Environment, while others are located in remote Azure regions.  As a result, outbound connectivity to the Internet is always required for an App Service Environment to function properly. 
 


### PR DESCRIPTION
See comments section:
https://azure.microsoft.com/en-us/documentation/articles/app-service-app-service-environment-intro/

Stefan Schackow:
>"Hmm - is the Linux VM in the *same* subnet as the ASE? I think what is happening is that 10.0.0.8 is in the subnet address range containing the ASE. If that is the case, the behavior is expected because we block connectivity (except for specific intra-ASE routing) to any other IP address in the subnet containing the ASE. If you can redeploy the Linux VM to a different subnet, then connectivity will work.

Hit the same problem myself. Deploying to a different Subnet fixes connectivity. Decided to send PR for make benefit glorious nation of cloud.