### PR TITLE
fix missing spaces in commandToExecute

### DIFF
--- a/articles/virtual-machines/virtual-machines-windows-extensions-configuration-samples.md
+++ b/articles/virtual-machines/virtual-machines-windows-extensions-configuration-samples.md
@@ -91,7 +91,7 @@ Before deploying the extension please check the latest extension version and rep
               "fileUris": [
                   "http: //Yourstorageaccount.blob.core.windows.net/customscriptfiles/start.ps1"
               ],
-              "commandToExecute": "powershell.exe-ExecutionPolicyUnrestricted -start.ps1"
+              "commandToExecute": "powershell.exe -ExecutionPolicy Unrestricted -start.ps1"
           },
           "protectedSettings": {
             "storageAccountName": "yourStorageAccountName",
@@ -118,10 +118,10 @@ Please refer to CustomScript version 1.4 for parameter description. Version 1.7 
                 "fileUris": [
                     "http: //Yourstorageaccount.blob.core.windows.net/customscriptfiles/start.ps1"
                 ],
-                "commandToExecute": "powershell.exe-ExecutionPolicyUnrestricted -start.ps1"
+                "commandToExecute": "powershell.exe -ExecutionPolicy Unrestricted -start.ps1"
             },
             "protectedSettings": {
-              "commandToExecute": "powershell.exe-ExecutionPolicyUnrestricted -start.ps1",
+              "commandToExecute": "powershell.exe -ExecutionPolicy Unrestricted -start.ps1",
               "storageAccountName": "yourStorageAccountName",
               "storageAccountKey": "yourStorageAccountKey"
             }


### PR DESCRIPTION
there are typos in the command for the extension sample - it's missing spaces and won't run.

```
"commandToExecute": "powershell.exe-ExecutionPolicyUnrestricted -start.ps1",
```

should be
```
"commandToExecute": "powershell.exe -ExecutionPolicy Unrestricted -start.ps1",
```