### PR TITLE
Added custom RBAC role to tenant relationship details

### DIFF
--- a/articles/active-directory/role-based-access-control-custom-roles.md
+++ b/articles/active-directory/role-based-access-control-custom-roles.md
@@ -20,7 +20,7 @@
 # Custom Roles in Azure RBAC
 
 
-Create a custom role in Azure Role-Based Access Control (RBAC) if none of the built-in roles meet your specific access needs. Custom roles can be created using [Azure PowerShell](role-based-access-control-manage-access-powershell.md), [Azure Command-Line Interface](role-based-access-control-manage-access-azure-cli.md) (CLI), and the [REST API](role-based-access-control-manage-access-rest.md). Just like built-in roles, custom roles can be assigned to users, groups, and applications at subscription, resource group, and resource scopes. Custom roles are stored in an Azure AD tenant and are shared across all subscriptions that use that tenant as the Azure AD directory for the subsciption. 
+Create a custom role in Azure Role-Based Access Control (RBAC) if none of the built-in roles meet your specific access needs. Custom roles can be created using [Azure PowerShell](role-based-access-control-manage-access-powershell.md), [Azure Command-Line Interface](role-based-access-control-manage-access-azure-cli.md) (CLI), and the [REST API](role-based-access-control-manage-access-rest.md). Just like built-in roles, custom roles can be assigned to users, groups, and applications at subscription, resource group, and resource scopes. Custom roles are stored in an Azure AD tenant and can be shared across all subscriptions that use that tenant as the Azure AD directory for the subsciption. 
 
 The following is an example of a custom role for monitoring and restarting virtual machines:
 

--- a/articles/active-directory/role-based-access-control-custom-roles.md
+++ b/articles/active-directory/role-based-access-control-custom-roles.md
@@ -20,7 +20,7 @@
 # Custom Roles in Azure RBAC
 
 
-Create a custom role in Azure Role-Based Access Control (RBAC) if none of the built-in roles meet your specific access needs. Custom roles can be created using [Azure PowerShell](role-based-access-control-manage-access-powershell.md), [Azure Command-Line Interface](role-based-access-control-manage-access-azure-cli.md) (CLI), and the [REST API](role-based-access-control-manage-access-rest.md). Just like built-in roles, custom roles can be assigned to users, groups, and applications at subscription, resource group, and resource scopes.
+Create a custom role in Azure Role-Based Access Control (RBAC) if none of the built-in roles meet your specific access needs. Custom roles can be created using [Azure PowerShell](role-based-access-control-manage-access-powershell.md), [Azure Command-Line Interface](role-based-access-control-manage-access-azure-cli.md) (CLI), and the [REST API](role-based-access-control-manage-access-rest.md). Just like built-in roles, custom roles can be assigned to users, groups, and applications at subscription, resource group, and resource scopes. Custom roles are stored in an Azure AD tenant and are shared across all subscriptions that use that tenant as the Azure AD directory for the subsciption. 
 
 The following is an example of a custom role for monitoring and restarting virtual machines:
 


### PR DESCRIPTION
There weren't any details about the scope of how a custom RBAC role relates to an AAD tenant, so added a sentence to clarify this. Feedback welcome on if this needs to be made more clearly.