### PR TITLE
Put correct flag for genpassphrase

### DIFF
--- a/articles/site-recovery/site-recovery-vmware-to-azure.md
+++ b/articles/site-recovery/site-recovery-vmware-to-azure.md
@@ -546,7 +546,7 @@ Oracle Enterprise Linux 6.4, 6.5 (64 bit only) | Microsoft-ASR_UA_9.*.0.0_OL6-64
 
 	![Mobility service](./media/site-recovery-vmware-to-azure/mobility3.png)
 
-3. In **Configuration Server Details** specify the IP address of the configuration server and the passphrase that was generated when you ran Unified Setup. You can retrieve the passphrase  by running: **<SiteRecoveryInstallationFolder>\home\sysystems\bin\genpassphrase.exe –n** on the configuration server.
+3. In **Configuration Server Details** specify the IP address of the configuration server and the passphrase that was generated when you ran Unified Setup. You can retrieve the passphrase  by running: **<SiteRecoveryInstallationFolder>\home\sysystems\bin\genpassphrase.exe –v** on the configuration server.
 
 	![Mobility service](./media/site-recovery-vmware-to-azure/mobility6.png)
 


### PR DESCRIPTION
The current genpassphrase has the -n flag which will display the passphrase after generating, it is better to use the -v flag, in order to view the current flag and not change any current passphrase.