### PR TITLE
Changed names of values to reflect those on Azure Portal

### DIFF
--- a/articles/virtual-network/virtual-networks-udr-overview.md
+++ b/articles/virtual-network/virtual-networks-udr-overview.md
@@ -43,9 +43,16 @@ Packets are routed over a TCP/IP network based on a route table defined at each 
 
 |Property|Description|Constraints|Considerations|
 |---|---|---|---|
-| Address Prefix | The destination CIDR to which the route applies, such as 10.1.0.0/16.|Must be a valid CIDR range representing addresses on the public Internet, Azure virtual network, or on-premises datacenter.|Make sure the **Address prefix** does not contain the address for the **Nexthop value**, otherwise your packets will enter in a loop going from the source to the next hop without ever reaching the destination. |
-| Next hop type | The type of Azure hop the packet should be sent to. | Must be one of the following values: <br/> **Local**. Represents the local virtual network. For instance, if you have two subnets, 10.1.0.0/16 and 10.2.0.0/16 in the same virtual network, the route for each subnet in the route table will have a next hop value of *Local*. <br/> **VPN Gateway**. Represents an Azure S2S VPN Gateway. <br/> **Internet**. Represents the default Internet gateway provided by the Azure Infrastructure. <br/> **Virtual Appliance**. Represents a virtual appliance you added to your Azure virtual network. <br/> **NULL**. Represents a black hole. Packets forwarded to a black hole will not be forwarded at all.| Consider using a **NULL** type to stop packages from flowing to a given destination. | 
-| Nexthop Value | The next hop value contains the IP address packets should be forwarded to. Next hop values are only allowed in routes where the next hop type is *Virtual Appliance*.| Must be a reachable IP address. | If the IP address represents a VM, make sure you enable [IP forwarding](#IP-forwarding) in Azure for the VM. |
+| Address Prefix | The destination CIDR to which the route applies, such as 10.1.0.0/16.|Must be a valid CIDR range representing addresses on the public Internet, Azure virtual network, or on-premises datacenter.|Make sure the **Address prefix** does not contain the address for the **Next hop address**, otherwise your packets will enter in a loop going from the source to the next hop without ever reaching the destination. |
+| Next hop type | The type of Azure hop the packet should be sent to. | Must be one of the following values: <br/> **Virtual Network**. Represents the local virtual network. For instance, if you have two subnets, 10.1.0.0/16 and 10.2.0.0/16 in the same virtual network, the route for each subnet in the route table will have a next hop value of *Virtual Network*. <br/> **Virtual Network Gateway**. Represents an Azure S2S VPN Gateway. <br/> **Internet**. Represents the default Internet gateway provided by the Azure Infrastructure. <br/> **Virtual Appliance**. Represents a virtual appliance you added to your Azure virtual network. <br/> **None**. Represents a black hole. Packets forwarded to a black hole will not be forwarded at all.| Consider using a **None** type to stop packages from flowing to a given destination. | 
+| Next hop address | The next hop address contains the IP address packets should be forwarded to. Next hop values are only allowed in routes where the next hop type is *Virtual Appliance*.| Must be a reachable IP address. | If the IP address represents a VM, make sure you enable [IP forwarding](#IP-forwarding) in Azure for the VM. |
+
+In Azure PowerShell some of the "NextHopType" values have different names:
+- Virtual Network is VnetLocal
+- Virtual Network Gateway is VirtualNetworkGateway
+- Virtual Appliance is VirtualAppliance
+- Internet is Internet
+- None is None
 
 ### System Routes
 Every subnet created in a virtual network is automatically associated with a route table that contains the following system route rules:


### PR DESCRIPTION
The name of the route properties are outdated and do not currently reflect the names that are on the Azure Portal, causing confusion when deploying UDR routes on the portal or even when trying to do using Azure PowerShell. I have updated the names to correctly match those of the portal and added a small section to specify the differences in names when using Azure PowerShell.