### PR TITLE
Key Vault access policy error

### DIFF
--- a/articles/key-vault/key-vault-use-from-web-application.md
+++ b/articles/key-vault/key-vault-use-from-web-application.md
@@ -163,7 +163,7 @@ Now that you have a certificate, you need to associate it with an Azure AD appli
 
 	PS C:\> $sp = New-AzureRmADServicePrincipal -ApplicationId $adapp.ApplicationId
 
-	PS C:\> Set-AzureRmKeyVaultAccessPolicy -VaultName 'contosokv' -ServicePrincipalName $sp.ServicePrincipalName -PermissionsToKeys all -ResourceGroupName 'contosorg'
+	PS C:\> Set-AzureRmKeyVaultAccessPolicy -VaultName 'contosokv' -ServicePrincipalName $sp.ServicePrincipalName -PermissionsToSecrets all -ResourceGroupName 'contosorg'
 
 	# get the thumbprint to use in your app settings
 	PS C:\>$x509.Thumbprint


### PR DESCRIPTION
'Set-AzureRmKeyVaultAccessPolicy' should be called using '-PermissionsToSecrets all' in order to manage secrets.