### PR TITLE
Remove all default settings

### DIFF
--- a/articles/virtual-machines/virtual-machines-linux-mac-create-ssh-keys.md
+++ b/articles/virtual-machines/virtual-machines-linux-mac-create-ssh-keys.md
@@ -170,18 +170,6 @@ Host github.private
   PubKeyAuthentication yes
   IdentityFile /Users/steve/.ssh/private_repo_github_id_rsa
 # ./Github Keys
-# Default Settings
-Host *
-  PubkeyAuthentication=no
-  IdentitiesOnly=yes
-  ServerAliveInterval=60
-  ServerAliveCountMax=30
-  ControlMaster auto
-  ControlPath /Users/steve/.ssh/Connections/ssh-%r@%h:%p
-  ControlPersist 4h
-  StrictHostKeyChecking=no
-  IdentityFile /Users/steve/.ssh/id_rsa
-  UseRoaming=no
 ```
 
 This SSH config gives you sections for each service to enable each to have its own dedicated key pair. The default settings are for any hosts that you are logged into that do not match any of the above groups. The SSH config also enables you to have two separate [GitHub](https://github.com) logins, one for public work and a second just for private repos that may be common at your work.


### PR DESCRIPTION
SSH has perfectly good defaults already, but in particular why would you set a default to prevent PubKeyAuthentication. I've wasted significant time trying to help Mac users log into their service. I was struck by how many had this setting and eventually tracked it down to this file. It's really not a good idea to turn off key auth when in an article about how to do key auth. This would require the user to edit the config file every time they create a new SSH connection. 

Similarly, why would we turn strict host authentication off by default? Are we trying to encourage man-in-the-middle attacks?