### PR TITLE
Fixed two errors in the ACL example code

### DIFF
--- a/articles/storage/storage-nodejs-how-to-use-queues.md
+++ b/articles/storage/storage-nodejs-how-to-use-queues.md
@@ -310,8 +310,8 @@ The following example gets the current ACL for **myqueue**, then adds the new po
 	queueSvc.getQueueAcl('myqueue', function(error, result, response) {
       if(!error){
 		//push the new policy into signedIdentifiers
-		result.signedIdentifiers.push(sharedAccessPolicy);
-		queueSvc.setQueueAcl('myqueue', result, function(error, result, response){
+		result.signedIdentifiers = result.signedIdentifiers.concat(sharedAccessPolicy);
+		queueSvc.setQueueAcl('myqueue', result.signedIdentifiers, function(error, result, response){
 	  	  if(!error){
 	    	// ACL set
 	  	  }


### PR DESCRIPTION
* `sharedAccessPlicy` from `queueSvc.getQueueAcl` is already an array, `result.signedIdentifiers.push(sharedAccessPlicy)` will result in `signedIdentifiers` being in `[[{}, {}]]` format.
* `queueSvc.setQueueAcl` accepts the `signedIdentifiers` as its second param, not the `result` object returned from previous call (verified from source)