### PR TITLE
Fix indentation in documentdb-dotnet-application.md

### DIFF
--- a/articles/documentdb/documentdb-dotnet-application.md
+++ b/articles/documentdb/documentdb-dotnet-application.md
@@ -335,7 +335,7 @@ The first thing to do here is add a class that contains all the logic to connect
 			}
 		}
 
-		> [AZURE.TIP] When creating a new DocumentCollection you can supply an optional RequestOptions parameter of OfferType, which allows you to specify the performance level of the new collection. If this parameter is not passed the default offer type will be used. For more on DocumentDB offer types please refer to [DocumentDB Performance Levels](documentdb-performance-levels.md)
+	> [AZURE.TIP] When creating a new DocumentCollection you can supply an optional RequestOptions parameter of OfferType, which allows you to specify the performance level of the new collection. If this parameter is not passed the default offer type will be used. For more on DocumentDB offer types please refer to [DocumentDB Performance Levels](documentdb-performance-levels.md)
 
 3. We're reading some values from configuration, so open the **Web.config** file of your application and add the following lines under the `<AppSettings>` section.
 	


### PR DESCRIPTION
Fixes indentation problem that was making the RequestOptions parameter tip display as part of the code sample