### PR TITLE
proposing change

### DIFF
--- a/articles/virtual-network/virtual-networks-move-vm-role-to-subnet.md
+++ b/articles/virtual-network/virtual-networks-move-vm-role-to-subnet.md
@@ -31,7 +31,7 @@ To move a VM, run the Set-AzureSubnet PowerShell cmdlet, using the example below
 	| Set-AzureSubnet –SubnetNames Subnet-2 `
 	| Update-AzureVM
 
-If you specified a static DIP for your VM, you'll have to clear that setting before you can move the VM to a new subnet. In that case, use the following:
+If you specified a static internal private IP for your VM, you'll have to clear that setting before you can move the VM to a new subnet. In that case, use the following:
 
 	Get-AzureVM -ServiceName TestVMCloud -Name TestVM `
 	| Remove-AzureStaticVNetIP `


### PR DESCRIPTION
as per this article https://azure.microsoft.com/en-us/documentation/articles/virtual-networks-reserved-private-ip/ this change sound logical to me. I'm aware that the "Static Internal Private IP" was referred to as DIP earlier, but I think that now its not supposed to be called DIP. And in this context it also makes no sense:
"static dynamic IP".

Feel free to reject it if you find that its not a sufficient reason for a change, thanks!
ps. also all those PIP,DIP,VIP are really confusing in a whitepaper, I always forget whats the right one, so i have to bing it.