### PR TITLE
proxy.SubscribeAsync<IGameEvents> example fix

### DIFF
--- a/articles/service-fabric/service-fabric-reliable-actors-events.md
+++ b/articles/service-fabric/service-fabric-reliable-actors-events.md
@@ -60,7 +60,7 @@ On the client, create a proxy to the actor that publishes the event and subscrib
 ```csharp
 var proxy = ActorProxy.Create<IGameActor>(
                     new ActorId(Guid.Parse(arg)), ApplicationName);
-proxy.SubscribeAsync(new GameEventsHandler()).Wait();
+proxy.SubscribeAsync<IGameEvents>(new GameEventsHandler()).Wait();
 ```
 
 In the event of failovers, the actor may fail over to a different process or node. The actor proxy manages the active subscriptions and automatically re-subscribes them. You can control the re-subscription interval through the `ActorProxyEventExtensions.SubscribeAsync<TEvent>` API. To unsubscribe, use the `ActorProxyEventExtensions.UnsubscribeAsync<TEvent>` API.


### PR DESCRIPTION
SubscribeAsync<TEvent>

Summary:
Subscribe to a published actor event.

Type Parameters:
TEvent: The type of the event interface.