### PR TITLE
Add .net framework support-ability in each cluster version

### DIFF
--- a/articles/hdinsight/hdinsight-component-versioning.md
+++ b/articles/hdinsight/hdinsight-component-versioning.md
@@ -108,7 +108,7 @@ The SLA is defined in terms of a "Support Window". A Support Window refers to th
 
 The **Deprecation Date** is the date after which the cluster version cannot be created on HDInsight.
 
-> [AZURE.NOTE] Both HDInsight 2.1 and 3.0 clusters run on Azure Guest OS [Family 4](../cloud-services/cloud-services-guestos-update-matrix.md), which uses the 64-bit version of Windows Server 2012 R2 and supports .NET Framework 4.0, 4.5. and 4.5.1.
+> [AZURE.NOTE] Both HDInsight 2.1 and 3.0 clusters run on Azure Guest OS [Family 4](../cloud-services/cloud-services-guestos-update-matrix.md), which uses the 64-bit version of Windows Server 2012 R2 and supports .NET Framework 4.0, 4.5. and 4.5.1. {requires additional info in .net framework version supported in higher version of cluster here}
 
 ## Hortonworks release notes associated with HDInsight versions##
 


### PR DESCRIPTION
I have confirmed that version 3.3.0.941 cluster supports .Net Framework 4.5.2. .Net framework version matters to anyone who runs application on it. Please specify in the document from which version of cluster supports which version of .Net framework. Please see my post to refer the detail. 

http://ahkim.com/HDInsight-instance-supports-.Net-Framework-4.5.2.html