### PR TITLE
modified the max # of replicas to 12 from 6

### DIFF
--- a/articles/search/search-capacity-planning.md
+++ b/articles/search/search-capacity-planning.md
@@ -91,7 +91,7 @@ Currently, there is no built-in mechanism for disaster recovery. Adding partitio
 
 **Partitions** provide storage and IO. A single Search service can have a maximum of 12 partitions. Each partition comes with a hard limit of 15 million documents or 25 GB of storage, whichever comes first. If you add partitions, your Search service can load more documents. For example, a service with a single partition that initially stores up to 25 GB of data can store 50 GB when you add a second partition to the service.
 
-**Replicas** are copies of the search engine. A single Search service can have a maximum of 6 replicas. You need at least 2 replicas for read (query) availability, and at least 3 replicas for read-write (query, indexing) availability.
+**Replicas** are copies of the search engine. A single Search service can have a maximum of 12 replicas. You need at least 2 replicas for read (query) availability, and at least 3 replicas for read-write (query, indexing) availability.
 
 A copy of each index runs on each replica. As you add replicas, additional copies of the index are brought online to support greater query workloads and to load balance the requests over the multiple replicas. If you have multiple indexes, say 6, and 3 replicas, each replica will have a copy of all 6 indexes.
 


### PR DESCRIPTION
I read ' Capacity planning in Azure Search' page and  found a wrong number in the following sentence:

Replicas are copies of the search engine. A single Search service can have a maximum of **6** replicas.
doc ref: https://azure.microsoft.com/en-us/documentation/articles/search-capacity-planning/

I believe actual max number of replica is** 12 **at this moment. 

Please review this. 


