### PR TITLE
Fix API

### DIFF
--- a/articles/storage/storage-java-how-to-use-table-storage.md
+++ b/articles/storage/storage-java-how-to-use-table-storage.md
@@ -81,7 +81,7 @@ and uses it to create a new **CloudTable** object which represents a table named
 
 	   // Create the table if it doesn't exist.
 	   String tableName = "people";
-	   CloudTable cloudTable = new CloudTable(tableName,tableClient);
+	   CloudTable cloudTable = tableClient.getTableReference(tableName);
 	   cloudTable.createIfNotExists();
     }
     catch (Exception e)


### PR DESCRIPTION
`new CloudTable(tableName, tableClient)` does not seem to be supported anymore, the way to go is `tableClient.getTableReference(tableName)` which returns the same CloudTable to operate on.