### PR TITLE
[Azure Stack] Update the Azure PowerShell link

### DIFF
--- a/articles/azure-stack/azure-stack-sqlrp-deploy.md
+++ b/articles/azure-stack/azure-stack-sqlrp-deploy.md
@@ -72,7 +72,7 @@ To deploy a resource provider, your PowerShell ISE must be run as an administrat
 
 3. Open the Control Panel, click **Uninstall a program**, click the **Azure PowerShell** entry, and then click **Uninstall**.
 
-4. Download and install the latest Azure PowerShell from [http://aka.ms/webpi-azps](http://aka.ms/webpi-azps).
+4. Download and install the latest Azure PowerShell from [http://aka.ms/azStackPsh](http://aka.ms/azStackPsh).
 
 ## Create a wildcard certificate
 


### PR DESCRIPTION
The previous link would download the version 1.2.2, which doesn't support api version Azure stack use. Replace use the download link for version 1.2.1 instead.