### PR TITLE
Update hdinsight-apache-spark-intellij-tool-plugin.md

### DIFF
--- a/articles/hdinsight/hdinsight-apache-spark-intellij-tool-plugin.md
+++ b/articles/hdinsight/hdinsight-apache-spark-intellij-tool-plugin.md
@@ -216,7 +216,6 @@ While running the local Spark Scala application on a Windows computer, you might
 
 		![Create Spark Scala application](./media/hdinsight-apache-spark-intellij-tool-plugin/hdi-scala-local-project-details.png)
 
-
 3. Define the project structure to create an artifact (packaged jar) that will eventually contain the code that runs on the cluster. 
 
 	1. From the **File** menu, click **Project Structure**.

--- a/articles/hdinsight/hdinsight-apache-spark-intellij-tool-plugin.md
+++ b/articles/hdinsight/hdinsight-apache-spark-intellij-tool-plugin.md
@@ -205,8 +205,6 @@ While running the local Spark Scala application on a Windows computer, you might
 
 2. In the next window, provide the project details.
 
-	![Create Spark Scala application](./media/hdinsight-apache-spark-intellij-tool-plugin/hdi-scala-local-project-details.png)
-
 	* Provide a project name and project location.
 	* For **Project SDK**, make sure you provide a Java version greater than 7.
 	* For **Scala SDK**, click **Create**, click **Download**, and then select the version of Scala to use. **Make sure you do not use version 2.11.x**. This sample uses version **2.10.6**.
@@ -215,6 +213,9 @@ While running the local Spark Scala application on a Windows computer, you might
 
 	* For **Spark SDK**, download and use the SDK from [here](http://go.microsoft.com/fwlink/?LinkID=723585&clcid=0x409).
 	* Click **Finish**.
+
+		![Create Spark Scala application](./media/hdinsight-apache-spark-intellij-tool-plugin/hdi-scala-local-project-details.png)
+
 
 3. Define the project structure to create an artifact (packaged jar) that will eventually contain the code that runs on the cluster. 
 

--- a/articles/hdinsight/hdinsight-apache-spark-intellij-tool-plugin.md
+++ b/articles/hdinsight/hdinsight-apache-spark-intellij-tool-plugin.md
@@ -79,7 +79,7 @@ If IntelliJ IDEA installation did not not prompt for enabling Scala plugin, laun
 
 	* For **Spark SDK**, download and use the SDK from [here](http://go.microsoft.com/fwlink/?LinkID=723585&clcid=0x409).
 
-	![Create Spark Scala application](./media/hdinsight-apache-spark-intellij-tool-plugin/hdi-scala-project-details.png)
+		![Create Spark Scala application](./media/hdinsight-apache-spark-intellij-tool-plugin/hdi-scala-project-details.png)
 
 	* Click **Finish**.
 

--- a/articles/hdinsight/hdinsight-apache-spark-intellij-tool-plugin.md
+++ b/articles/hdinsight/hdinsight-apache-spark-intellij-tool-plugin.md
@@ -71,8 +71,6 @@ If IntelliJ IDEA installation did not not prompt for enabling Scala plugin, laun
 
 2. In the next window, provide the project details.
 
-	![Create Spark Scala application](./media/hdinsight-apache-spark-intellij-tool-plugin/hdi-scala-project-details.png)
-
 	* Provide a project name and project location.
 	* For **Project SDK**, make sure you provide a Java version greater than 7.
 	* For **Scala SDK**, click **Create**, click **Download**, and then select the version of Scala to use. **Make sure you do not use version 2.11.x**. This sample uses version **2.10.6**.
@@ -80,6 +78,9 @@ If IntelliJ IDEA installation did not not prompt for enabling Scala plugin, laun
 		![Create Spark Scala application](./media/hdinsight-apache-spark-intellij-tool-plugin/hdi-scala-version.png)
 
 	* For **Spark SDK**, download and use the SDK from [here](http://go.microsoft.com/fwlink/?LinkID=723585&clcid=0x409).
+
+	![Create Spark Scala application](./media/hdinsight-apache-spark-intellij-tool-plugin/hdi-scala-project-details.png)
+
 	* Click **Finish**.
 
 3. Define the project structure to create an artifact (packaged jar) that will eventually contain the code that runs on the cluster. 


### PR DESCRIPTION
The picture takes up to much space where it is, and is confusing because this not what a first time user will see. By moving the picture down, one will read all the steps before seeing the picture, which shows all the configs set up.