### PR TITLE
Added guidance for ASN number

### DIFF
--- a/includes/vpn-gateway-bpg-faq-include.md
+++ b/includes/vpn-gateway-bpg-faq-include.md
@@ -14,7 +14,9 @@ Yes, you can use your own public ASNs or private ASNs for both your on-premises 
 
 No, you must assign different ASNs between your on-premises networks and your Azure VNets if you are connecting them together with BGP. Azure VPN Gateways have a default ASN of 65515 assigned, whether BGP is enabled for not for your cross-premises connectivity. You can override this default by assigning a different ASN when creating the VPN gateway, or change the ASN after the gateway is created. You will need to assign your on-premises ASNs to the corresponding Azure Local Network Gateways.
 
+### Will Azure force me to select a valid ASN?
 
+No, hence please ensure you verify you have selected a valid ASN within the range of 0 to 65535. If you don't do this, the VPN Gateway will create fine, but later when you try and add BGP enabled Connections, the Connection will fail to ever reach the Connected state.
 
 ### What address prefixes will Azure VPN gateways advertise to me?
 


### PR DESCRIPTION
Currently there is a bug in Azure where we allow the user to select an invalid ASN number. If they do so, there is no error, and later they can't create BGP connections (with no error visible to them about what is wrong).

Hopefully this FAQ will save Azure users some pain.

I plan to also submit an update to the PowerShell cmd-lets to add a check for a valid ASN number.