### PR TITLE
Update mobile-services-apns-configure-push.md

### DIFF
--- a/includes/mobile-services-apns-configure-push.md
+++ b/includes/mobile-services-apns-configure-push.md
@@ -1,4 +1,4 @@
 
-* Follow the steps at [Installing a Client SSL Signing Identity on the Server](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/ConfiguringPushNotifications/ConfiguringPushNotifications.html#//apple_ref/doc/uid/TP40012582-CH32-SW15) to export the certificate you downloaded in the previous step to a .p12 file.
+* Follow the steps at [Installing a Client SSL Signing Identity on the Server](https://developer.apple.com/library/prerelease/ios/documentation/IDEs/Conceptual/AppDistributionGuide/AddingCapabilities/AddingCapabilities.html#//apple_ref/doc/uid/TP40012582-CH26-SW16) to export the certificate you downloaded in the previous step to a .p12 file.
 
 * In the Azure classic portal, click **Mobile Services** > your app > the **Push** tab > **apple push notification settings** > "**Upload**. Upload the .p12 file, making sure that the correct **Mode** is selected (either Sandbox or Production, corresponding to whether the client SSL certificate you generated was Development or Distribution.) Your mobile service is now configured to work with push notifications on iOS!


### PR DESCRIPTION
Fix a broken link to apple's documentation. 
On safari, the new link doesn't scroll correctly, but it is better then the PageNotFound in the existing docs.