### PR TITLE
Defining on-prem resource by IP address is not supported

### DIFF
--- a/articles/biztalk-services/integration-hybrid-connection-create-manage.md
+++ b/articles/biztalk-services/integration-hybrid-connection-create-manage.md
@@ -28,10 +28,15 @@
 
 This topic lists these steps. 
 
-[AZURE.IMPORTANT] It is possible to set a Hybrid Connection endpoint to an IP address **but** if you do so, you may or may not be able to reach the on premises resource depending on your client. The Hybrid Connection feature depends on the client doing a DNS lookup (In most cases the __client__ is your application code). If the client does not perform a DNS lookup, so it does not try to resolve the IP address as if it were a domain name (x.x.x.x), then traffic will not be sent through the Hybrid Connection.
-Example (pseudocode) -- Considering you define **10.4.5.6** as your on premises host: 
-**This works:** `Application code -> GetHostByName("10.4.5.6") -> Resolves to 127.0.0.3 -> Connect("127.0.0.3") -> Hybrid Connection -> on-prem host` // 
-**This doesn't work:** `Application code -> Connect("10.4.5.6") -> ?? -> No route to host`
+> [AZURE.IMPORTANT] It is possible to set a Hybrid Connection endpoint to an IP address. If you use an IP address, you may or may not reach the on-premises resource, depending on your client. The Hybrid Connection depends on the client doing a DNS lookup. In most cases, the __client__ is your application code. If the client does not perform a DNS lookup, (it does not try to resolve the IP address as if it were a domain name (x.x.x.x)), then traffic is not sent through the Hybrid Connection.
+>
+> For example (pseudocode), you define **10.4.5.6** as your on-premises host:
+> 
+> **The following scenario works:**  
+> `Application code -> GetHostByName("10.4.5.6") -> Resolves to 127.0.0.3 -> Connect("127.0.0.3") -> Hybrid Connection -> on-prem host`
+> 
+> **The following scenario doesn't work:**  
+> `Application code -> Connect("10.4.5.6") -> ?? -> No route to host`
 
 
 ## <a name="CreateHybridConnection"></a>Create a Hybrid Connection
@@ -54,7 +59,7 @@ A Hybrid Connection can be created in the Azure portal using Web Apps **or** usi
 	Property | Description
 --- | ---
 Name | The Hybrid Connection name must be unique and cannot be the same name as the BizTalk Service. You can enter any name but be specific with its purpose. Examples include:<br/><br/>Payroll*SQLServer*<br/>SupplyList*SharepointServer*<br/>Customers*OracleServer*
-Host Name | Enter the fully qualified host name or only the host name of the on-premises resource. Examples include:<br/><br/>mySQLServer<br/>*mySQLServer*.*Domain*.corp.*yourCompany*.com<br/>*myHTTPSharePointServer*<br/>*myHTTPSharePointServer*.*yourCompany*.com
+Host Name | Enter the fully qualified host name, only the host name, or the IPv4 address of the on-premises resource. Examples include:<br/><br/>mySQLServer<br/>*mySQLServer*.*Domain*.corp.*yourCompany*.com<br/>*myHTTPSharePointServer*<br/>*myHTTPSharePointServer*.*yourCompany*.com<br/>10.100.10.10<br/><br/>If you use the IPv4 address, note that your client or application code may not resolve the IP address. See the Important note at the top of this topic.
 Port | Enter the port number of the on-premises resource. For example, if you're using Web Apps, enter port 80 or port 443. If you're using SQL Server, enter port 1433.
 
 5. Select the check mark to complete the setup. 

--- a/articles/biztalk-services/integration-hybrid-connection-create-manage.md
+++ b/articles/biztalk-services/integration-hybrid-connection-create-manage.md
@@ -21,7 +21,7 @@
 
 
 ## Overview of the Steps
-1. Create a Hybrid Connection by entering the **host name** (computer name or internal FQDN) of the on-premises resource in your private network.
+1. Create a Hybrid Connection by entering the **host name** or **FQDN** of the on-premises resource in your private network.
 2. Link your Azure web apps or Azure mobile apps to the Hybrid Connection.
 3. Install the Hybrid Connection Manager on your on-premises resource and connect to the specific Hybrid Connection. The Azure portal provides a single-click experience to install and connect.
 4. Manage Hybrid Connections and their connection keys.
@@ -51,7 +51,7 @@ A Hybrid Connection can be created in the Azure portal using Web Apps **or** usi
 	Property | Description
 --- | ---
 Name | The Hybrid Connection name must be unique and cannot be the same name as the BizTalk Service. You can enter any name but be specific with its purpose. Examples include:<br/><br/>Payroll*SQLServer*<br/>SupplyList*SharepointServer*<br/>Customers*OracleServer*
