### PR TITLE
Correct links in sql-database-in-memory-md

### DIFF
--- a/articles/sql-database/sql-database-in-memory.md
+++ b/articles/sql-database/sql-database-in-memory.md
@@ -107,7 +107,7 @@ You can create the AdventureWorksLT [V12] sample database by a few clicks in the
 
 2. Connect to the database with SQL Server Management Studio [(SSMS.exe)](http://msdn.microsoft.com/library/mt238290.aspx).
 
-3. Copy the [In-Memory OLTP Transact-SQL script](http://raw.githubusercontent.com/Azure/azure-sql-database-samples/master/T-SQL/In-Memory/sql_in-memory_oltp_sample.sql) to your clipboard.
+3. Copy the [In-Memory OLTP Transact-SQL script](https://raw.githubusercontent.com/Azure/azure-sql-database-samples/master/t-sql/In-Memory/sql_in-memory_oltp_sample.sql) to your clipboard.
  - The T-SQL script creates the necessary In-Memory objects in the AdventureWorksLT sample database you created in step 1.
 
 4. Paste the T-SQL script into SSMS, and the execute the script.
@@ -348,7 +348,7 @@ For real-time analytics on an OLTP workload, it is often best to use a NONcluste
  - Use that exact name.
  - Choose any Premium service tier.
 
-2. Copy the [sql_in-memory_analytics_sample](http://raw.githubusercontent.com/Azure/azure-sql-database-samples/master/T-SQL/In-Memory/sql_in-memory_analytics_sample.sql) to your clipboard.
+2. Copy the [sql_in-memory_analytics_sample](https://raw.githubusercontent.com/Azure/azure-sql-database-samples/master/t-sql/In-Memory/sql_in-memory_analytics_sample.sql) to your clipboard.
  - The T-SQL script creates the necessary In-Memory objects in the AdventureWorksLT sample database you created in step 1.
  - The script creates the Dimension table, and two fact tables. The fact tables are populated with 3.5 million rows each.
  - The script might take 15 minutes to complete.
@@ -371,7 +371,7 @@ For real-time analytics on an OLTP workload, it is often best to use a NONcluste
 #### Crucial queries to compare the columnstore index
 
 
-[Here](http://raw.githubusercontent.com/Azure/azure-sql-database-samples/master/T-SQL/In-Memory/clustered_columnstore_sample_queries.sql) are several T-SQL query types you can run to see performance improvements. From Step 2 in the T-SQL script there is a pair of queries that are of direct interest. The two queries differ only on one line:
+[Here](https://raw.githubusercontent.com/Azure/azure-sql-database-samples/master/t-sql/In-Memory/clustered_columnstore_sample_queries.sql) are several T-SQL query types you can run to see performance improvements. From Step 2 in the T-SQL script there is a pair of queries that are of direct interest. The two queries differ only on one line:
 
 
 - `FROM FactResellerSalesXL_PageCompressed a`


### PR DESCRIPTION
Links to the sample scripts for the OLTP and Analytic workloads as well as the sample queries were broken. Updated them with corrected links.