### PR TITLE
The picture for peering is showing a wrong.

### DIFF
--- a/articles/expressroute/expressroute-workflows.md
+++ b/articles/expressroute/expressroute-workflows.md
@@ -36,6 +36,7 @@ The figure and corresponding steps below show the tasks you must follow in order
 	
 	>[AZURE.IMPORTANT] You must ensure that you use a separate proxy / edge to connect to Microsoft than the one you use for the Internet. Using the same edge for both ExpressRoute and the Internet will cause asymmetric routing and cause connectivity outages for your network.
 
+### This picture is showing a wrong information ###
 	![](./media/expressroute-workflows/expressroute-routing-workflow.png)
 
 5. Linking virtual networks to ExpressRoute circuits - You can link virtual networks to your ExpressRoute circuit. Follow instructions [to link VNets](expressroute-howto-linkvnet-arm.md) to your circuit. These VNets can either be in the same Azure subscription as the ExpressRoute circuit, or can be in a different subscription.


### PR DESCRIPTION
According to ./media/expressroute-workflows/expressroute-routing-workflow.png, Public Peering and Microsoft Peering supports a public ASN only. But, it supports a private ASN and public ASN both at present.

So please update the picture to prevent to make a customer confused?

![peeringpict](https://cloud.githubusercontent.com/assets/20660114/17467225/e3ef638c-5d56-11e6-818e-0a1fe8103669.png)
