### PR TITLE
Fix InstallMongoOnWindowsVM URL

### DIFF
--- a/articles/app-service-web/web-sites-dotnet-store-data-mongodb-vm.md
+++ b/articles/app-service-web/web-sites-dotnet-store-data-mongodb-vm.md
@@ -472,7 +472,7 @@ For more information on developing C# applications against MongoDB, see [CSharp 
 [MongoConnectionStrings]: http://www.mongodb.org/display/DOCS/Connections
 [MongoDB]: http://www.mongodb.org
 [InstallMongoOnCentOSLinuxVM]: /manage/linux/common-tasks/mongodb-on-a-linux-vm/
-[InstallMongoOnWindowsVM]: /manage/windows/common-tasks/install-mongodb/
+[InstallMongoOnWindowsVM]: ../virtual-machines-install-mongodb-windows-server/
 [VSEWeb]: http://www.microsoft.com/visualstudio/eng/2013-downloads#d-2013-express
 [VSUlt]: http://www.microsoft.com/visualstudio/eng/2013-downloads
 


### PR DESCRIPTION
Would like to have fixed `InstallMongoOnCentOSLinuxVM` too, but the contents of https://github.com/Azure/azure-content/blob/master/includes/install-and-run-mongo-on-centos-vm.md do not appear to manifest anywhere on https://azure.microsoft.com/en-us/documentation ? :bowtie: :mag_right: :link: