### PR TITLE
Fix a missing pointer in AAD iOS login in Azure Mobile Apps tutorial

### DIFF
--- a/articles/app-service-mobile/app-service-mobile-ios-how-to-use-client-library.md
+++ b/articles/app-service-mobile/app-service-mobile-ios-how-to-use-client-library.md
@@ -540,7 +540,7 @@ and the Pod:
 	    NSString *clientId = @"INSERT-CLIENT-ID-HERE";
 	    NSURL *redirectUri = [[NSURL alloc]initWithString:@"INSERT-REDIRECT-URI-HERE"];
 	    ADAuthenticationError *error;
-	    ADAuthenticationContext authContext = [ADAuthenticationContext authenticationContextWithAuthority:authority error:&error];
+	    ADAuthenticationContext *authContext = [ADAuthenticationContext authenticationContextWithAuthority:authority error:&error];
 	    authContext.parentController = parent;
 	    [ADAuthenticationSettings sharedInstance].enableFullScreen = YES;
 	    [authContext acquireTokenWithResource:resourceId


### PR DESCRIPTION
Objective C code sample for AAD authentication is missing a pointer of `authContext` variable