### PR TITLE
Typo fix in service-fabric-reliable-actors-introduction.md

### DIFF
--- a/articles/service-fabric/service-fabric-reliable-actors-introduction.md
+++ b/articles/service-fabric/service-fabric-reliable-actors-introduction.md
@@ -47,7 +47,7 @@ Service Fabric actors are virtual, meaning that their lifetime is not tied to th
 
 This virtual actor lifetime abstraction carries some caveats as a result of the virtual actor model, and in fact the Reliable Actors implementation deviates at times from this model.
 
- - An actor is automatically activated (causing an actor object to be contructed) the first time a message is sent to its actor ID. After some period of time, the actor object is garbage collected. In the future, using the actor ID again, causes a new actor object to be constructed. An actor's state outlives the object's lifetime when stored in the state manager.
+ - An actor is automatically activated (causing an actor object to be constructed) the first time a message is sent to its actor ID. After some period of time, the actor object is garbage collected. In the future, using the actor ID again, causes a new actor object to be constructed. An actor's state outlives the object's lifetime when stored in the state manager.
  
  - Calling any actor method for an actor ID activates that actor. For this reason, actor types have their constructor called implicitly by the runtime. Therefore, client code cannot pass parameters to the actor type's constructor, although parameters may be passed to the actor's constructor by the service itself. The result is that actors may be constructed in a partially-initialized state by the time other methods are called on it, if the actor requires initialization parameters from the client. There is no single entry point for the activation of an actor from the client.
 


### PR DESCRIPTION
Looks like github added a line break at the end. Sorry :disappointed: