### PR TITLE
Update resource-group-move-resources.md

### DIFF
--- a/articles/resource-group-move-resources.md
+++ b/articles/resource-group-move-resources.md
@@ -63,8 +63,10 @@ For now, the services that support moving to both a new resource group and subsc
 - Redis Cache
 - Scheduler
 - Search
+- Storage
 - Storage (classic) - see [Classic deployment limitations](#classic-deployment-limitations)
 - SQL Database server - The database and server must reside in the same resource group. When you move a SQL server, all of its databases are also moved.
+- Virtual Machines
 - Virtual Machines (classic) - see [Classic deployment limitations](#classic-deployment-limitations)
 
 ## Services that partially support move
@@ -79,8 +81,6 @@ The services that currently do not support moving a resource are:
 
 - Application Insights
 - Express Route
-- Storage
-- Virtual Machines
 - Virtual Networks (classic) - see [Classic deployment limitations](#classic-deployment-limitations)
 
 ## App Service limitations


### PR DESCRIPTION
moved Virtual Machines and Storage to supported. VM's appear to have support in Portal, whereas Storage not, but I've just successfully moved Storage Account using Internal Subscription. If OK , please confirm / QA wit Product Group