### PR TITLE
Update service-fabric-cluster-creation-via-portal.md

### DIFF
--- a/articles/service-fabric/service-fabric-cluster-creation-via-portal.md
+++ b/articles/service-fabric/service-fabric-cluster-creation-via-portal.md
@@ -77,7 +77,8 @@ In the Basics blade you need to provide the basic details for your cluster.
 	b. Select the VM size/pricing tier. The default is D4 Standard, but if you are just going to use this cluster for testing your application, you can select D2 or any smaller VM.
 
 	c. The minumum number of VMs for the primary node type is driven by the reliablity tier you choose. The default for the reliablity tier is Silver. Read more on how to [choose the Service Fabric cluster reliability and durability](service-fabric-cluster-reliability-and-durability.md) document.
-
+	##BROKEN LINK###
+	
 	c. Choose the number of VMs for the node type. You can scale up or down the number of VMs in a node type later on, but on the primary node type, the minumum is driven by the reliablity level that you have choosen. Other node types can have a minumum of 1 VM.
 
 


### PR DESCRIPTION
The link for this content is broken:
```c. The minumum number of VMs for the primary node type is driven by the reliablity tier you choose. The default for the reliablity tier is Silver. Read more on how to [choose the Service Fabric cluster reliability and durability](service-fabric-cluster-reliability-and-durability.md) document.```