### PR TITLE
added line 440: app.set('view engine', 'jade');

### DIFF
--- a/articles/documentdb/documentdb-nodejs-application.md
+++ b/articles/documentdb/documentdb-nodejs-application.md
@@ -437,6 +437,8 @@ That takes care of all the initial setup and configuration, now let’s get down
 		app.get('/', taskList.showTasks.bind(taskList));
 		app.post('/addtask', taskList.addTask.bind(taskList));
 		app.post('/completetask', taskList.completeTask.bind(taskList));
+		app.set('view engine', 'jade');
+
 
 
 6. These lines define a new instance of our **TaskDao** object, with a new connection to DocumentDB (using the values read from the **config.js**), initialize the task object and then bind form actions to methods on our **TaskList** controller. 


### PR DESCRIPTION
corrects the following throw new Error('No default engine was specified and no extension was provided.');

Otherwise the node.js version of the tutorial does not work at step 6.