### PR TITLE
Make it easier to integrate with Azure web sites

### DIFF
--- a/articles/api-management/api-management-howto-mutual-certificates.md
+++ b/articles/api-management/api-management-howto-mutual-certificates.md
@@ -24,7 +24,7 @@ For information about managing certificates using the API Management REST API, s
 
 ## <a name="prerequisites"> </a>Prerequisites
 
-This guide shows you how to configure your API Management service instance to use client certificate authentication to access the back-end service for an API. Before following the steps in this topic, you should have your back-end service configured for client certificate authentication, and have access to the certificate and the password for the certificate for uploading in the API Management publisher portal.
+This guide shows you how to configure your API Management service instance to use client certificate authentication to access the back-end service for an API. Before following the steps in this topic, you should have your back-end service configured for client certificate authentication ([to configure certificate authentication in Azure WebSites refer to this article][]), and have access to the certificate and the password for the certificate for uploading in the API Management publisher portal.
 
 ## <a name="step1"> </a>Upload a client certificate
 
@@ -129,6 +129,7 @@ For more information on other ways to secure your backend service, such as HTTP 
 
 [Azure API Management REST API Certificate entity]: http://msdn.microsoft.com/library/azure/dn783483.aspx
 [WebApp-GraphAPI-DotNet]: https://github.com/AzureADSamples/WebApp-GraphAPI-DotNet
+[to configure certificate authentication in Azure WebSites refer to this article]: https://azure.microsoft.com/en-us/documentation/articles/app-service-web-configure-tls-mutual-auth/
 
 [Prerequisites]: #prerequisites
 [Upload a client certificate]: #step1
@@ -136,7 +137,6 @@ For more information on other ways to secure your backend service, such as HTTP 
 [Configure an API to use a client certificate for gateway authentication]: #step2
 [Test the configuration by calling an operation in the Developer Portal]: #step3
 [Next steps]: #next-steps
-
 
 
  


### PR DESCRIPTION
It adds a reference link on how to configure client certificates in Azure Websites. I spent the full day getting this to work due to lack of knowledge about how to do it on websites (misleading that we can remote into IIS Manager and activate it there, even though that is the wrong way to do it). Until I finally found the link referenced and got it to work. If this link would have been part of the article, I would have finished configuring in 1 hour and not 8.