### PR TITLE
Include troubleshooting note for nodejs

### DIFF
--- a/articles/xplat-cli-install.md
+++ b/articles/xplat-cli-install.md
@@ -63,6 +63,11 @@ Once the Azure CLI has been installed, you will be able to run the **azure** com
 ```
 azure help
 ```
+> [AZURE.NOTE]On some Linux distributions you may receive an error, /usr/bin/env: ‘node’: No such file or directory, this comes from recent installations of nodejs being installed at /usr/bin/nodejs. To fix this error create a symbolic link to /usr/bin/node by running the command below
+
+```
+sudo ln -s /usr/bin/nodejs /usr/bin/node
+```
 
 To see the version of the Azure CLI you installed, type the following:
 


### PR DESCRIPTION
Hey, I ran into the proposed change while I was attempting to install the cli on Ubuntu 16.04 and I found the proposed change at http://stackoverflow.com/questions/26320901/cannot-install-nodejs-usr-bin-env-node-no-such-file-or-directory