### PR TITLE
Added correct path reference to the Import-Module HybridRegistration.…

### DIFF
--- a/articles/automation/automation-hybrid-runbook-worker.md
+++ b/articles/automation/automation-hybrid-runbook-worker.md
@@ -81,7 +81,7 @@ When you add an agent to Operations Management Suite, the Automation solution pu
 Open a PowerShell session in Administrator mode and run the following commands to import the module.
 
 	cd "C:\Program Files\Microsoft Monitoring Agent\Agent\AzureAutomation\<version>\HybridRegistration"
-	Import-Module HybridRegistration.psd1
+	Import-Module .\HybridRegistration.psd1
 
 
 Then run the **Add-HybridRunbookWorker** cmdlet using the following syntax:


### PR DESCRIPTION
…psd1 call.

In current form the call fails because it cannot find the .psd1 file (no .\ included).  Error: The specified module was not loaded because no valid module file was found in any directory.