### PR TITLE
[Azure Stack] Update the Azure PowerShell link

### DIFF
--- a/articles/azure-stack/azure-stack-mysqlrp-deploy.md
+++ b/articles/azure-stack/azure-stack-mysqlrp-deploy.md
@@ -58,7 +58,7 @@ To deploy a resource provider, your PowerShell ISE must be run as an administrat
 
 3. Open the Control Panel, click **Uninstall a program**, click the **Azure PowerShell** entry, and then click **Uninstall**.
 
-4. Download and install the latest Azure PowerShell from [http://aka.ms/webpi-azps](http://aka.ms/webpi-azps).
+4. Download and install the latest Azure PowerShell from [http://aka.ms/azStackPsh](http://aka.ms/azStackPsh).
 
 ### Enable certificates, marketplace items, and binaries
 


### PR DESCRIPTION
The previous link would download version 1.2.2, which doesn't support Azure Stack's api version. I use the version 1.2.1's forward link to replace it.