### PR TITLE
Update configure-ssl-web-site.md

### DIFF
--- a/includes/configure-ssl-web-site.md
+++ b/includes/configure-ssl-web-site.md
@@ -455,8 +455,8 @@ Before performing the steps in this section, you must have associated a custom d
 >
 > 2. Using the tools provided by your domain name registrar, modify the A record for your custom domain name to point to the IP address from the previous step.
 
-> [AZURE.NOTE] If you add an **IP based SSL** to a Web App that already had an SNI binding with a different certificate, as soon as IP SSL is enabled for the Web App, we'll remap the site's hostname to that IP address, so if any other hostname is CNAME'd to that site's hostname it will also get traffic on IP SSL address. 
-For such cases we created one more DNS entry: sni.<nameofyourWebApp>.azurewebsites.net where <nameofyourWebApp> is the name of your Azure App Service Web App. So, you should change your DNS records pointing to the name used in your SNI binding so that it points to sni.<nameofyourWebApp>.azurewebsites.net instead.
+&gt; [AZURE.NOTE] If you add an **IP based SSL** to a Web App that already had an **SNI binding** with a different certificate, as soon as IP SSL is enabled for the Web App, we'll remap the site's hostname to that IP address, so if any other hostname is CNAME'd to that site's hostname it will also get traffic on IP SSL address. 
+For such cases we created one more DNS entry: sni.&lt;nameofyourWebApp&gt;.azurewebsites.net where &lt;nameofyourWebApp&gt; is the name of your Azure App Service Web App. So, you should change your DNS records pointing to the name used in your SNI binding so that it points to sni.&lt;nameofyourWebApp&gt;.azurewebsites.net instead.
 
 At this point, you should be able to visit your app using `HTTPS://` instead of `HTTP://` to verify that the certificate has been configured correctly.
 

--- a/includes/configure-ssl-web-site.md
+++ b/includes/configure-ssl-web-site.md
@@ -455,6 +455,8 @@ Before performing the steps in this section, you must have associated a custom d
 >
 > 2. Using the tools provided by your domain name registrar, modify the A record for your custom domain name to point to the IP address from the previous step.
 
+> [AZURE.NOTE] If you add an **IP based SSL** to a Web App that already had an SNI binding with a different certificate, as soon as IP SSL is enabled for the Web App, we'll remap the site's hostname to that IP address, so if any other hostname is CNAME'd to that site's hostname it will also get traffic on IP SSL address. 
+For such cases we created one more DNS entry: sni.<nameofyourWebApp>.azurewebsites.net where <nameofyourWebApp> is the name of your Azure App Service Web App. So, you should change your DNS records pointing to the name used in your SNI binding so that it points to sni.<nameofyourWebApp>.azurewebsites.net instead.
 
 At this point, you should be able to visit your app using `HTTPS://` instead of `HTTP://` to verify that the certificate has been configured correctly.
 


### PR DESCRIPTION
Adding a note explaining the behavior when having both an IP Based SSL binding and an SNI binding with a different certificate for the same Web App.
In line 458 adding:
&gt; [AZURE.NOTE] If you add an **IP based SSL** to a Web App that already had an **SNI binding** with a different certificate, as soon as IP SSL is enabled for the Web App, we'll remap the site's hostname to that IP address, so if any other hostname is CNAME'd to that site's hostname it will also get traffic on IP SSL address. 
For such cases we created one more DNS entry: sni.&lt;nameofyourWebApp&gt;.azurewebsites.net where &lt;nameofyourWebApp&gt; is the name of your Azure App Service Web App. So, you should change your DNS records pointing to the name used in your SNI binding, so that it points to sni.&lt;nameofyourWebApp&gt;.azurewebsites.net instead.