### PR TITLE
Fix typos in Import-PfxCertificate calls in service-fabric-cluster-security

### DIFF
--- a/articles/service-fabric/service-fabric-cluster-security.md
+++ b/articles/service-fabric/service-fabric-cluster-security.md
@@ -135,11 +135,11 @@ Invoke-AddCertToKeyVault -SubscriptionId 35389201-c0b3-405e-8a23-9f1450994307 -R
 Since it is a self-signed certificate, you will need to import it to your machine's "trusted people" store, before you can use this certificate to connect to a secure cluster.
 
 ```
-Import-PfxCertificate -Exportable -CertStoreLocation Cert:\CurrentUser\TrustedPeople -FilePath C:C:\MyCertificates\ChackdanTestCertificate.pfx -Password (Read-Host -AsSecureString -Prompt "Enter Certificate Password ")
+Import-PfxCertificate -Exportable -CertStoreLocation Cert:\CurrentUser\TrustedPeople -FilePath C:\MyCertificates\ChackdanTestCertificate.pfx -Password (Read-Host -AsSecureString -Prompt "Enter Certificate Password")
 ```
 
 ```
-Import-PfxCertificate -Exportable -CertStoreLocation Cert:\CurrentUser\My -FilePath C:C:\MyCertificates\ChackdanTestCertificate.pfx -Password (Read-Host -AsSecureString -Prompt "Enter Certificate Password ")
+Import-PfxCertificate -Exportable -CertStoreLocation Cert:\CurrentUser\My -FilePath C:\MyCertificates\ChackdanTestCertificate.pfx -Password (Read-Host -AsSecureString -Prompt "Enter Certificate Password")
 ```
 
 On successful completion of the script, you will get an output like the one below. You need these for Step 3.


### PR DESCRIPTION
- Fix extra space in Read-Host call
- Remove extra 'C:' in file path