### PR TITLE
Update Azure SQL Database resource limits

### DIFF
--- a/articles/sql-database/sql-database-resource-limits.md
+++ b/articles/sql-database/sql-database-resource-limits.md
@@ -60,6 +60,8 @@ For an expanded definition of each resource listed in the previous tables, see t
 | Area | Limit | Description |
 |---|---|---|
 | Databases using Automated export per subscription | 10 | Automated export allows you to create a custom schedule for backing up your SQL databases. For more information, see [SQL Databases: Support for Automated SQL Database Exports](http://weblogs.asp.net/scottgu/windows-azure-july-updates-sql-database-traffic-manager-autoscale-virtual-machines).|
+| Database per server | Up to 5000 | Up to 5000 databases are allowed per server on V12 servers. Lower limits may apply in practice depending on log-in activity across all databases on the server and query usage on system views in the master database. Customers are recommended to monitor database connections for any issues when significantly increasing the number of databases on a server. |
+| DTUs per server | 45000 | 45000 DTUs are available per server on V12 servers for provisioning databases, elastic pools and data warehouses. |
 
 ## Resources
 


### PR DESCRIPTION
Added two item limits "database per server" and "DTUs per server" to the existing "Other SQL Database limits" table.

- Databases per server: up to 5000

- DTUs per server: 45000