### PR TITLE
Fixing broken link

### DIFF
--- a/articles/virtual-machines/virtual-machines-windows-ps-migration-classic-resource-manager.md
+++ b/articles/virtual-machines/virtual-machines-windows-ps-migration-classic-resource-manager.md
@@ -135,6 +135,6 @@ If the prepared configuration looks good, you can move forward and Commit the re
 
 ## References
 
-- [Platform supported migration of IaaS resources from Classic to Resource Manager](virtual-machines-windows-migration-classic-resource-manager-arm.md)
+- [Platform supported migration of IaaS resources from Classic to Resource Manager](virtual-machines-windows-migration-classic-resource-manager.md)
 - [Technical Deep Dive on Platform supported migration from Classic to Resource Manager](virtual-machines-windows-migration-classic-resource-manager-deep-dive.md)
 - [Clone a classic Virtual Machine to Azure Resource Manager using Community PowerShell Scripts](virtual-machines-windows-migration-scripts.md)


### PR DESCRIPTION
Article naming change broke all the embedded links in the article. Updating it. 