### PR TITLE
Fixed mistake in data-factory-azure-documentdb-connector.md

### DIFF
--- a/articles/data-factory/data-factory-azure-documentdb-connector.md
+++ b/articles/data-factory/data-factory-azure-documentdb-connector.md
@@ -18,7 +18,7 @@
 
 # Move data to and from DocumentDB using Azure Data Factory
 
-This article outlines how you can use the Copy Activity in an Azure data factory to move data to Azure DocumentDB from another data store and move data from another data store to DocumentDB. This article builds on the [data movement activities](data-factory-data-movement-activities.md) article which presents a general overview of data movement with copy activity and supported data store combinations.
+This article outlines how you can use the Copy Activity in an Azure data factory to move data to Azure DocumentDB from another data store and move data to another data store from DocumentDB. This article builds on the [data movement activities](data-factory-data-movement-activities.md) article which presents a general overview of data movement with copy activity and supported data store combinations.
 
 The following sample(s) show how to copy data to and from Azure DocumentDB and Azure Blob Storage. However, data can be copied **directly** from any of sources to any of the sinks stated [here](data-factory-data-movement-activities.md#supported-data-stores) using the Copy Activity in Azure Data Factory.  
 


### PR DESCRIPTION
A 'from' and 'to' got switched in the first paragraph causing the article to repeat itself.