### PR TITLE
Update service-fabric-reliable-actors-platform.md

### DIFF
--- a/articles/service-fabric/service-fabric-reliable-actors-platform.md
+++ b/articles/service-fabric/service-fabric-reliable-actors-platform.md
@@ -173,7 +173,20 @@ class MyActorService : ActorService, IMyActorService
 
     public Task BackupActorsAsync()
     {
-        return this.BackupAsync(new BackupDescription(...));
+        return this.BackupAsync(new BackupDescription(PerformBackupAsync));
+    }
+    
+    private async Task<bool> PerformBackupAsync(BackupInfo backupInfo, CancellationToken cancellationToken)
+    {
+        try
+        {
+           // store the contents of backupInfo.Directory
+           return true;
+        }
+        finally
+        {
+           Directory.Delete(backupInfo.Directory, recursive: true);
+        }
     }
 }
 ```


### PR DESCRIPTION
Due to a bug, actor backup directories are not deleted, and will blow up your disk unless you delete them manually.
Updating the sample to reflect that until the bug is fixed.