### PR TITLE
Change author and service

### DIFF
--- a/articles/virtual-network/virtual-networks-arm-asm-s2s.md
+++ b/articles/virtual-network/virtual-networks-arm-asm-s2s.md
@@ -1,19 +1,19 @@
 <properties 
    pageTitle="How to connect classic VNets to ARM VNets in Azure - Solution Guide"
    description="Learn how to create a VPN connection between classic VNets and new VNets"
-   services="virtual-network"
+   services="vpn-gateway"
    documentationCenter="na"
-   authors="telmosampaio"
+   authors="cherylmc"
    manager="carmonm"
    editor="tysonn" />
 <tags 
-   ms.service="virtual-network"
+   ms.service="vpn-gateway"
    ms.devlang="na"
    ms.topic="article"
    ms.tgt_pltfrm="na"
    ms.workload="infrastructure-services"
    ms.date="03/15/2016"
-   ms.author="telmos" />
+   ms.author="cherylmc" />
 
 # Connecting classic VNets to new VNets
 


### PR DESCRIPTION
This article will stay in the virtual network folder until we properly redirect it so that we don't lose the Disqus comments before we have a chance to go through the article and refresh it. We're just changing the service and left nav to vpn gateway and the author to keep that information current and attached to the right service.