### PR TITLE
Fix incorrect resource type parameter

### DIFF
--- a/articles/service-fabric/service-fabric-cluster-scale-up-down.md
+++ b/articles/service-fabric/service-fabric-cluster-scale-up-down.md
@@ -30,7 +30,7 @@ Currently, you are not able to specify the auto-scale rules for VM scale sets us
 To get the list of VM scale set that make up your cluster, run the following cmdlets:
 
 ```powershell
-Get-AzureRmResource -ResourceGroupName <RGname> -ResourceType Microsoft.Network/VirtualMachineScaleSets
+Get-AzureRmResource -ResourceGroupName <RGname> -ResourceType Microsoft.Compute/VirtualMachineScaleSets
 
 Get-AzureRmVmss -ResourceGroupName <RGname> -VMScaleSetName <VM Scale Set name>
 ```


### PR DESCRIPTION
Apparently Microsoft.Network/VirtualMachineScaleSets changed to Microsoft.Compute/VirtualMachineScaleSets, or the former doesn't work for service fabric clusters.