### PR TITLE
Fixed ExpressRoute commands

### DIFF
--- a/articles/expressroute/expressroute-howto-linkvnet-arm.md
+++ b/articles/expressroute/expressroute-howto-linkvnet-arm.md
@@ -75,7 +75,7 @@ The circuit owner creates an authorization. This results in the creation of an a
 
 The cmdlet snippet below shows how to create an authorization. 
 
-	Add-AzureRmExpressRouteCircuitAuthorization -Circuit $circuit -Name "MyAuthorization1"
+	Add-AzureRmExpressRouteCircuitAuthorization -ExpressRouteCircuit $circuit -Name "MyAuthorization1"
 	Set-AzureRmExpressRouteCircuit -ExpressRouteCircuit $circuit
 	$circuit = Get-AzureRmExpressRouteCircuit -Name "MyCircuit" -ResourceGroupName "MyRG"
 
@@ -106,7 +106,7 @@ The circuit owner can review all authorizations issued on a particular circuit b
 The circuit owner can add authorizations using the following cmdlet.
 
 	$circuit = Get-AzureRmExpressRouteCircuit -Name "MyCircuit" -ResourceGroupName "MyRG"
-	Add-AzureRmExpressRouteCircuitAuthorization -Circuit $circuit -Name "MyAuthorization2"
+	Add-AzureRmExpressRouteCircuitAuthorization -ExpressRouteCircuit $circuit -Name "MyAuthorization2"
 	Set-AzureRmExpressRouteCircuit -ExpressRouteCircuit $circuit
 	
 	$circuit = Get-AzureRmExpressRouteCircuit -Name "MyCircuit" -ResourceGroupName "MyRG"
@@ -117,7 +117,7 @@ The circuit owner can add authorizations using the following cmdlet.
 
 The circuit owner can revoke/delete authorizations to the user by running the following cmdlet.
 
-	Remove-AzureRmExpressRouteCircuitAuthorization -Name "MyAuthorization2" -Circuit $circuit
+	Remove-AzureRmExpressRouteCircuitAuthorization -Name "MyAuthorization2" -ExpressRouteCircuit $circuit
 	Set-AzureRmExpressRouteCircuit -ExpressRouteCircuit $circuit	
 
 ### Circuit user operations


### PR DESCRIPTION
Several ExpressRoute commands were using -Circuit instead of -ExpressRouteCircuit. This PR addresses those.