-Host Name | Enter the fully qualified host name or only the host name (computer name) of the on-premises resource. Examples include:<br/><br/>mySQLServer<br/>*mySQLServer*.*Domain*.corp.*yourCompany*.com<br/>*myHTTPSharePointServer*<br/>*myHTTPSharePointServer*.*yourCompany*.com
+Host Name | Enter the fully qualified host name or only the host name of the on-premises resource. Examples include:<br/><br/>mySQLServer<br/>*mySQLServer*.*Domain*.corp.*yourCompany*.com<br/>*myHTTPSharePointServer*<br/>*myHTTPSharePointServer*.*yourCompany*.com
 Port | Enter the port number of the on-premises resource. For example, if you're using Web Apps, enter port 80 or port 443. If you're using SQL Server, enter port 1433.
 
 5. Select the check mark to complete the setup. 

--- a/articles/biztalk-services/integration-hybrid-connection-create-manage.md
+++ b/articles/biztalk-services/integration-hybrid-connection-create-manage.md
@@ -21,10 +21,12 @@
 
 
 ## Overview of the Steps
-1. Create a Hybrid Connection by entering the host name or IP address of the on-premises resource in your private network.
+1. Create a Hybrid Connection by entering the **host name** (computer name or internal FQDN) of the on-premises resource in your private network.
 2. Link your Azure web apps or Azure mobile apps to the Hybrid Connection.
 3. Install the Hybrid Connection Manager on your on-premises resource and connect to the specific Hybrid Connection. The Azure portal provides a single-click experience to install and connect.
 4. Manage Hybrid Connections and their connection keys.
+
+[AZURE.NOTE] Using the IP address of your on-premises resource instead of host name or FQDN is not supported and will result in communication failure.
 
 This topic lists these steps. 
 
@@ -49,7 +51,7 @@ A Hybrid Connection can be created in the Azure portal using Web Apps **or** usi
 	Property | Description
 --- | ---
 Name | The Hybrid Connection name must be unique and cannot be the same name as the BizTalk Service. You can enter any name but be specific with its purpose. Examples include:<br/><br/>Payroll*SQLServer*<br/>SupplyList*SharepointServer*<br/>Customers*OracleServer*
-Host Name | Enter the fully qualified host name, only the host name, or the IPv4 address of the on-premises resource. Examples include:<br/><br/>mySQLServer<br/>*mySQLServer*.*Domain*.corp.*yourCompany*.com<br/>*myHTTPSharePointServer*<br/>*myHTTPSharePointServer*.*yourCompany*.com<br/>10.100.10.10
+Host Name | Enter the fully qualified host name or only the host name (computer name) of the on-premises resource. Examples include:<br/><br/>mySQLServer<br/>*mySQLServer*.*Domain*.corp.*yourCompany*.com<br/>*myHTTPSharePointServer*<br/>*myHTTPSharePointServer*.*yourCompany*.com
 Port | Enter the port number of the on-premises resource. For example, if you're using Web Apps, enter port 80 or port 443. If you're using SQL Server, enter port 1433.
 
 5. Select the check mark to complete the setup. 

--- a/articles/biztalk-services/integration-hybrid-connection-create-manage.md
+++ b/articles/biztalk-services/integration-hybrid-connection-create-manage.md
@@ -26,9 +26,12 @@
 3. Install the Hybrid Connection Manager on your on-premises resource and connect to the specific Hybrid Connection. The Azure portal provides a single-click experience to install and connect.
 4. Manage Hybrid Connections and their connection keys.
 
-[AZURE.NOTE] Using the IP address of your on-premises resource instead of host name or FQDN is not supported and will result in communication failure.
-
 This topic lists these steps. 
+
+[AZURE.IMPORTANT] It is possible to set a Hybrid Connection endpoint to an IP address **but** if you do so, you may or may not be able to reach the on premises resource depending on your client. The Hybrid Connection feature depends on the client doing a DNS lookup (In most cases the __client__ is your application code). If the client does not perform a DNS lookup, so it does not try to resolve the IP address as if it were a domain name (x.x.x.x), then traffic will not be sent through the Hybrid Connection.
+Example (pseudocode) -- Considering you define **10.4.5.6** as your on premises host: 
+**This works:** `Application code -> GetHostByName("10.4.5.6") -> Resolves to 127.0.0.3 -> Connect("127.0.0.3") -> Hybrid Connection -> on-prem host` // 
+**This doesn't work:** `Application code -> Connect("10.4.5.6") -> ?? -> No route to host`
 
 
 ## <a name="CreateHybridConnection"></a>Create a Hybrid Connection


### PR DESCRIPTION
/cc @chriscompy for review.

Ref: http://stackoverflow.com/questions/38127579/azure-hybrid-connection-to-http-service
I think mentioning IP addresses here does more harm than good even if it does work in edge cases. I can back up this claim with proof.