### PR TITLE
Update service-bus-event-hubs-get-started-send-c.md

### DIFF
--- a/includes/service-bus-event-hubs-get-started-send-c.md
+++ b/includes/service-bus-event-hubs-get-started-send-c.md
@@ -13,7 +13,7 @@ In this section we will write a C app to send events to your Event Hub. We will 
 3. Download the [Qpid Proton library](http://qpid.apache.org/proton/index.html) library, and extract it, e.g.:
 
 	```
-	wget http://apache.fastbull.org/qpid/proton/0.7/qpid-proton-0.7.tar.gz
+	wget http://archive.apache.org/dist/qpid/proton/0.7/qpid-proton-0.7.tar.gz
 	tar xvfz qpid-proton-0.7.tar.gz
 	```
 


### PR DESCRIPTION
The Qpid Proton 0.7 tar.gz file was moved under archive path on Apache org. The previous link isn't available anymore so the user can't finish this guide in the right way.