### PR TITLE
Adding step to .NET SDK samples

### DIFF
--- a/articles/hdinsight/hdinsight-hadoop-create-linux-clusters-dotnet-sdk.md
+++ b/articles/hdinsight/hdinsight-hadoop-create-linux-clusters-dotnet-sdk.md
@@ -48,8 +48,9 @@ The HDInsight .NET SDK provides .NET client libraries that make it easier to wor
 
 6. Run the following command in the console to install the packages:
 
-        Install-Package Microsoft.Azure.Common.Authentication -pre
+        Install-Package Microsoft.Azure.Common.Authentication -Pre
         Install-Package Microsoft.Azure.Management.HDInsight -Pre
+        Install-Package Microsoft.Azure.Management.Resources -Pre
 
     These commands add .NET libraries and references to them to the current Visual Studio project.
 
@@ -63,6 +64,7 @@ The HDInsight .NET SDK provides .NET client libraries that make it easier to wor
         using Microsoft.Azure.Common.Authentication.Models;
         using Microsoft.Azure.Management.HDInsight;
         using Microsoft.Azure.Management.HDInsight.Models;
+        using Microsoft.Azure.Management.Resources;
 
         namespace CreateHDInsightCluster
         {
@@ -100,6 +102,9 @@ The HDInsight .NET SDK provides .NET client libraries that make it easier to wor
 
                     var tokenCreds = GetTokenCloudCredentials();
                     var subCloudCredentials = GetSubscriptionCloudCredentials(tokenCreds, SubscriptionId);
+                    
+                    var resourceManagementClient = new ResourceManagementClient(subCloudCredentials);
+                    var rpResult = resourceManagementClient.Providers.Register("Microsoft.HDInsight");
 
                     _hdiManagementClient = new HDInsightManagementClient(subCloudCredentials);
 

--- a/articles/hdinsight/hdinsight-hadoop-create-windows-clusters-dotnet-sdk.md
+++ b/articles/hdinsight/hdinsight-hadoop-create-windows-clusters-dotnet-sdk.md
@@ -42,8 +42,9 @@ The application requires an Azure resource group, and the default storage accoun
 1. Create a new C# console application in Visual Studio.
 2. Run the following Nuget command in the Nuget Package Management console.
 
-		Install-Package Microsoft.Azure.Common.Authentication -pre
+		Install-Package Microsoft.Azure.Common.Authentication -Pre
 		Install-Package Microsoft.Azure.Management.HDInsight -Pre
+		Install-Package Microsoft.Azure.Management.Resources -Pre
 
 6. From Solution Explorer, double-click **Program.cs** to open it, paste the following code, and provide values for the variables:
 
@@ -55,6 +56,7 @@ The application requires an Azure resource group, and the default storage accoun
 		using Microsoft.Azure.Common.Authentication.Models;
 		using Microsoft.Azure.Management.HDInsight;
 		using Microsoft.Azure.Management.HDInsight.Models;
+		using Microsoft.Azure.Management.Resources;
 		
 		namespace CreateHDInsightCluster
 		{
@@ -82,7 +84,10 @@ The application requires an Azure resource group, and the default storage accoun
 		
 					var tokenCreds = GetTokenCloudCredentials();
 					var subCloudCredentials = GetSubscriptionCloudCredentials(tokenCreds, SubscriptionId);
-		
+					
+					var resourceManagementClient = new ResourceManagementClient(subCloudCredentials);
+					resourceManagementClient.Providers.Register("Microsoft.HDInsight");
+					
 					_hdiManagementClient = new HDInsightManagementClient(subCloudCredentials);
 				
 					var parameters = new ClusterCreateParameters

--- a/articles/hdinsight/hdinsight-hadoop-customize-cluster.md
+++ b/articles/hdinsight/hdinsight-hadoop-customize-cluster.md
@@ -198,6 +198,7 @@ The following sample demonstrates how to install Spark on Windows based HDInsigh
 
 		Install-Package Microsoft.Azure.Management.HDInsight -Pre
 		Install-Package Microsoft.Azure.Common.Authentication -Pre
+		Install-Package Microsoft.Azure.Management.Resources -Pre
 
 2. Use the following using statements in the Program.cs file:
 
@@ -210,6 +211,7 @@ The following sample demonstrates how to install Spark on Windows based HDInsigh
 		using Microsoft.Azure.Common.Authentication;
 		using Microsoft.Azure.Common.Authentication.Factories;
 		using Microsoft.Azure.Common.Authentication.Models;
+		using Microsoft.Azure.Management.Resources;
 
 3. Place the code in the class with the following:
 
@@ -235,6 +237,9 @@ The following sample demonstrates how to install Spark on Windows based HDInsigh
 
             var tokenCreds = GetTokenCloudCredentials();
             var subCloudCredentials = GetSubscriptionCloudCredentials(tokenCreds, SubscriptionId);
+            
+            var resourceManagementClient = new ResourceManagementClient(subCloudCredentials);
+            resourceManagementClient.Providers.Register("Microsoft.HDInsight");
 
             _hdiManagementClient = new HDInsightManagementClient(subCloudCredentials);
 

--- a/articles/hdinsight/hdinsight-provision-clusters-v1.md
+++ b/articles/hdinsight/hdinsight-provision-clusters-v1.md
@@ -697,8 +697,9 @@ Create a self-signed certificate, install it on your workstation, and upload it 
 
 6. Run the following command in the console to install the packages:
 
-		Install-Package Microsoft.Azure.Common.Authentication -pre
+		Install-Package Microsoft.Azure.Common.Authentication -Pre
 		Install-Package Microsoft.Azure.Management.HDInsight -Pre
+		Install-Package Microsoft.Azure.Management.Resources -Pre
 
 	These commands add .NET libraries and references to them to the current Visual Studio project.
 
@@ -711,6 +712,7 @@ Create a self-signed certificate, install it on your workstation, and upload it 
 		using Microsoft.Azure.Common.Authentication.Models;
 		using Microsoft.Azure.Management.HDInsight;
 		using Microsoft.Azure.Management.HDInsight.Models;
+		using Microsoft.Azure.Management.Resources;
 
 		namespace CreateHDICluster
 		{
@@ -739,6 +741,9 @@ Create a self-signed certificate, install it on your workstation, and upload it 
 		        {
 		            var tokenCreds = GetTokenCloudCredentials();
 		            var subCloudCredentials = GetSubscriptionCloudCredentials(tokenCreds, SubscriptionId);
+		            
+		            var resourceManagementClient = new ResourceManagementClient(subCloudCredentials);
+		            resourceManagementClient.Providers.Register("Microsoft.HDInsight");
 		
 		            _hdiManagementClient = new HDInsightManagementClient(subCloudCredentials);
 		


### PR DESCRIPTION
Adding step to .NET SDK samples to register the user's subscription with HDInsight's resource provider (frontend). This is necessary because if users use the SDK prior to using the portal UI, then their application won't be able to interact with HDInsight, unless they register using this code.