### PR TITLE
Fixed dead link in "Next Steps" section

### DIFF
--- a/articles/active-directory/active-directory-understanding-resource-access.md
+++ b/articles/active-directory/active-directory-understanding-resource-access.md
@@ -60,7 +60,7 @@ Operations such as moving resources between subscriptions can be more difficult 
 
 - To learn more about how to change administrators for an Azure subscription, see [How to add or change Azure administrator roles](../billing-add-change-azure-subscription-administrator.md)
 
-- For more information on how Azure Active Directory relates to your Azure subscription, see [How Azure subscriptions are associated with Azure Active Directory](active-directory-how-subscriptions-associated directory.md)
+- For more information on how Azure Active Directory relates to your Azure subscription, see [How Azure subscriptions are associated with Azure Active Directory](active-directory-how-subscriptions-associated-directory.md)
 
 - For more information on how to assign roles in Azure AD, see [Assigning administrator roles in Azure Active Directory](active-directory-assign-admin-roles.md)
 


### PR DESCRIPTION
There was a dead link in the Next Steps section, a - was missing.