### PR TITLE
Update data-factory-use-custom-activities.md

### DIFF
--- a/articles/data-factory/data-factory-use-custom-activities.md
+++ b/articles/data-factory/data-factory-use-custom-activities.md
@@ -543,7 +543,7 @@ In this step, you will create datasets to represent input and output data.
 		    }
 		}
 
- 	Output location is **adftutorial/customactivityoutput/YYYYMMDDHH/** where YYYYMMDDHH is the year, month, date, and hour of the slice being produced. See [Developer Reference][adf-developer-reference] for details.
+ 	Output location is **adftutorial/customactivityoutput/** and output file name is yyyy-MM-dd-HH.txt where yyyy-MM-dd-HH is the year, month, date, and hour of the slice being produced. See [Developer Reference][adf-developer-reference] for details.
 
 	An output blob/file is generated for each input slice. Here is how an output file is named for each slice. All the output files are generated in one output folder: **adftutorial\customactivityoutput**.
 


### PR DESCRIPTION
I propose a change as following as the sample creates a file dynamically but folder name is static. 

>> Output location is **adftutorial/customactivityoutput/YYYYMMDDHH/** where YYYYMMDDHH is the year, month, date, and hour of the slice being produced. See [Developer Reference][adf-developer-reference] for details.

to 

>>Output location is **adftutorial/customactivityoutput/** and output file name is yyyy-MM-dd-HH.txt where yyyy-MM-dd-HH is the year, month, date, and hour of the slice being produced. See [Developer Reference][adf-developer-reference] for details.