### PR TITLE
Corrected Get-AzureRmResource example

### DIFF
--- a/articles/resource-manager-template-links.md
+++ b/articles/resource-manager-template-links.md
@@ -71,7 +71,7 @@ To work with links through REST, see [Linked Resources](https://msdn.microsoft.c
 
 Use the following Azure PowerShell command to see all of the links in your subscription. You can provide other parameters to limit the results.
 
-    Get-AzureRmResource -ResourceType Microsoft.Resources/links -isCollection -OutputObjectFormat New
+    Get-AzureRmResource -ResourceType Microsoft.Resources/links -isCollection -ResourceGroupName <YourResourceGroupName>
 
 ## Examples
 


### PR DESCRIPTION
Corrected the PowerShell example of Get-AzureRmResource which was failing with the error: Get-AzureRmResource : A parameter cannot be found that matches parameter name 'OutputObjectFormat'.

This looks to be occurring due to an update to the cmdlet around 2nd December 2015 (https://github.com/Azure/azure-powershell/issues/638#issuecomment-161458310) which has removed the OutputObjectFormat parameter.