### PR TITLE
Corrected Syntax For Android Register With Tags

### DIFF
--- a/articles/notification-hubs/notification-hubs-android-push-notification-google-gcm-get-started.md
+++ b/articles/notification-hubs/notification-hubs-android-push-notification-google-gcm-get-started.md
@@ -233,7 +233,7 @@ Your notification hub is now configured to work with GCM, and you have the conne
 
 		                // If you want to use tags...
 						// Refer to : https://azure.microsoft.com/en-us/documentation/articles/notification-hubs-routing-tag-expressions/
-		                // regID = hub.register(token, "tag1,tag2").getRegistrationId();
+		                // regID = hub.register(token, "tag1", "tag2").getRegistrationId();
 
 		                resultString = "Registered Successfully - RegId : " + regID;
 		                Log.i(TAG, resultString);		


### PR DESCRIPTION
Each tag should be a separate parameter since they are varargs in the library. Also, ``,`` is an invalid tag character.