### PR TITLE
Retrieval of connection string from web.config/app.config is wrong

### DIFF
--- a/includes/storage-dotnet-retrieve-conn-string.md
+++ b/includes/storage-dotnet-retrieve-conn-string.md
@@ -15,4 +15,4 @@ If you are creating an application with no reference to Microsoft.WindowsAzure.C
 	using System.Configuration;
 	...
 	CloudStorageAccount storageAccount = CloudStorageAccount.Parse(
-		ConfigurationManager.ConnectionStrings["StorageConnectionString"].ConnectionString);
+		ConfigurationManager.AppSettings["StorageConnectionString"]);


### PR DESCRIPTION
The code for retrieving the storage accounts connection string was wrong. The connection string should either be created under configuration > connectionStrings or the retrieval should point to appSettings. As there are multiple documents already referring to the string being stored under appSettings I propose to change the retrieval code here.