### PR TITLE
Corrected Selecting Azure Resource Manager Subscription

### DIFF
--- a/articles/virtual-machines/virtual-machines-windows-create-powershell.md
+++ b/articles/virtual-machines/virtual-machines-windows-create-powershell.md
@@ -57,7 +57,7 @@ Get your subscription name using the following command.
 Set your Azure subscription. Replace everything within the quotes, including the < and > characters, with the correct names.
 
 	$subscr="<subscription name>"
-	Select-AzureSubscription -SubscriptionName $subscr –Current
+	Select-AzureRMSubscription -SubscriptionName $subscr
 
 
 ## Step 3: Create resources


### PR DESCRIPTION
Corrected syntax to use Select-AzureRMSubscription otherwise the subscription does not get picked up in the context of Resource Manager and will default to whatever subscription is selected when using Select-AzureSubscription.  Problematic when you have multiple subscriptions.