### PR TITLE
Update documentdb-get-started.md: collection config unused

### DIFF
--- a/articles/documentdb/documentdb-get-started.md
+++ b/articles/documentdb/documentdb-get-started.md
@@ -236,7 +236,7 @@ Copy and paste the **CreateDocumentCollectionIfNotExists** method underneath you
 				// Here we create a collection with 400 RU/s.
 				await this.client.CreateDocumentCollectionAsync(
 					UriFactory.CreateDatabaseUri(databaseName),
-					new DocumentCollection { Id = collectionName },
+					collectionInfo,
 					new RequestOptions { OfferThroughput = 400 });
 
 				this.WriteToConsoleAndPromptToContinue("Created {0}", collectionName);


### PR DESCRIPTION
The example code for creating a collection via the .NET SDK attempted to demonstrate configuration of a custom indexing policy, but didn't actually do so. This change corrects that, with collectionInfo no longer going unused.