### PR TITLE
Updating a note on using AWVERIFY records

### DIFF
--- a/articles/app-service-web/web-sites-traffic-manager-custom-domain-name.md
+++ b/articles/app-service-web/web-sites-traffic-manager-custom-domain-name.md
@@ -55,7 +55,7 @@ To associate your custom domain with a web app in Azure App Service, you must ad
 
 1. While the specifics of each registrar vary, in general you map *from* your custom domain name (such as **contoso.com**,) *to* the Traffic Manager domain name (**contoso.trafficmanager.net**) that is used for your web app.
 
-> [AZURE.NOTE] Alternatively, if a record is already in use and you need to preemptively bind your apps to it, map **awverify.contoso.com** to **contoso.trafficmanager.net**.
+> [AZURE.NOTE] Alternatively, if a record is already in use and you need to preemptively bind your apps to it. For example, to preemptively bind www.contoso.com to your web app, create a CNAME record from **awverify.www** to **contoso.trafficmanager.net**. You can then add "www.contoso.com" to the Web App without changing the "www" CNAME record.
 
 1. Once you have finished adding or modifying DNS records at your registrar, save the changes.
 


### PR DESCRIPTION
I tested this with a customer, but the note on using AWVERIFY records is confusing. Since Traffic Manager does not allow for the root domain to be mapped to it, having an example saying "create an awverify record from 'awverify.contoso.com' to 'contoso.trafficmanager.net' is confusing. I updated it to show an example of preemptively binding the www subdomain to a web app.