### PR TITLE
Note to unblock the downloaded file

### DIFF
--- a/articles/azure-stack/azure-stack-sql-rp-deploy-long.md
+++ b/articles/azure-stack/azure-stack-sql-rp-deploy-long.md
@@ -78,13 +78,15 @@ To deploy a resource provider, you run the PowerShell Integrated Scripting Envir
 
 1. Connect the Azure Stack POC remote desktop to clientVm.AzureStack.Local and sign in as azurestack\\azurestackuser.
 
-2. [Download the SQLRP binaries](http://aka.ms/massqlrprfrsh) file and extract it to D:\\SQLRP.
+2. [Download the SQLRP binaries](http://aka.ms/massqlrprfrsh) file. You may need to remove the Internet download security block by right-clicking on the file, selecting **Properties** and from the **General** tab, tick **Unblock**, **OK**. This should prevent 'Could not load file or assembly' exceptions related to DeploymentTelemetry.dll and the subsequent Trace-Deployment exceptions.
 
-3. Run the D:\\SQLRP\\Bootstrap.cmd file as an administrator (azurestack\\administrator).
+3. Extract the files to D:\\SQLRP.
+
+4. Run the D:\\SQLRP\\Bootstrap.cmd file as an administrator (azurestack\\administrator).
 
 	This opens the Bootstrap.ps1 file in the PowerShell ISE.
 
-4. When the PowerShell ISE window completes loading, click the play button or press F5.
+5. When the PowerShell ISE window completes loading, click the play button or press F5.
 
 	![](./media/azure-stack-sql-rp-deploy-long/1strun.png)
 


### PR DESCRIPTION
The standard approach for file downloaded from the Internet in Edge or Internet Explorer is to mark them as blocked. If you extract files from such a downloaded archive, then those extracted files are similarly marked. PowerShell may then refuse to run those extracts, thereby making them fail. 

Removing the block removes the failure, but is a security risk, so you must trust the source.

There may be other solutions, like dropping the security stance of PS, marking the source url as trusted, etc, but they're quite broad and this is specifically for this file. I also included the why, which is odd in brief instructions, so that it was searchable. I came across the solution [here](https://social.msdn.microsoft.com/Forums/en-US/e409d9fa-19b8-48a1-a383-bc51e868b7f8/error-during-sqlrp-install-using-the-incremental-update-bits?forum=AzureStack), but it took a while to find it and wanted to make it quicker for everyone else (who hasn't had this fairly generic problem before).
