### PR TITLE
Correct grammar: "read *from* the regions specified"

### DIFF
--- a/articles/documentdb/documentdb-developing-with-multiple-regions.md
+++ b/articles/documentdb/documentdb-developing-with-multiple-regions.md
@@ -26,7 +26,7 @@ The SDK will automatically send all writes to the current write region.
 
 All reads will be sent to the first available region in the PreferredLocations list. If the request fails, the client will fail down the list to the next region, and so on. 
 
-The client SDKs will only attempt to read to the regions specified in PreferredLocations. So, for example, if the Database Account is available in three regions, but the client only specifies two of the non-write regions for PreferredLocations, then no reads will be served out of the write region, even in the case of failover.
+The client SDKs will only attempt to read from the regions specified in PreferredLocations. So, for example, if the Database Account is available in three regions, but the client only specifies two of the non-write regions for PreferredLocations, then no reads will be served out of the write region, even in the case of failover.
 
 The application can verify the current write endpoint and read endpoint chosen by the SDK by checking two properties, WriteEndpoint and ReadEndpoint, available in SDK version 1.8 and above. 
 


### PR DESCRIPTION
Changed "read to the regions specified..." to "read from the regions specified..."