### PR TITLE
fixed typo for keyvault set-policy parameters.

### DIFF
--- a/articles/key-vault/key-vault-manage-with-cli.md
+++ b/articles/key-vault/key-vault-manage-with-cli.md
@@ -185,11 +185,11 @@ To authorize the application to access the key or secret in the vault, use the `
 
 For example, if your vault name is ContosoKeyVault and the application you want to authorize has a client ID of 8f8c4bbd-485b-45fd-98f7-ec6300b7b4ed, and you want to authorize the application to decrypt and sign with keys in your vault, then run the following:
 
-    azure keyvault set-policy --vault-name 'ContosoKeyVault' --spn 8f8c4bbd-485b-45fd-98f7-ec6300b7b4ed --perm-to-keys '["decrypt","sign"]'
+    azure keyvault set-policy --vault-name 'ContosoKeyVault' --spn 8f8c4bbd-485b-45fd-98f7-ec6300b7b4ed --perms-to-keys '["decrypt","sign"]'
 
 If you want to authorize that same application to read secrets in your vault, run the following:
 
-	azure keyvault set-policy --vault-name 'ContosoKeyVault' --spn 8f8c4bbd-485b-45fd-98f7-ec6300b7b4ed --perm-to-secrets '["get"]'
+	azure keyvault set-policy --vault-name 'ContosoKeyVault' --spn 8f8c4bbd-485b-45fd-98f7-ec6300b7b4ed --perms-to-secrets '["get"]'
 
 ## If you want to use a hardware security module (HSM) ##
 


### PR DESCRIPTION
according to azure keyvault set-policy --help

help:      --perms-to-keys <perms-to-keys> 
JSON-encoded array of strings representing key operations; each string can be one of [all, create, import, update, delete, get, list, backup, restore, sign, verify, encrypt, decrypt, wrapKey, unwrapKey]

help:      --perms-to-secrets <perms-to-secrets>
JSON-encoded array of strings representing secret operations; each string can be one of [all, set, get, list, delete]