### PR TITLE
set the correct plugin name

### DIFF
--- a/articles/app-service-mobile/app-service-mobile-cordova-how-to-use-client-library.md
+++ b/articles/app-service-mobile/app-service-mobile-cordova-how-to-use-client-library.md
@@ -31,7 +31,7 @@ tutorials. This guide also assumes that you have added the Apache Cordova Plugin
 Cordova plugin to your project on the command-line:
 
 ```
-cordova plugin add ms-azure-mobile-apps
+cordova plugin add cordova-plugin-ms-azure-mobile-apps
 ```
 
 For more information on creating [your first Apache Cordova app], see their documentation.


### PR DESCRIPTION
Executing will this command will fail 

`cordova plugin add ms-azure-mobile-apps 
`

Since the name of the plugin is _cordova-plugin-ms-azure-mobile-apps_ according to the [npm registry](https://www.npmjs.com/package/cordova-plugin-ms-azure-mobile-apps)


