### PR TITLE
Update hdinsight-hadoop-create-linux-clusters-azure-powershell.md

### DIFF
--- a/articles/hdinsight/hdinsight-hadoop-create-linux-clusters-azure-powershell.md
+++ b/articles/hdinsight/hdinsight-hadoop-create-linux-clusters-azure-powershell.md
@@ -81,7 +81,7 @@ The following script demonstrates how to create a new cluster:
         -StorageAccountName $defaultStorageAccountName `
         -Location $location `
         -Type Standard_LRS
-    $defaultStorageAccountKey = (Get-AzureRmStorageAccountKey -Name $defaultStorageAccountName -ResourceGroupName $resourceGroupName)[0].Value
+    $defaultStorageAccountKey = (Get-AzureRmStorageAccountKey -Name $defaultStorageAccountName -ResourceGroupName $resourceGroupName)[0].Key1
     $destContext = New-AzureStorageContext -StorageAccountName $defaultStorageAccountName -StorageAccountKey $defaultStorageAccountKey
     New-AzureStorageContainer -Name $defaultStorageContainerName -Context $destContext
 


### PR DESCRIPTION
Changed "Value" on Line 84 to "Key1".  I had to make this change in my environment to get this to properly pull the key for the storage account into the $defaultStorageAccountKey variable.