### PR TITLE
Reviewed topics referring to Xamarin setup to refer to new MSDN topics

### DIFF
--- a/articles/active-directory/active-directory-devquickstarts-xamarin.md
+++ b/articles/active-directory/active-directory-devquickstarts-xamarin.md
@@ -41,14 +41,14 @@ To build the complete working application, you’ll need to:
 To get started, [download a skeleton project](https://github.com/AzureADQuickStarts/NativeClient-MultiTarget-DotNet/archive/skeleton.zip) or [download the completed sample](https://github.com/AzureADQuickStarts/NativeClient-MultiTarget-DotNet/archive/complete.zip).  Each is a Visual Studio 2013 solution.  You'll also need an Azure AD tenant in which you can create users and register an application.  If you don't already have a tenant, [learn how to get one](active-directory-howto-tenant.md).
 
 ## *0. Set up your Xamarin Development Environment*
-There are several different ways you might want to set up Xamarin, depending on the specific platforms you wish to target.  Since this tutorial includes projects for iOS, Android, and Windows, we'll elect to use Visual Studio 2013 and the [Xamarin.iOS Build Host](http://developer.xamarin.com/guides/ios/getting_started/installation/windows/), which will require:
-- A windows machine to run Visual Studio & the Windows apps
-- An OSX machine (if you want to be able to run the iOS app)
-- A Xamarin Business subscription (a [free trial](http://developer.xamarin.com/guides/cross-platform/getting_started/beginning_a_xamarin_trial/) is sufficient)
-- [Xamarin for Windows](https://xamarin.com/download), which includes Xamarin.iOS, Xamarin.Android, and the Visual Studio Integration (recommended for this sample).
-- [Xamarin for OS X](https://xamarin.com/download), which includes Xamarin.iOS (and the Xamarin.iOS Build Host), Xamarin.Android, Xamarin.Mac, and Xamarin Studio.
+Because this tutorial includes projects for iOS, Android, and Windows, you'll need Visual Studio 2015 and Xamarin together. This requires:
+- A Windows machine to run Visual Studio and the Android/Windows apps
+- An Mac OS X machine, if you want to run the iOS app
+- A Xamarin Business license (free 30-day trial)
+- Xamarin for Windows, which includes Xamarin.iOS, Xamarin.Android, and the Visual Studio Integration (recommended for this sample).
+- Xamarin for OS X, which includes Xamarin.iOS (and the Xamarin.iOS Build Host), Xamarin.Android, Xamarin.Mac, and Xamarin Studio.
 
-We recommend you begin with the [Xamarin Download Page](https://xamarin.com/download), installing Xamarin on both your Mac and PC.  If you don't have both machines available, you can still run the sample, but certain projects will have to be omitted.  Follow the [detailed installation guides](http://developer.xamarin.com/guides/cross-platform/getting_started/installation/) for iOS and Android, and if you would like to understand more about the options available to you for development, have a look at the [Building Cross Platform Applications](http://developer.xamarin.com/guides/cross-platform/application_fundamentals/building_cross_platform_applications/part_1_-_understanding_the_xamarin_mobile_platform/) guide.  You do not need to setup a device for development at this time, nor do you need a Apple Developer Program subscription (unless, of course, you want to run the iOS app on a device).
+To create this environment, follow the complete instructions on [Setup and Install for Visual Studio and Xamarin](https://msdn.microsoft.com/en-US/library/mt613162.aspx) on MSDN. Those instructions include material you can review to learn more about Xamarin while you're waiting for the installers to complete.
 
 Once you've completed the necessary setup, open the solution in Visual Studio to get started.  You will find six projects: five platform-specific projects and one portable class library that will be shared across all platforms, `DirectorySearcher.cs`
 

--- a/articles/active-directory/active-directory-devquickstarts-xamarin.md
+++ b/articles/active-directory/active-directory-devquickstarts-xamarin.md
@@ -48,7 +48,7 @@ Because this tutorial includes projects for iOS, Android, and Windows, you'll ne
 - Xamarin for Windows, which includes Xamarin.iOS, Xamarin.Android, and the Visual Studio Integration (recommended for this sample).
 - Xamarin for OS X, which includes Xamarin.iOS (and the Xamarin.iOS Build Host), Xamarin.Android, Xamarin.Mac, and Xamarin Studio.
 
-To create this environment, follow the complete instructions on [Setup and Install for Visual Studio and Xamarin](https://msdn.microsoft.com/en-US/library/mt613162.aspx) on MSDN. Those instructions include material you can review to learn more about Xamarin while you're waiting for the installers to complete.
+To create this environment, follow the complete instructions on [Setup and Install for Visual Studio and Xamarin](https://msdn.microsoft.com/en-US/library/mt613162.aspx).
 
 Once you've completed the necessary setup, open the solution in Visual Studio to get started.  You will find six projects: five platform-specific projects and one portable class library that will be shared across all platforms, `DirectorySearcher.cs`
 

--- a/articles/app-service-mobile/app-service-mobile-xamarin-android-get-started-offline-data.md
+++ b/articles/app-service-mobile/app-service-mobile-xamarin-android-get-started-offline-data.md
@@ -28,12 +28,6 @@ In this tutorial, you will update the client project from the tutorial [Create a
 
 To learn more about the offline sync feature, see the topic [Offline Data Sync in Azure Mobile Apps].
 
-## Requirements
-
-* Visual Studio 2013
-* Visual Studio [Xamarin extension] **or** [Xamarin Studio]
-* Completion of the tutorial [Create a Xamarin Android app]. This tutorial uses the completed app covered in that tutorial.
-
 ## Review the client sync code
 
 The Xamarin client project that you downloaded when you completed the tutorial [Create a Xamarin Android app] already contains code supporting offline synchronization using a local SQLite database. Here is a brief overview of what is already included in the tutorial code. For a conceptual overview of the feature, see [Offline Data Sync in Azure Mobile Apps].

--- a/articles/app-service-mobile/app-service-mobile-xamarin-android-get-started-push.md
+++ b/articles/app-service-mobile/app-service-mobile-xamarin-android-get-started-push.md
@@ -22,7 +22,7 @@
 
 ##Overview
 
-In this tutorial, you add push notifications to the [Xamarin.Android quickstart] project so that every time a record is inserted, a push notification is sent. This tutorial is based on the [Xamarin.Android quickstart] tutorial, which you must complete first. If you do not use the downloaded quick start server project, you must add the push notification extension package to your project. For more information about server extension packages, see [Work with the .NET backend server SDK for Azure Mobile Apps](app-service-mobile-dotnet-backend-how-to-use-server-sdk.md).
+In this tutorial, you add push notifications to the [Xamarin.Android quickstart] project so that every time a record is inserted, a push notification is sent. This tutorial is based on the [Create a Xamarin.Android app] tutorial, which you must complete first. If you do not use the downloaded quick start server project, you must add the push notification extension package to your project. For more information about server extension packages, see [Work with the .NET backend server SDK for Azure Mobile Apps](app-service-mobile-dotnet-backend-how-to-use-server-sdk.md).
 
 ##Prerequisites
 
@@ -31,9 +31,6 @@ This tutorial requires the following:
 + An active Google account. You can sign up for a Google account at [accounts.google.com](http://go.microsoft.com/fwlink/p/?LinkId=268302).
 
 + [Google Cloud Messaging Client Component](http://components.xamarin.com/view/GCMClient/). You will add this component during the tutorial.
-
-+ Complete the [Create a Xamarin.Android app] tutorial.
-
 
 ##<a name="create-hub"></a>Create a Notification Hub
 

--- a/articles/app-service-mobile/app-service-mobile-xamarin-android-get-started-push.md
+++ b/articles/app-service-mobile/app-service-mobile-xamarin-android-get-started-push.md
@@ -32,7 +32,7 @@ This tutorial requires the following:
 
 + [Google Cloud Messaging Client Component](http://components.xamarin.com/view/GCMClient/). You will add this component during the tutorial.
 
-+ Completed [Xamarin.Android quickstart] tutorial.
++ Complete the [Create a Xamarin.Android app] tutorial.
 
 
 ##<a name="create-hub"></a>Create a Notification Hub
@@ -78,6 +78,7 @@ You can test the app by using a virtual device in the emulator. There are additi
 
 <!-- URLs. -->
 [Xamarin.Android quickstart]: app-service-mobile-xamarin-android-get-started.md
+[Create a Xamarin.Android app]: app-service-mobile-xamarin-android-get-started.md
 
 [Google Cloud Messaging Client Component]: http://components.xamarin.com/view/GCMClient/
 [Xamarin.Android]: http://xamarin.com/download/

--- a/articles/app-service-mobile/app-service-mobile-xamarin-android-get-started.md
+++ b/articles/app-service-mobile/app-service-mobile-xamarin-android-get-started.md
@@ -36,7 +36,7 @@ To complete this tutorial, you need the following:
 
 * An active Azure account. If you don't have an account, you can sign up for an Azure trial and get up to 10 free Mobile Apps that you can keep using even after your trial ends. For details, see [Azure Free Trial](https://azure.microsoft.com/pricing/free-trial/).
 
-* [Visual Studio Community 2013] or later.  If you install Visual Studio Community 2013, install [Xamarin] separately.  You can install the Xamarin tools when you install Visual Studio 2015.
+* [Visual Studio] 2013 or later. For Visual StduioStudio 2015, follow the [Setup and Install for Visual Studio](https://msdn.microsoft.com/en-US/library/mt488770.aspx) instructions. For Visual Studio 2013, install [Xamarin] separately.
 
 >[AZURE.NOTE] If you want to get started with Azure App Service before signing up for an Azure account, go to [Try App Service](https://tryappservice.azure.com/?appServiceName=mobile), where you can immediately create a short-lived starter Mobile App in App Service. No credit cards required; no commitments.
 
@@ -87,4 +87,4 @@ You have now provisioned an Azure Mobile App backend that can be used by your mo
 [Xcode]: https://go.microsoft.com/fwLink/?LinkID=266532&clcid=0x409
 [Xamarin for Windows]: https://go.microsoft.com/fwLink/?LinkID=330242&clcid=0x409
 
-[Visual Studio Community 2013]: https://go.microsoft.com/fwLink/p/?LinkID=534203
+[Visual Studio]: https://go.microsoft.com/fwLink/p/?LinkID=534203

--- a/articles/app-service-mobile/app-service-mobile-xamarin-android-get-started.md
+++ b/articles/app-service-mobile/app-service-mobile-xamarin-android-get-started.md
@@ -36,7 +36,7 @@ To complete this tutorial, you need the following:
 
 * An active Azure account. If you don't have an account, you can sign up for an Azure trial and get up to 10 free Mobile Apps that you can keep using even after your trial ends. For details, see [Azure Free Trial](https://azure.microsoft.com/pricing/free-trial/).
 
-* [Visual Studio] 2013 or later. For Visual StduioStudio 2015, follow the [Setup and Install for Visual Studio](https://msdn.microsoft.com/en-US/library/mt488770.aspx) instructions. For Visual Studio 2013, install [Xamarin] separately.
+* [Visual Studio] 2013 or later. For Visual Studio 2015, follow the [Setup and Install for Visual Studio](https://msdn.microsoft.com/en-US/library/mt488770.aspx) instructions. For Visual Studio 2013, install [Xamarin] separately.
 
 >[AZURE.NOTE] If you want to get started with Azure App Service before signing up for an Azure account, go to [Try App Service](https://tryappservice.azure.com/?appServiceName=mobile), where you can immediately create a short-lived starter Mobile App in App Service. No credit cards required; no commitments.
 

--- a/articles/app-service-mobile/app-service-mobile-xamarin-forms-blob-storage.md
+++ b/articles/app-service-mobile/app-service-mobile-xamarin-forms-blob-storage.md
@@ -30,15 +30,7 @@ In this tutorial, you will create a storage account and add a connection string 
 
 ## Prerequisites
 
-To complete this tutorial, you need the following:
-
-* An active Azure account. If you don't have an account, you can sign up for an Azure trial and get up to 10 free mobile apps that you can keep using even after your trial ends. For details, see [Azure Free Trial](https://azure.microsoft.com/pricing/free-trial/).
-
-* Visual Studio 2013 with Xamarin. See [Setup and Install for Visual Studio and Xamarin](https://msdn.microsoft.com/en-US/library/mt613162.aspx) for instructions.
-
-* A Mac with [Xcode](https://go.microsoft.com/fwLink/?LinkID=266532) v7.0 or later and [Xamarin Studio](http://xamarin.com/download) installed. You can also run Visual Studio on the Mac as described on [Setup, Install, and Verifications for Mac Users with Xamarin](https://msdn.microsoft.com/en-US/library/mt488770.aspx).
-
-* Completion of the tutorial [Create a Xamarin.Forms app]. This article uses the completed app from that tutorial.
+Complete the [Create a Xamarin.Forms app], which lists other prerequisites. This article uses the completed app from that tutorial.
 
 >[AZURE.NOTE] If you want to get started with Azure App Service before you sign up for an Azure account, go to [Try App Service](https://tryappservice.azure.com/?appServiceName=mobile). There, you can immediately create a short-lived starter mobile app in App Service—no credit card required, and no commitments.
 

--- a/articles/app-service-mobile/app-service-mobile-xamarin-forms-blob-storage.md
+++ b/articles/app-service-mobile/app-service-mobile-xamarin-forms-blob-storage.md
@@ -30,7 +30,7 @@ In this tutorial, you will create a storage account and add a connection string 
 
 ## Prerequisites
 
-Complete the [Create a Xamarin.Forms app], which lists other prerequisites. This article uses the completed app from that tutorial.
+Complete the [Create a Xamarin.Forms app] tutorial, which lists other prerequisites. This article uses the completed app from that tutorial.
 
 >[AZURE.NOTE] If you want to get started with Azure App Service before you sign up for an Azure account, go to [Try App Service](https://tryappservice.azure.com/?appServiceName=mobile). There, you can immediately create a short-lived starter mobile app in App Service—no credit card required, and no commitments.
 
@@ -710,7 +710,7 @@ This article described how to use the new file support in the Azure Mobile clien
 <!-- URLs. -->
 
 [Visual Studio Community 2013]: https://go.microsoft.com/fwLink/p/?LinkID=534203
-[Create a Xamarin.Forms app]: ../app-service-mobile-xamarin-forms-get-started.md
+[Create a Xamarin.Forms app]: app-service-mobile-xamarin-forms-get-started.md
 [Xamarin.Forms DependencyService]: https://developer.xamarin.com/guides/xamarin-forms/dependency-service/
 [Microsoft.Azure.Mobile.Client.Files]: https://www.nuget.org/packages/Microsoft.Azure.Mobile.Client.Files/
 [Microsoft.Azure.Mobile.Client.SQLiteStore]: https://www.nuget.org/packages/Microsoft.Azure.Mobile.Client.SQLiteStore/

--- a/articles/app-service-mobile/app-service-mobile-xamarin-forms-blob-storage.md
+++ b/articles/app-service-mobile/app-service-mobile-xamarin-forms-blob-storage.md
@@ -34,9 +34,9 @@ To complete this tutorial, you need the following:
 
 * An active Azure account. If you don't have an account, you can sign up for an Azure trial and get up to 10 free mobile apps that you can keep using even after your trial ends. For details, see [Azure Free Trial](https://azure.microsoft.com/pricing/free-trial/).
 
-* [Visual Studio Community 2013] or later.
+* Visual Studio 2013 with Xamarin. See [Setup and Install for Visual Studio and Xamarin](https://msdn.microsoft.com/en-US/library/mt613162.aspx) for instructions.
 
-* A Mac with [Xcode](https://go.microsoft.com/fwLink/?LinkID=266532) v7.0 or later and [Xamarin Studio](http://xamarin.com/download) installed.
+* A Mac with [Xcode](https://go.microsoft.com/fwLink/?LinkID=266532) v7.0 or later and [Xamarin Studio](http://xamarin.com/download) installed. You can also run Visual Studio on the Mac as described on [Setup, Install, and Verifications for Mac Users with Xamarin](https://msdn.microsoft.com/en-US/library/mt488770.aspx).
 
 * Completion of the tutorial [Create a Xamarin.Forms app]. This article uses the completed app from that tutorial.
 

--- a/articles/app-service-mobile/app-service-mobile-xamarin-forms-get-started-push.md
+++ b/articles/app-service-mobile/app-service-mobile-xamarin-forms-get-started-push.md
@@ -30,16 +30,9 @@ The [iOS simulator does not support push notifications](https://developer.apple.
 
 ##Prerequisites
 
-To complete this tutorial, you need the following:
-
-* An active Azure account.
-If you don't have an account yet, sign up for an Azure trial and get up to 10 free mobile apps. You can keep using them even after your trial ends. See [Azure Free Trial](https://azure.microsoft.com/pricing/free-trial/).
-
-* A Mac with [Xamarin Studio] and [Xcode] v4.4 or later installed it. You can run the Xamarin.Forms app using Visual Studio on a Windows computer if you want, but it's a bit more complicated because you have to connect to a networked Mac running the Xamarin.iOS Build Host. If you're interested in doing that, see [Installing Xamarin.iOS on Windows].
+* Complete the [Create a Xamarin.Forms app](app-service-mobile-xamarin-forms-get-started.md) tutorial , which lists other prerequisites. This article uses the completed app from that tutorial.
 
 * A physical iOS device. Push notifications are not supported by the iOS simulator.
-
-* Complete the [Xamarin.Forms quickstart tutorial](app-service-mobile-xamarin-forms-get-started.md).
 
 ##Create a Notification Hub for your Mobile App
 

--- a/articles/app-service-mobile/app-service-mobile-xamarin-forms-get-started-push.md
+++ b/articles/app-service-mobile/app-service-mobile-xamarin-forms-get-started-push.md
@@ -30,7 +30,7 @@ The [iOS simulator does not support push notifications](https://developer.apple.
 
 ##Prerequisites
 
-* Complete the [Create a Xamarin.Forms app](app-service-mobile-xamarin-forms-get-started.md) tutorial , which lists other prerequisites. This article uses the completed app from that tutorial.
+* Complete the [Create a Xamarin.Forms app](app-service-mobile-xamarin-forms-get-started.md) tutorial, which lists other prerequisites. This article uses the completed app from that tutorial.
 
 * A physical iOS device. Push notifications are not supported by the iOS simulator.
 

--- a/articles/app-service-mobile/app-service-mobile-xamarin-forms-get-started-users.md
+++ b/articles/app-service-mobile/app-service-mobile-xamarin-forms-get-started-users.md
@@ -24,7 +24,7 @@
 
 This topic shows you how to authenticate users of an App Service Mobile App from your client application. In this tutorial, you add authentication to the Xamarin.Forms quickstart project using an identity provider that is supported by App Service. After being successfully authenticated and authorized by your Mobile App, the user ID value is displayed and you will be able to access restricted table data.
 
-You must first complete the [Xamarin.Forms quickstart tutorial](app-service-mobile-xamarin-forms-get-started.md). If you do not use the downloaded quick start server project, you must add the authentication extension package to your project. For more information about server extension packages, see [Work with the .NET backend server SDK for Azure Mobile Apps](app-service-mobile-dotnet-backend-how-to-use-server-sdk.md).
+You must first complete the [Create a Xamarin.Forms app](app-service-mobile-xamarin-forms-get-started.md). If you do not use the downloaded quick start server project, you must add the authentication extension package to your project. For more information about server extension packages, see [Work with the .NET backend server SDK for Azure Mobile Apps](app-service-mobile-dotnet-backend-how-to-use-server-sdk.md).
 
 
 ##Register your app for authentication and configure App Services

--- a/articles/app-service-mobile/app-service-mobile-xamarin-forms-get-started.md
+++ b/articles/app-service-mobile/app-service-mobile-xamarin-forms-get-started.md
@@ -32,10 +32,10 @@ To complete this tutorial, you need the following:
 
 * An active Azure account. If you don't have an account, you can sign up for an Azure trial and get up to 10 free Mobile Apps that you can keep using even after your trial ends. For details, see [Azure Free Trial](https://azure.microsoft.com/pricing/free-trial/).
 
-* [Visual Studio Community 2013] or later.  If you install Visual Studio Community 2013, install [Xamarin] separately.  You can install the Xamarin tools when you install Visual Studio 2015.
+* [Visual Studio Community 2013] or later.  If you install Visual Studio Community 2013, install [Xamarin] separately.  You can install the Xamarin tools when you install Visual Studio 2015. Complete instructions can be found on [Setup and Install for Visual Studio and Xamarin](https://msdn.microsoft.com/en-US/library/mt613162.aspx) (MSDN).
 
-* A Mac with [Xcode] v7.0 or later and [Xamarin Studio] installed. If you plan to build your app on a Windows computer by using Visual Studio, you'll still need access to a networked Mac to do it.
-
+* A Mac with [Xcode] v7.0 or later and [Xamarin Studio] installed. If you plan to build your app on a Windows computer by using Visual Studio, you'll still need access to a networked Mac to do it. Instructions for setting up a Mac are also included on [Setup and Install for Visual Studio and Xamarin](https://msdn.microsoft.com/en-US/library/mt613162.aspx) (MSDN).
+ 
 >[AZURE.NOTE] If you want to get started with Azure App Service before signing up for an Azure account, go to [Try App Service](https://tryappservice.azure.com/?appServiceName=mobile), where you can immediately create a short-lived starter Mobile App in App Service. No credit cards required; no commitments.
 
 ## Create a new Azure Mobile App backend

--- a/articles/app-service-mobile/app-service-mobile-xamarin-forms-get-started.md
+++ b/articles/app-service-mobile/app-service-mobile-xamarin-forms-get-started.md
@@ -65,7 +65,7 @@ If you chose a .NET backend configuration above, you can optionally test the bac
 
 Here you have a couple of choices. You can download the solution to a Mac and open it in Xamarin Studio, or you can download the solution to a Windows computer and open it in Visual Studio. You can also use both environments and switch back and forth between them. Consider these things:
 
-* It's easier to run the iOS project of your solution on a Mac. You can use Visual Studio on your Windows computer if you want, but it's a bit more complicated because you have to connect to a networked Mac. If you're interested in doing that, see [Installing Xamarin.iOS on Windows].
+* It's easier to run the iOS project of your solution on a Mac. You can use Visual Studio on your Windows computer if you want, but it's a bit more complicated because you have to connect to a networked Mac. If you're interested in doing that, see [Setup and Install for Visual Studio and Xamarin](https://msdn.microsoft.com/en-US/library/mt613162.aspx).
 * You can run the Android project on either your Mac or your Windows computer.
 * You can run the Windows project(s) only by using Visual Studio on a Windows computer.
 

--- a/articles/app-service-mobile/app-service-mobile-xamarin-ios-get-started-offline-data.md
+++ b/articles/app-service-mobile/app-service-mobile-xamarin-ios-get-started-offline-data.md
@@ -151,10 +151,10 @@ In this section you will reconnect the app to the mobile backend, which simulate
 <!-- Images -->
 
 <!-- URLs. -->
-[Create a Xamarin iOS app]: ../app-service-mobile-xamarin-ios-get-started.md
-[Offline Data Sync in Azure Mobile Apps]: ../app-service-mobile-offline-data-sync.md
+[Create a Xamarin iOS app]: app-service-mobile-xamarin-ios-get-started.md
+[Offline Data Sync in Azure Mobile Apps]: app-service-mobile-offline-data-sync.md
 
-[How to use the Xamarin Component client for Azure Mobile Services]: ../partner-xamarin-mobile-services-how-to-use-client-library.md
+[How to use the Xamarin Component client for Azure Mobile Services]: partner-xamarin-mobile-services-how-to-use-client-library.md
 
 [Xamarin Studio]: http://xamarin.com/download
 [Xamarin extension]: http://xamarin.com/visual-studio

--- a/articles/app-service-mobile/app-service-mobile-xamarin-ios-get-started-offline-data.md
+++ b/articles/app-service-mobile/app-service-mobile-xamarin-ios-get-started-offline-data.md
@@ -28,14 +28,6 @@ In this tutorial, you will update the Xamarin.iOS app project from the tutorial 
 
 To learn more about the offline sync feature, see the topic [Offline Data Sync in Azure Mobile Apps].
 
-## Requirements
-
-This tutorial requires the following:
-
-* Visual Studio 2013
-* Visual Studio [Xamarin extension] **or** [Xamarin Studio] on OS X
-* Completion of the tutorial [Create a Xamarin iOS app]. This tutorial uses the completed app covered in that tutorial.
-
 ## Review the client sync code
 
 The Xamarin client project that you downloaded when you completed the tutorial [Create a Xamarin iOS app] already contains code supporting offline synchronization using a local SQLite database. Here is a brief overview of what is already included in the tutorial code. For a conceptual overview of the feature, see [Offline Data Sync in Azure Mobile Apps].

--- a/articles/app-service-mobile/app-service-mobile-xamarin-ios-get-started-push.md
+++ b/articles/app-service-mobile/app-service-mobile-xamarin-ios-get-started-push.md
@@ -22,22 +22,13 @@
 
 ##Overview
 
-This tutorial is based on the [Xamarin.iOS quickstart tutorial](app-service-mobile-xamarin-ios-get-started.md), which you must complete first. You will add push notifications to the Xamarin.iOS quick start project so that every time a record is inserted, a push notification is sent. If you do not use the downloaded quick start server project, you must add the push notification extension package to your project. For more information about server extension packages, see [Work with the .NET backend server SDK for Azure Mobile Apps](app-service-mobile-dotnet-backend-how-to-use-server-sdk.md).
+This tutorial is based on the [Create a Xamarin iOS app](app-service-mobile-xamarin-ios-get-started.md) tutorial, which you must complete first. You will add push notifications to the Xamarin.iOS quick start project so that every time a record is inserted, a push notification is sent. If you do not use the downloaded quick start server project, you must add the push notification extension package to your project. For more information about server extension packages, see [Work with the .NET backend server SDK for Azure Mobile Apps](app-service-mobile-dotnet-backend-how-to-use-server-sdk.md).
 
 ##Prerequisites
 
-To complete this tutorial, you need the following:
+* Complete the [Create a Xamarin iOS app](app-service-mobile-xamarin-ios-get-started.md) tutorial.
 
-* An active Azure account.
-If you don't have an account yet, sign up for an Azure trial and get up to 10 free Mobile App backends. You can keep using them even after your trial ends. See [Azure Free Trial](https://azure.microsoft.com/pricing/free-trial/).
-
-* A Mac with [Xamarin Studio] and [Xcode] v4.4 or later, or Visual Studio on a Windows machine with a networked Mac. To create this environment, follow the complete instructions on [Setup and Install for Visual Studio and Xamarin](https://msdn.microsoft.com/en-US/library/mt613162.aspx).
- 
 * A physical iOS device. Push notifications are not supported by the iOS simulator.
-
-* An [Apple Developer Program membership](https://developer.apple.com/programs/ios/), required to register with the Apple Push Notification Service (APNS).
-
-* Complete the [Xamarin.iOS quickstart tutorial](app-service-mobile-xamarin-ios-get-started.md).
 
 
 ##Register the app for push notifications on Apple's developer portal
@@ -165,9 +156,6 @@ You have successfully completed this tutorial.
 <!-- Images. -->
 
 <!-- URLs. -->
-[Xamarin Studio]: http://xamarin.com/platform
-[Install Xcode]: https://go.microsoft.com/fwLink/p/?LinkID=266532
-[Xcode]: https://go.microsoft.com/fwLink/?LinkID=266532
-[Installing Xamarin.iOS on Windows]: http://developer.xamarin.com/guides/ios/getting_started/installation/windows/
+
 
 

--- a/articles/app-service-mobile/app-service-mobile-xamarin-ios-get-started-push.md
+++ b/articles/app-service-mobile/app-service-mobile-xamarin-ios-get-started-push.md
@@ -31,8 +31,8 @@ To complete this tutorial, you need the following:
 * An active Azure account.
 If you don't have an account yet, sign up for an Azure trial and get up to 10 free Mobile App backends. You can keep using them even after your trial ends. See [Azure Free Trial](https://azure.microsoft.com/pricing/free-trial/).
 
-* A Mac with [Xamarin Studio] and [Xcode] v4.4 or later installed it. You can run the Xamarin.iOS app using Visual Studio on a Windows computer if you want, but it's a bit more complicated because you have to connect to a networked Mac running the Xamarin.iOS Build Host. If you're interested in doing that, see [Installing Xamarin.iOS on Windows].
-
+* A Mac with [Xamarin Studio] and [Xcode] v4.4 or later, or Visual Studio on a Windows machine with a networked Mac. To create this environment, follow the complete instructions on [Setup and Install for Visual Studio and Xamarin](https://msdn.microsoft.com/en-US/library/mt613162.aspx).
+ 
 * A physical iOS device. Push notifications are not supported by the iOS simulator.
 
 * An [Apple Developer Program membership](https://developer.apple.com/programs/ios/), required to register with the Apple Push Notification Service (APNS).

--- a/articles/app-service-mobile/app-service-mobile-xamarin-ios-get-started.md
+++ b/articles/app-service-mobile/app-service-mobile-xamarin-ios-get-started.md
@@ -33,11 +33,9 @@ To complete this tutorial, you need the following:
 
 * An active Azure account. If you don't have an account, you can sign up for an Azure trial and get up to 10 free mobile apps that you can keep using even after your trial ends. For details, see [Azure Free Trial](https://azure.microsoft.com/pricing/free-trial/).
 
-* [Visual Studio Community 2013] or later.  If you install Visual Studio Community 2013, install [Xamarin] separately.  You can install the Xamarin tools when you install Visual Studio 2015.
+* [Visual Studio] 2013 or later. For Visual Studio 2015, follow the [Setup and Install for Visual Studio](https://msdn.microsoft.com/en-US/library/mt488770.aspx) instructions. For Visual Studio 2013, install [Xamarin] separately.
 
-* A Mac with [Xcode] v7.0 or later and [Xamarin Studio] installed.
-
-* If you plan to build your app on a Windows-based computer running Visual Studio, you will still need access to a networked Mac running the Xamarin.iOS Build Host to actually build and deploy. For more information see, [Installing Xamarin.iOS on Windows](http://developer.xamarin.com/guides/ios/getting_started/installation/windows/)
+* A Mac OS X machine with [Xcode] v7.0 or later and [Xamarin Studio] installed. [Setup and Install for Visual Studio](https://msdn.microsoft.com/en-US/library/mt488770.aspx) also covers connecting this machine with Visual Studio.
 
 >[AZURE.NOTE] If you want to get started with Azure App Service before you sign up for an Azure account, go to [Try App Service](https://tryappservice.azure.com/?appServiceName=mobile). There, you can immediately create a short-lived starter mobile app in App Service—no credit card required, and no commitments.
 

--- a/articles/mobile-services/mobile-services-dotnet-backend-xamarin-android-get-started-push.md
+++ b/articles/mobile-services/mobile-services-dotnet-backend-xamarin-android-get-started-push.md
@@ -34,7 +34,7 @@ This tutorial requires the following:
 + An active Google account.
 + [Google Cloud Messaging Client Component]. You will add this component during the tutorial.
 
-You should already have the [Xamarin.Android] and [Azure Mobile Services][Azure Mobile Services Component] components installed in your project from when you completed [Get started with Mobile Services].
+You should already have the Xamarin.Android and [Azure Mobile Services][Azure Mobile Services Component] components installed in your project from when you completed [Get started with Mobile Services].
 
 ##<a id="register"></a>Enable Google Cloud Messaging
 
@@ -71,5 +71,4 @@ You can test the app by directly attaching an Android phone with a USB cable, or
 
 
 [Google Cloud Messaging Client Component]: http://components.xamarin.com/view/GCMClient/
-[Xamarin.Android]: http://xamarin.com/download/
 [Azure Mobile Services Component]: http://components.xamarin.com/view/azure-mobile-services/

--- a/articles/mobile-services/mobile-services-dotnet-backend-xamarin-android-get-started.md
+++ b/articles/mobile-services/mobile-services-dotnet-backend-xamarin-android-get-started.md
@@ -51,9 +51,11 @@ Once you have created your mobile service, you can follow an easy quickstart in 
 
 In this section you will download a new Xamarin Android app and a service project for your mobile service.
 
-1. In the [classic portal], click **Mobile Services**, and then click the mobile service that you just created.
+1. If you haven't already done so, install Visual Studio with Xamarin. Instructions can be found on [Setup and Install for Visual Studio and Xamarin](https://msdn.microsoft.com/en-US/library/mt613162.aspx). You can also use [Xamarin Studio] on a Mac OS X machine.
 
-2. In the quickstart tab, click **Xamarin** under **Choose platform** and expand **Create a new Xamarin app**.
+2. In the [classic portal], click **Mobile Services**, and then click the mobile service that you just created.
+
+3. In the quickstart tab, click **Xamarin** under **Choose platform** and expand **Create a new Xamarin app**.
 
    	![][6]
 
@@ -61,11 +63,7 @@ In this section you will download a new Xamarin Android app and a service projec
 
   	![][7]
 
-3. If you haven't already done so, download and install [Visual Studio Professional 2013](https://go.microsoft.com/fwLink/p/?LinkID=257546) on your local computer or virtual machine.
-
-4. If you haven't already done so, download and install [Xamarin Studio] or Xamarin for Visual Studio.
-
-5. Under **Download and publish your service to the cloud**, select **Android** and click **Download**.
+4. Under **Download and publish your service to the cloud**, select **Android** and click **Download**.
 
   	This downloads a solution containing projects for both the mobile service and for the sample _To do list_ application that is connected to your mobile service. Save the compressed project file to your local computer, and make a note of where you save it.
 

--- a/articles/mobile-services/mobile-services-dotnet-backend-xamarin-ios-get-started.md
+++ b/articles/mobile-services/mobile-services-dotnet-backend-xamarin-ios-get-started.md
@@ -51,19 +51,17 @@ Once you have created your mobile service, you can follow an easy quickstart in 
 
 In this section you will download a new Xamarin iOS app and a service project for your mobile service.
 
-1. In the [Azure classic portal], click **Mobile Services**, and then click the mobile service that you just created.
+1. If you haven't already done so, install Visual Studio with Xamarin. Instructions can be found on [Setup and Install for Visual Studio and Xamarin](https://msdn.microsoft.com/en-US/library/mt613162.aspx). You can also use [Xamarin Studio] on a Mac OS X machine.
 
-2. In the quickstart tab, click **Xamarin** under **Choose platform** and expand **Create a new Xamarin app**.
+2. In the [Azure classic portal], click **Mobile Services**, and then click the mobile service that you just created.
+
+3. In the quickstart tab, click **Xamarin** under **Choose platform** and expand **Create a new Xamarin app**.
 
    	![][6]
 
    	This displays the three easy steps to create a Xamarin iOS app connected to your mobile service.
 
   	![][7]
-
-3. If you haven't already done so, download and install <a href="https://go.microsoft.com/fwLink/p/?LinkID=257546" target="_blank">Visual Studio Professional 2013</a> on your local computer or virtual machine.
-
-4. Download and install [Xcode] v4.4 or a later version and [Xamarin Studio]. You can also use Xamarin for Visual Studio.
 
 5. Under **Download and publish your service to the cloud**, select **iOS** and click **Download**.
 

--- a/articles/mobile-services/mobile-services-xamarin-android-get-started-offline-data.md
+++ b/articles/mobile-services/mobile-services-xamarin-android-get-started-offline-data.md
@@ -46,7 +46,7 @@ This tutorial walks you through these basic steps:
 
 This tutorial requires the following:
 
-* Visual Studio with the [Xamarin extension] **or** [Xamarin Studio]
+*  Visual Studio with Xamarin; see [Setup and Install for Visual Studio and Xamarin](https://msdn.microsoft.com/en-US/library/mt613162.aspx). You can also use [Xamarin Studio] on OS X.
 * Completion of the [Get started with Mobile Services] tutorial
 
 ## <a name="review-offline"></a>Review the Mobile Services sync code

--- a/articles/mobile-services/mobile-services-xamarin-ios-get-started-offline-data.md
+++ b/articles/mobile-services/mobile-services-xamarin-ios-get-started-offline-data.md
@@ -46,7 +46,7 @@ This tutorial walks you through these basic steps:
 
 This tutorial requires the following:
 
-* Visual Studio with the [Xamarin extension] **or** [Xamarin Studio] on OS X
+* Visual Studio with Xamarin; see [Setup and Install for Visual Studio and Xamarin](https://msdn.microsoft.com/en-US/library/mt613162.aspx). You can also use [Xamarin Studio] on OS X.
 * XCode 4.5 and iOS 6.0 (or later versions)
 * Completion of the [Get started with Mobile Services] tutorial
 

--- a/articles/mobile-services/partner-xamarin-mobile-services-android-get-started-push.md
+++ b/articles/mobile-services/partner-xamarin-mobile-services-android-get-started-push.md
@@ -33,7 +33,7 @@ This tutorial requires the following:
 + An active Google account.
 + [Google Cloud Messaging Client Component]. You will add this component during the tutorial.
 
-You should already have the [Xamarin.Android] and the [Azure Mobile Services Component] installed in your project from when you completed either [Get started with Mobile Services].
+You should already have Xamarin.Android and the [Azure Mobile Services Component] installed in your project from when you completed either [Get started with Mobile Services].
 
 ##<a id="register"></a>Enable Google Cloud Messaging
 

--- a/articles/mobile-services/partner-xamarin-mobile-services-android-get-started-users.md
+++ b/articles/mobile-services/partner-xamarin-mobile-services-android-get-started-users.md
@@ -35,7 +35,7 @@ This tutorial walks you through these basic steps to enable authentication in yo
 
 This tutorial is based on the Mobile Services quickstart. You must also first complete the tutorial [Get started with Mobile Services].
 
-Completing this tutorial requires Xamarin.Android and Android SDK 4.2 or a later version. See  [Setup and Install for Visual Studio and Xamarin](https://msdn.microsoft.com/en-US/library/mt613162.aspx) or install [Xamarin Studio](https://xamarin.com/platform).
+Completing this tutorial requires [Xamarin.Android] with either Visual Studio or Xamarin Studio and Android SDK 4.2 or later. For instructions on setting up Visual Studio, see [Setup and Install for Visual Studio and Xamarin](https://msdn.microsoft.com/en-US/library/mt613162.aspx).
 
 ##<a name="register"></a>Register your app for authentication and configure Mobile Services
 

--- a/articles/mobile-services/partner-xamarin-mobile-services-android-get-started-users.md
+++ b/articles/mobile-services/partner-xamarin-mobile-services-android-get-started-users.md
@@ -35,7 +35,7 @@ This tutorial walks you through these basic steps to enable authentication in yo
 
 This tutorial is based on the Mobile Services quickstart. You must also first complete the tutorial [Get started with Mobile Services].
 
-Completing this tutorial requires Xamarin.Android and Android SDK 4.2 or a later version.
+Completing this tutorial requires Xamarin.Android and Android SDK 4.2 or a later version. See  [Setup and Install for Visual Studio and Xamarin](https://msdn.microsoft.com/en-US/library/mt613162.aspx) or install [Xamarin Studio](https://xamarin.com/platform).
 
 ##<a name="register"></a>Register your app for authentication and configure Mobile Services
 

--- a/articles/mobile-services/partner-xamarin-mobile-services-android-get-started.md
+++ b/articles/mobile-services/partner-xamarin-mobile-services-android-get-started.md
@@ -41,7 +41,7 @@ A screenshot from the completed app is below:
 
 ![][0]
 
-Completing this tutorial requires [Xamarin.Android], which installs Xamarin Studio and a Visual Studio plug-in (on Windows) as well as the latest Android platform. Android 4.2 SDK or a later version is required.
+Completing this tutorial requires [Xamarin.Android] with either Visual Studio or Xamarin Studio and Android SDK 4.2 or later. For instructions on setting up Visual Studio, see [Setup and Install for Visual Studio and Xamarin](https://msdn.microsoft.com/en-US/library/mt613162.aspx).
 
 The downloaded quickstart project contains the Azure Mobile services component for Xamarin.Android. While this project targets Android 4.2 or a later version, the Mobile Services SDK requires only Android 2.2 or a later version.
 

--- a/articles/mobile-services/partner-xamarin-mobile-services-ios-get-started.md
+++ b/articles/mobile-services/partner-xamarin-mobile-services-ios-get-started.md
@@ -40,7 +40,7 @@ A screenshot from the completed app is below:
 
 ![][0]
 
-Completing this tutorial requires XCode and [Xamarin Studio] for OS X or the Xamarin Visual Studio plug-in for Visual Studio on Windows. Complete installation instructions are on [Setup and Install for Visual Studio and Xamarin](https://msdn.microsoft.com/en-US/library/mt613162.aspx).
+Completing this tutorial requires XCode and [Xamarin Studio] for OS X or the Xamarin and Visual Studio on Windows. Complete installation instructions are on [Setup and Install for Visual Studio and Xamarin](https://msdn.microsoft.com/en-US/library/mt613162.aspx).
 
 > [AZURE.IMPORTANT] To complete this tutorial, you need an Azure account. If you don't have an account, you can sign up for an Azure trial and get up to 10 free mobile services that you can keep using even after your trial ends. For details, see [Azure Free Trial](https://azure.microsoft.com/pricing/free-trial/).
 

--- a/articles/mobile-services/partner-xamarin-mobile-services-ios-get-started.md
+++ b/articles/mobile-services/partner-xamarin-mobile-services-ios-get-started.md
@@ -40,7 +40,7 @@ A screenshot from the completed app is below:
 
 ![][0]
 
-Completing this tutorial requires XCode and [Xamarin Studio] for OS X or the Xamarin Visual Studio plug-in for Visual Studio on Windows. The sample will run on iOS 5.0 and newer.
+Completing this tutorial requires XCode and [Xamarin Studio] for OS X or the Xamarin Visual Studio plug-in for Visual Studio on Windows. Complete installation instructions are on [Setup and Install for Visual Studio and Xamarin](https://msdn.microsoft.com/en-US/library/mt613162.aspx).
 
 > [AZURE.IMPORTANT] To complete this tutorial, you need an Azure account. If you don't have an account, you can sign up for an Azure trial and get up to 10 free mobile services that you can keep using even after your trial ends. For details, see [Azure Free Trial](https://azure.microsoft.com/pricing/free-trial/).
 

--- a/articles/notification-hubs/partner-xamarin-notification-hubs-android-get-started.md
+++ b/articles/notification-hubs/partner-xamarin-notification-hubs-android-get-started.md
@@ -40,7 +40,7 @@ The completed code for this tutorial can be found on GitHub [here](https://githu
 
 This tutorial requires the following:
 
-+ [Xamarin.Android]
++ [Xamarin.Android] using Xamarin Studio on a Mac OS X machine, or [Visual Studio with Xamarin on Windows](https://msdn.microsoft.com/en-US/library/mt613162.aspx).
 + Active Google account
 + [Azure Messaging Component]
 + [Google Cloud Messaging Client Component]

--- a/articles/storage/storage-xamarin-blob-storage.md
+++ b/articles/storage/storage-xamarin-blob-storage.md
@@ -55,8 +55,7 @@ For more information about shared access signatures, see the [SAS tutorial for .
 
 For this tutorial, we'll be creating our Xamarin application in Visual Studio. Follow these steps to create the application:
 
-1. Download and install [Visual Studio](https://www.visualstudio.com/).
-2. Download and install [Xamarin](http://xamarin.com/platform).
+1. Run the [Visual Studio 2015 installer](https://www.visualstudio.com/), selecting a **Custom** install and checking checking the box under **Cross-Platform Mobile Development > C#/.NET (Xamarin)**. If you already have Visual Studio installed, download and install [Xamarin](http://xamarin.com/platform) directly. For complete instructions for Visual Studio and Xamarin, see [Setup and Install](https://msdn.microsoft.com/en-US/library/mt613162.aspx) on MSDN.
 3. Open Visual Studio, and select **File > New > Project > Android > Blank App(Android)**.
 4. Right-click your project in the Solution Explorer pane and select **Manage NuGet Packages**. Then search for **Azure Storage** and install **Azure Storage 4.4.0-preview**.
 


### PR DESCRIPTION
We've recently published a new set of Xamarin installation instructions on MSDN, so I've gone through the Azure topics to find occurrences of setup instructions where I could point to MSDN. This allowed removal of such instructions from a number of topics and consolidation of pre-reqs in others.