### PR TITLE
Update traffic manager custom domain name docs for clarity

### DIFF
--- a/articles/app-service-web/web-sites-traffic-manager-custom-domain-name.md
+++ b/articles/app-service-web/web-sites-traffic-manager-custom-domain-name.md
@@ -55,6 +55,8 @@ To associate your custom domain with a web app in Azure App Service, you must ad
 
 5. While the specifics of each registrar vary, in general you map *from* your custom domain name (such as **contoso.com**,) *to* the Traffic Manager domain name (**contoso.trafficmanager.net**) that is used for your web app.
 
+> [AZURE.NOTE] Alternatively, if a record is already in use and you need to preemptively bind your apps to it, map **awverify.contoso.com** to **contoso.trafficmanager.net**.
+
 6. Once you have finished adding or modifying DNS records at your registrar, save the changes.
 
 <a name="enabledomain"></a>


### PR DESCRIPTION
It's not explicitly stated anywhere that setting the awverify sub-domain to point at a traffic manager allows you to preemptively bind domain names that currently point elsewhere. This is crucial for a decent cut-over.