### PR TITLE
Fixed Typos in Example Code

### DIFF
--- a/articles/virtual-network/virtual-network-deploy-multinic-arm-ps.md
+++ b/articles/virtual-network/virtual-network-deploy-multinic-arm-ps.md
@@ -77,6 +77,7 @@ You can download the full PowerShell script used [here](https://raw.githubuserco
 		$vmNamePrefix          = "DB"
 		$osDiskPrefix          = "osdiskdb"
 		$dataDiskPrefix        = "datadisk"
+		$diskSize	           = "120"	
 		$nicNamePrefix         = "NICDB"
 		$ipAddressPrefix       = "192.168.2."
 		$numberOfVMs           = 2
@@ -139,12 +140,12 @@ You need to use a loop to create as many VMs as you want, and create the necessa
 
 5. Create two data disks per VM. Notice that the data disks are in the premium storage account created earlier.
 
-		    $dataDisk1Name = $vmName + "-" + $dataDiskSuffix + "-1"    
+		    $dataDisk1Name = $vmName + "-" + $osDiskPrefix + "-1"    
 		    $data1VhdUri = $prmStorageAccount.PrimaryEndpoints.Blob.ToString() + "vhds/" + $dataDisk1Name + ".vhd"
 		    Add-AzureRmVMDataDisk -VM $vmConfig -Name $dataDisk1Name -DiskSizeInGB $diskSize `
 				-VhdUri $data1VhdUri -CreateOption empty -Lun 0
 
-		    $dataDisk2Name = $vmName + "-" + $dataDiskSuffix + "-2"    
+		    $dataDisk2Name = $vmName + "-" + $dataDiskPrefix + "-2"    
 		    $data2VhdUri = $prmStorageAccount.PrimaryEndpoints.Blob.ToString() + "vhds/" + $dataDisk2Name + ".vhd"
 		    Add-AzureRmVMDataDisk -VM $vmConfig -Name $dataDisk2Name -DiskSizeInGB $diskSize `
 				-VhdUri $data2VhdUri -CreateOption empty -Lun 1


### PR DESCRIPTION
The Script was missing "diskSize" var in the beginning. Also the var $dataDisk1Name & $dataDisk2Name had the wrong suffix parameter name.