### PR TITLE
Update notification-hubs-portal-create-new-hub.md

### DIFF
--- a/includes/notification-hubs-portal-create-new-hub.md
+++ b/includes/notification-hubs-portal-create-new-hub.md
@@ -1,6 +1,6 @@
 
 
-1. Log on to the [Azure Portal](https://portal.windowsazure.com/), and then click **+NEW** at the bottom of the screen.
+1. Log on to the [Azure Portal](https://portal.azure.com)/, and then click **+NEW** at the bottom of the screen.
 
 2. Click on **New**, then **Web + Mobile**, then **Notification Hub**, then **Quick Create**.
 


### PR DESCRIPTION
Currently portal.azure is linking to portal.windowsazure.com which no longer resolves. Moved to portal.azure.com

"unable to resolve host address ‘portal.windowsazure.com’"