### PR TITLE
updated link to avoid 404

### DIFF
--- a/articles/service-fabric/service-fabric-project-creation-next-step-tasks.md
+++ b/articles/service-fabric/service-fabric-project-creation-next-step-tasks.md
@@ -47,7 +47,7 @@ When you add a new reliable actor, Visual Studio adds two projects to your solut
 The actor project provides methods for setting and getting the value of a counter that is reliably persisted within the actor's state. The interface project provides an interface that other services can use to invoke the actor.
 
 ### Stateless Web API
-The stateless Web API project provides a basic web service that you can use to open your application to external clients. For more information about how the project structured, see [Service Fabric Web API services with OWIN self-hosting](service-fabric-reliable-services-communication-webapi).
+The stateless Web API project provides a basic web service that you can use to open your application to external clients. For more information about how the project structured, see [Service Fabric Web API services with OWIN self-hosting](service-fabric-reliable-services-communication-webapi.md).
 
 ## Next steps
 ### Create an Azure cluster


### PR DESCRIPTION
Was getting 404 going to https://github.com/Azure/azure-content/blob/master/articles/service-fabric/service-fabric-reliable-services-communication-webapi changed to https://github.com/Azure/azure-content/blob/master/articles/service-fabric/service-fabric-reliable-services-communication-webapi.md