### PR TITLE
Guide users to not install R versions of PowerCLI

### DIFF
--- a/articles/site-recovery/site-recovery-vmware-to-azure.md
+++ b/articles/site-recovery/site-recovery-vmware-to-azure.md
@@ -148,7 +148,7 @@ The Site Recovery process server can automatically discover VMware VMs on vSpher
 	- Allow access to [http://cdn.mysql.com/archives/mysql-5.5/mysql-5.5.37-win32.msi](http://cdn.mysql.com/archives/mysql-5.5/mysql-5.5.37-win32.msi) to download MySQL.
 	- Allow firewall communication to Azure with the [Azure datacenter IP ranges](https://www.microsoft.com/download/confirmation.aspx?id=41653) and the HTTPS (433) protocol.
 
-2.	Download and install [VMware vSphere PowerCLI 6.0](https://developercenter.vmware.com/tool/vsphere_powercli/6.0) on the configuration server. (Ensure to install Version 6.0 and not the R versions)
+2.	Download and install [VMware vSphere PowerCLI 6.0](https://developercenter.vmware.com/tool/vsphere_powercli/6.0) on the configuration server. (Currently other versions of PowerCLI aren't supported, including R releases of version 6.0.)
 
 
 ## Create a Recovery Services vault

--- a/articles/site-recovery/site-recovery-vmware-to-azure.md
+++ b/articles/site-recovery/site-recovery-vmware-to-azure.md
@@ -148,7 +148,7 @@ The Site Recovery process server can automatically discover VMware VMs on vSpher
 	- Allow access to [http://cdn.mysql.com/archives/mysql-5.5/mysql-5.5.37-win32.msi](http://cdn.mysql.com/archives/mysql-5.5/mysql-5.5.37-win32.msi) to download MySQL.
 	- Allow firewall communication to Azure with the [Azure datacenter IP ranges](https://www.microsoft.com/download/confirmation.aspx?id=41653) and the HTTPS (433) protocol.
 
-2.	Download and install [VMware vSphere PowerCLI 6.0](https://developercenter.vmware.com/tool/vsphere_powercli/6.0) on the configuration server.
+2.	Download and install [VMware vSphere PowerCLI 6.0](https://developercenter.vmware.com/tool/vsphere_powercli/6.0) on the configuration server. (Ensure to install Version 6.0 and not the R versions)
 
 
 ## Create a Recovery Services vault


### PR DESCRIPTION
I had an issue at a customer where we installed the latest R version of PowerCLI on our processing server which caused a significant amount of troubleshooting for a week.  We lost a lot of time.  We couldn't uninstall the R3 version and just install "RTM" as when R3 is installed, the code is stuck in there even when installed 6.0.  We had to rebuild our processing server from scratch.  When you look at the download page, I believe you are compelled to want to get the latest version, which is the issue we got stuck on.  The edit is to try and avoid other pros from making this mistake.