### PR TITLE
Fixed typo in step to set context and restore JSON file

### DIFF
--- a/articles/backup/backup-azure-vms-automation.md
+++ b/articles/backup/backup-azure-vms-automation.md
@@ -332,10 +332,9 @@ After you have restored the disks, use these steps to create and configure the v
 2. Set the Azure storage context and restore the JSON configuration file.
 
     ```
-    Set -AzureRmCurrentStorageAccount -Name $storageaccountname -ResourceGroupName testvault
+    PS C:\> Set-AzureRmCurrentStorageAccount -Name $storageaccountname -ResourceGroupName testvault
     PS C:\> $destination_path = "C:\vmconfig.json"
-    Get-AzureStorageBlobContent -Container $containerName -Blob $blobName -Destination
-    PS C:\> $destination_path -Context $storageContext
+    PS C:\> Get-AzureStorageBlobContent -Container $containerName -Blob $blobName -Destination $destination_path
     PS C:\> $obj = ((Get-Content -Path $destination_path -Encoding Unicode)).TrimEnd([char]0x00) | ConvertFrom-Json
     ```
 


### PR DESCRIPTION
There were a couple typos in the steps where you set the storage context and restore the JSON config file. I also don't think the -context parameter was needed on the Get-AzureStorageBlobContent command as we set the current context previously, and it doesn't look like that variable was actually ever set in the first place.