### PR TITLE
Missing -EnableBGP True from 2 PowerShell commands

### DIFF
--- a/articles/vpn-gateway/vpn-gateway-bgp-resource-manager-ps.md
+++ b/articles/vpn-gateway/vpn-gateway-bgp-resource-manager-ps.md
@@ -122,7 +122,7 @@ Request a public IP address to be allocated to the gateway you will create for y
 
 Create the virtual network gateway for TestVNet1. Note that BGP requires a Route-Based VPN gateway, and also the addition parameter, -Asn, to set the ASN (AS Number) for TestVNet1. Creating a gateway can take a while (30 minutes or more to complete).
 
-	New-AzureRmVirtualNetworkGateway -Name $GWName1 -ResourceGroupName $RG1 -Location $Location1 -IpConfigurations $gwipconf1 -GatewayType Vpn -VpnType RouteBased -GatewaySku HighPerformance -Asn $VNet1ASN
+	New-AzureRmVirtualNetworkGateway -Name $GWName1 -ResourceGroupName $RG1 -Location $Location1 -IpConfigurations $gwipconf1 -GatewayType Vpn -VpnType RouteBased -GatewaySku HighPerformance -Asn $VNet1ASN -EnableBgp True
 
 #### 3. Obtain the Azure BGP Peer IP address
 
@@ -267,7 +267,7 @@ Request a public IP address to be allocated to the gateway you will create for y
 
 Create the VPN gateway with the AS number. Note that you must override the default ASN on your Azure VPN gateways. The ASNs for the connected VNets must be different to enable BGP and transit routing.
 
-	New-AzureRmVirtualNetworkGateway -Name $GWName2 -ResourceGroupName $RG2 -Location $Location2 -IpConfigurations $gwipconf2 -GatewayType Vpn -VpnType RouteBased -GatewaySku Standard -Asn $VNet2ASN
+	New-AzureRmVirtualNetworkGateway -Name $GWName2 -ResourceGroupName $RG2 -Location $Location2 -IpConfigurations $gwipconf2 -GatewayType Vpn -VpnType RouteBased -GatewaySku Standard -Asn $VNet2ASN -EnableBGP True
 
 ### Step 2 - Connect the TestVNet1 and TestVNet2 gateways
 


### PR DESCRIPTION
Although the text explains to add this flag, it is easy to forget it users use the 'copy' feature for the PowerShell commands.
If you do not specify the flag, the default is False for the EnableBgp setting.