### PR TITLE
Update data-factory-create-datasets.md

### DIFF
--- a/articles/data-factory/data-factory-create-datasets.md
+++ b/articles/data-factory/data-factory-create-datasets.md
@@ -140,7 +140,7 @@ The availability section below specifies that the dataset is either produced hou
 	"availability":	
 	{	
 		"frequency": "Hour",		
-		"interval": "1",	
+		"interval": 1	
 	}
 
 The following table describes properties you can use in the availability section. 


### PR DESCRIPTION
There is no need for comma as it doesn't have next parameter and 1 instead "1" because it requires to be integer. 

> "interval": "1", to "interval": 1