### PR TITLE
Updated to use SAS in place of ACS

### DIFF
--- a/articles/service-bus/service-bus-java-how-to-use-jms-api-amqp.md
+++ b/articles/service-bus/service-bus-java-how-to-use-jms-api-amqp.md
@@ -53,7 +53,7 @@ JMS uses the Java Naming and Directory Interface (JNDI) to create a separation b
 	
 # Register a ConnectionFactory in JNDI using the form:
 # connectionfactory.[jndi_name] = [ConnectionURL]
-connectionfactory.SBCF = amqps://[username]:[password]@[namespace].servicebus.windows.net
+connectionfactory.SBCF = amqps://[SASPolicyName]:[SASPolicyKey]@[namespace].servicebus.windows.net
 	
 # Register some queues in JNDI using the form
 # queue.[jndi_name] = [physical_name]
@@ -77,13 +77,13 @@ Where **[jndi_name]** and **[ConnectionURL]** have the following meanings:
 The format of the **ConnectionURL** is as follows:
 
 ```
-amqps://[username]:[password]@[namespace].servicebus.windows.net
+amqps://[SASPolicyName]:[SASPolicyKey]@[namespace].servicebus.windows.net
 ```
-Where **[namespace]**, **[username]** and **[password]** have the following meanings:
+Where **[namespace]**, **[SASPolicyName]** and **[SASPolicyKey]** have the following meanings:
 
 - **[namespace]**: The Service Bus namespace.
-- **[username]**: The Service Bus issuer name.
-- **[password]**: URL-encoded form of the Service Bus issuer key.
+- **[SASPolicyName]**: The Queue Shared Access Signature policy name.
+- **[SASPolicyKey]**: The Queue Shared Access Signature policy key.
 
 > [AZURE.NOTE] You must URL-encode the password manually. A useful URL-encoding utility is available at [http://www.w3schools.com/tags/ref_urlencode.asp](http://www.w3schools.com/tags/ref_urlencode.asp).
 


### PR DESCRIPTION
ACS is no longer supported in Azure Service Bus Queues, so we now need to leverage the SAS policy name and key in place of the UserName and Password values. I've tested this change for a client that was trying to do JMS to ASB over AMQP and it worked. Also, note that this feedback was previously provided in the comments section for this article.