### PR TITLE
Correction of the statement on premium circuits

### DIFF
--- a/articles/expressroute/expressroute-howto-linkvnet-arm.md
+++ b/articles/expressroute/expressroute-howto-linkvnet-arm.md
@@ -40,7 +40,7 @@ This article will help you link virtual networks (VNets) to Azure ExpressRoute c
 	- Ensure that Azure private peering is configured and the BGP peering between your network and Microsoft is up so that you can enable end-to-end connectivity.
 	- Ensure that you have a virtual network and a virtual network gateway created and fully provisioned. Follow the instructions to create a [VPN gateway](../articles/vpn-gateway/vpn-gateway-create-site-to-site-rm-powershell.md), but be sure to use `-GatewayType ExpressRoute`.
 
-You can link up to 10 virtual networks to an ExpressRoute circuit. All ExpressRoute circuits must be in the same geopolitical region. You can link a larger number of virtual networks to your ExpressRoute circuit if you enabled the ExpressRoute premium add-on. Check the [FAQ](expressroute-faqs.md) for more details about the premium add-on.
+You can link up to 10 virtual networks to an ExpressRoute circuit. All virtual networks must be in the same geopolitical region. You can link a larger number of virtual networks to your ExpressRoute circuit, or link virtual networks that are in other geopolitical regions if you enabled the ExpressRoute premium add-on. Check the [FAQ](expressroute-faqs.md) for more details about the premium add-on.
 
 ## Connect a virtual network in the same subscription to a circuit
 


### PR DESCRIPTION
There was something that IMO isn't correct (all expressroute circuits must be in the same geopolitical region... it's vnets we're talking about and there's an exception if the circuit is a premium one).
Let me know if that makes sense!