### PR TITLE
Update store-blitline-how-to-use.md

### DIFF
--- a/articles/store-blitline-how-to-use.md
+++ b/articles/store-blitline-how-to-use.md
@@ -69,7 +69,7 @@ You can find more information about the *functions* we support here: <http://www
 
 You can also find documentation about the job options here: <http://www.blitline.com/docs/api>
 
-Once you have your JSON all you need to do is **POST** it to `http://api.blitline.com/jobs`
+Once you have your JSON all you need to do is **POST** it to `http://api.blitline.com/job`
 
 You will get JSON back that looks something like this:
 


### PR DESCRIPTION
Changed the http://api.blitline.com/jobs to http://api.blitline.com/job (Removed 's', since it was returning 404 response).