### PR TITLE
Added Azure warning for generalized machines for azure-content/articles/virtual-machines/virtual-machines-windows-capture-image.md

### DIFF
--- a/articles/virtual-machines/virtual-machines-windows-capture-image.md
+++ b/articles/virtual-machines/virtual-machines-windows-capture-image.md
@@ -26,6 +26,11 @@
 This article shows you how to use the Azure PowerShell to capture an Azure virtual machine running Windows so you can use it to create other virtual machines. This image includes the OS disk and data disks attached to the virtual machine. It doesn't include the virtual network resources you'll need to create a Windows VM, so you'll need to set those up before you create another virtual machine that uses the image. This image will also be prepared to be a [generalized Windows image](https://technet.microsoft.com/library/hh824938.aspx).
 
 
+> [AZURE.WARNING] The virtual machine cannot be started after it has been generalized.
+
+The virtual machine stays at a stopped(deallocated) state and this process is irreverible. Beware of this fact, although it should not affect your projects, since you can create multiple copies of the original virtual machine.
+ 
+
 ## Prerequisites
 
 These steps assume that you've already created an Azure virtual machine in the Resource Manager deployment model and configured the operating system, including attaching any data disks and making other customizations like installing applications. If you haven't done this yet, read [How to create a Windows VM with Resource Manager and PowerShell](virtual-machines-windows-ps-create.md). You can just as easily create a Windows virtual machine using the [Azure portal](https://portal.azure.com). Read [How to create a Windows virtual machine in the Azure portal](virtual-machines-windows-hero-tutorial.md).


### PR DESCRIPTION
It has been asked a lot (and I has the question myself) whether you can start the original VM after it has been generalized and after a lot of reading and PowerShell efforts, I have come to the conclusion that you cannot. I think there should this warning on the guide, to inform users that the stopped VM is in an irreversible state, to take proactive action.

@tysonn How do you feel about this? I think it is very important because this search to confirm took a well 4 hours!