### PR TITLE
Fix link to Azure Storage Explorer

### DIFF
--- a/articles/marketplace-publishing/marketplace-publishing-vm-image-creation.md
+++ b/articles/marketplace-publishing/marketplace-publishing-vm-image-creation.md
@@ -632,7 +632,7 @@ After you are done with the SKU details, you can move forward to the [Azure Mark
 
 [link-pushstaging]:marketplace-publishing-push-to-staging.md
 [link-github-waagent]:https://github.com/Azure/WALinuxAgent
-[link-azure-codeplex]:http://storageexplorer.com/
+[link-azure-codeplex]:https://azurestorageexplorer.codeplex.com/
 [link-azure-2]:../storage/storage-dotnet-shared-access-signature-part-2/
 [link-azure-1]:../storage/storage-dotnet-shared-access-signature-part-1/
 [link-msft-download]:http://www.microsoft.com/download/details.aspx?id=44299


### PR DESCRIPTION
The link to Azure Storage Explorer was pointing to the wrong tool (http://storageexplorer.com/ instead of https://azurestorageexplorer.codeplex.com/). This causes much confusion as the screen captures do not match.