### PR TITLE
Load balancer docs spelling error (ned to need)

### DIFF
--- a/articles/load-balancer/load-balancer-get-started-internet-arm-ps.md
+++ b/articles/load-balancer/load-balancer-get-started-internet-arm-ps.md
@@ -160,7 +160,7 @@ You need to create Network Interfaces (or modify existing ones) and associate th
 
 ### Step 1 
 
-Get the Virtual Network and Virtual Network Subnet, where the NICs ned to be created.
+Get the Virtual Network and Virtual Network Subnet, where the NICs need to be created.
 
 	$vnet = Get-AzureRmVirtualNetwork -Name NRPVNet -ResourceGroupName NRP-RG
 	$backendSubnet = Get-AzureRmVirtualNetworkSubnetConfig -Name LB-Subnet-BE -VirtualNetwork $vnet 


### PR DESCRIPTION
Changed ned to need for a spelling error: fixed "where the NICs ned to be created" to "where the NICs need to be created"