### PR TITLE
Newer Composer versions require https by default

### DIFF
--- a/includes/get-client-libraries.md
+++ b/includes/get-client-libraries.md
@@ -9,7 +9,7 @@
 	    "repositories": [
 	        {
 	            "type": "pear",
-	            "url": "http://pear.php.net"
+	            "url": "https://pear.php.net"
 	        }
 	    ],
 	    "require": {


### PR DESCRIPTION
https://pear.php.net works just fine, so use that.