### PR TITLE
Resource groups are not what "we" call applications

### DIFF
--- a/articles/resource-group-template-deploy.md
+++ b/articles/resource-group-template-deploy.md
@@ -16,13 +16,13 @@
    ms.date="02/17/2016"
    ms.author="tomfitz"/>
 
-# Deploy an application with Azure Resource Manager template
+# Deploy a Resource Group with Azure Resource Manager template
 
-This topic explains how to use Azure Resource Manager templates to deploy your application to Azure. It shows how deploy your application by using either Azure PowerShell, Azure CLI, REST API, or the Azure portal.
+This topic explains how to use Azure Resource Manager templates to deploy your Resources to Azure. It shows how deploy your Resources by using either Azure PowerShell, Azure CLI, REST API, or the Azure portal.
 
 For an introduction to Resource Manager, see [Azure Resource Manager overview](./resource-group-overview.md). To learn about creating templates, see [Authoring Azure Resource Manager templates](resource-group-authoring-templates.md).
 
-When deploying an application with a template, you can provide parameter values to customize how the resources are created.  You specify values for these parameters either inline or in a parameter file.
+When deploying an application definition with a template, you can provide parameter values to customize how the resources are created.  You specify values for these parameters either inline or in a parameter file.
 
 ## Incremental and complete deployments
 


### PR DESCRIPTION
Having spoken to a few other readers of this article we have all been confused by the same thing. Nowhere in here is an application deployed. We are PROVISIONING resources so they are ready to receive the resources implementation that make up and application.