### PR TITLE
Update websites-dotnet-webjobs-sdk-service-bus.md

### DIFF
--- a/articles/app-service-web/websites-dotnet-webjobs-sdk-service-bus.md
+++ b/articles/app-service-web/websites-dotnet-webjobs-sdk-service-bus.md
@@ -65,7 +65,7 @@ To write a function that the WebJobs SDK calls when a queue message is received,
 
 The SDK receives a message in `PeekLock` mode and calls `Complete` on the message if the function finishes successfully, or calls `Abandon` if the function fails. If the function runs longer than the `PeekLock` timeout, the lock is automatically renewed.
 
-Serice Bus does its own poison queue handling, so that is neither controlled by, nor configurable in, the WebJobs SDK. 
+Service Bus does its own poison queue handling, so that is neither controlled by, nor configurable in, the WebJobs SDK. 
 
 ### String queue message
 

--- a/articles/app-service-web/websites-dotnet-webjobs-sdk-service-bus.md
+++ b/articles/app-service-web/websites-dotnet-webjobs-sdk-service-bus.md
@@ -65,7 +65,7 @@ To write a function that the WebJobs SDK calls when a queue message is received,
 
 The SDK receives a message in `PeekLock` mode and calls `Complete` on the message if the function finishes successfully, or calls `Abandon` if the function fails. If the function runs longer than the `PeekLock` timeout, the lock is automatically renewed.
 
-Service Bus does its own poison queue handling, so that is neither controlled by, nor configurable in, the WebJobs SDK. 
+Service Bus does its own poison queue handling which cannot be controlled or configured by the WebJobs SDK. 
 
 ### String queue message
 


### PR DESCRIPTION
Minor spelling correction (related to Azure/azure-content#5551) and revised service bus statement to plain english.