### PR TITLE
VCRedist not required, clipboard fix

### DIFF
--- a/articles/service-fabric/service-fabric-cluster-creation-for-windows-server.md
+++ b/articles/service-fabric/service-fabric-cluster-creation-for-windows-server.md
@@ -52,7 +52,6 @@ Pre-requisites for each machine that you want to add to the cluster:
 - Windows Server 2012 R2 or Windows Server 2012 (you need to have KB2858668 installed for this).
 - .NET Framework 4.5.1 or higher, full install
 - Windows PowerShell 3.0
-- Visual C++ 2012 (VC++ 11.0) Redistributable Package
 - The cluster administrator deploying and configuring the cluster must have administrator privileges on each of the computers.
 
 ### Step 3: Determine the initial cluster size
@@ -101,7 +100,7 @@ Once you have modified the cluster configuration in the JSON doc and added all t
 This script can be run on any machine that has admin access to all the machines that are listed as nodes in the cluster configuration file. The machine that this script is run on may or may not be part of the cluster.
 
 ```
-C:\Microsoft.Azure.ServiceFabric.WindowsServer.5.0.135.9590> .\CreateServiceFabricCluster.ps1 -ClusterConfigFilePath C:\Microsoft.Azure.ServiceFabric.WindowsServer.5.0.135.9590\ClusterConfig.JSON -MicrosoftServiceFabricCabFilePath C:\Microsoft.Azure.ServiceFabric.WindowsServer.5.0.135.9590\MicrosoftAzureServiceFabric.cab
+.\CreateServiceFabricCluster.ps1 -ClusterConfigFilePath C:\Microsoft.Azure.ServiceFabric.WindowsServer.5.0.135.9590\ClusterConfig.JSON -MicrosoftServiceFabricCabFilePath C:\Microsoft.Azure.ServiceFabric.WindowsServer.5.0.135.9590\MicrosoftAzureServiceFabric.cab
 ```
 
 ## Next steps


### PR DESCRIPTION
1. vcredist package gets autoinstalled as part of DeployAnywhere FabricSetup, since this is included in the CAB package.
2. Since the CreateServiceFabricCluster cmdlet is inside a "copy to clipboard" type frame, the content inside should be usable without modification. The prompt is also written to clipboard, which will have to be removed by user.