### PR TITLE
Updating ADLA & ADLS Java "getting started" article

### DIFF
--- a/articles/data-lake-analytics/data-lake-analytics-get-started-java-sdk.md
+++ b/articles/data-lake-analytics/data-lake-analytics-get-started-java-sdk.md
@@ -83,7 +83,7 @@ You will need to give your application permission to create resources in Azure f
 	            <version>1.0.0-20160513.000812-28</version>
 	        </dependency>
 	        <dependency>
-	            <groupId>com.microsoft.azure</groupId>
+	            <groupId>com.microsoft.rest</groupId>
 	            <artifactId>client-runtime</artifactId>
 	            <version>1.0.0-20160513.000825-29</version>
 	        </dependency>

--- a/articles/data-lake-analytics/data-lake-analytics-get-started-java-sdk.md
+++ b/articles/data-lake-analytics/data-lake-analytics-get-started-java-sdk.md
@@ -75,7 +75,17 @@ You will need to give your application permission to create resources in Azure f
 	        <dependency>
 	            <groupId>com.microsoft.azure</groupId>
 	            <artifactId>azure-client-authentication</artifactId>
-	            <version>1.0.0-SNAPSHOT</version>
+	            <version>1.0.0-20160513.000802-24</version>
+	        </dependency>
+	        <dependency>
+	            <groupId>com.microsoft.azure</groupId>
+	            <artifactId>azure-client-runtime</artifactId>
+	            <version>1.0.0-20160513.000812-28</version>
+	        </dependency>
+	        <dependency>
+	            <groupId>com.microsoft.azure</groupId>
+	            <artifactId>client-runtime</artifactId>
+	            <version>1.0.0-20160513.000825-29</version>
 	        </dependency>
 	        <dependency>
 	            <groupId>com.microsoft.azure</groupId>

--- a/articles/data-lake-store/data-lake-store-get-started-java-sdk.md
+++ b/articles/data-lake-store/data-lake-store-get-started-java-sdk.md
@@ -95,7 +95,17 @@ You will need to give your application permission to create resources in Azure f
 	        <dependency>
 	            <groupId>com.microsoft.azure</groupId>
 	            <artifactId>azure-client-authentication</artifactId>
-	            <version>1.0.0-SNAPSHOT</version>
+	            <version>1.0.0-20160513.000802-24</version>
+	        </dependency>
+	        <dependency>
+	            <groupId>com.microsoft.azure</groupId>
+	            <artifactId>azure-client-runtime</artifactId>
+	            <version>1.0.0-20160513.000812-28</version>
+	        </dependency>
+	        <dependency>
+	            <groupId>com.microsoft.azure</groupId>
+	            <artifactId>client-runtime</artifactId>
+	            <version>1.0.0-20160513.000825-29</version>
 	        </dependency>
 	        <dependency>
 	            <groupId>com.microsoft.azure</groupId>

--- a/articles/data-lake-store/data-lake-store-get-started-java-sdk.md
+++ b/articles/data-lake-store/data-lake-store-get-started-java-sdk.md
@@ -103,7 +103,7 @@ You will need to give your application permission to create resources in Azure f
 	            <version>1.0.0-20160513.000812-28</version>
 	        </dependency>
 	        <dependency>
-	            <groupId>com.microsoft.azure</groupId>
+	            <groupId>com.microsoft.rest</groupId>
 	            <artifactId>client-runtime</artifactId>
 	            <version>1.0.0-20160513.000825-29</version>
 	        </dependency>


### PR DESCRIPTION
Updating ADLA & ADLS Java "getting started" article to replace SNAPSHOT versions with explicit version numbers, to avoid unexpected breaking changes.