### PR TITLE
Update virtual-machines-extensions-configuration-samples-windows.md

### DIFF
--- a/articles/virtual-machines/virtual-machines-extensions-configuration-samples-windows.md
+++ b/articles/virtual-machines/virtual-machines-extensions-configuration-samples-windows.md
@@ -74,7 +74,7 @@ Before deploying the extension please check the latest extension version and rep
             "fileUris": [
                 "http: //Yourstorageaccount.blob.core.windows.net/customscriptfiles/start.ps1"
             ],
-            "commandToExecute": "powershell.exe-ExecutionPolicyUnrestricted-Filestart.ps1"
+            "commandToExecute": "powershell.exe-ExecutionPolicyUnrestricted-File start.ps1"
         }
     }
 


### PR DESCRIPTION
missing space, making it hard to identify what the difference is between the commandToExecute and the fileUris are.