### PR TITLE
Site certificate should be installed into "My" store, not "CA" store

### DIFF
--- a/articles/cloud-services/cloud-services-configure-ssl-certificate-portal.md
+++ b/articles/cloud-services/cloud-services-configure-ssl-certificate-portal.md
@@ -65,7 +65,7 @@ Your application must be configured to use the certificate, and an HTTPS endpoin
             <Certificates>
                 <Certificate name="SampleCertificate" 
 							 storeLocation="LocalMachine" 
-                    		 storeName="CA"
+                    		 storeName="My"
                              permissionLevel="limitedOrElevated" />
                 <!-- IMPORTANT! Unless your certificate is either
                 self-signed or signed directly by the CA root, you


### PR DESCRIPTION
This is replay of changes from https://github.com/Azure/azure-content/pull/6246 for "blades" version of the portal.