### PR TITLE
Fix the grammar issues of sample code

### DIFF
--- a/articles/key-vault/key-vault-use-from-web-application.md
+++ b/articles/key-vault/key-vault-use-from-web-application.md
@@ -77,8 +77,8 @@ In order to use the Key Vault API you need an access token. The Key Vault Client
 Following is the code to get an access token from Azure Active Directory. This code can go anywhere in your application. I like to add a Utils or EncryptionHelper class.  
 
 	//add these using statements
-        using Microsoft.IdentityModel.Clients.ActiveDirectory;
-        using System.Threading.Tasks;
+    using Microsoft.IdentityModel.Clients.ActiveDirectory;
+    using System.Threading.Tasks;
 	using System.Web.Configuration;
 
 	//this is an optional property to hold the secret after it is retrieved

--- a/articles/key-vault/key-vault-use-from-web-application.md
+++ b/articles/key-vault/key-vault-use-from-web-application.md
@@ -77,14 +77,15 @@ In order to use the Key Vault API you need an access token. The Key Vault Client
 Following is the code to get an access token from Azure Active Directory. This code can go anywhere in your application. I like to add a Utils or EncryptionHelper class.  
 
 	//add these using statements
-    using Microsoft.IdentityModel.Clients.ActiveDirectory;
+        using Microsoft.IdentityModel.Clients.ActiveDirectory;
+        using System.Threading.Tasks;
 	using System.Web.Configuration;
 
 	//this is an optional property to hold the secret after it is retrieved
 	public static string EncryptSecret { get; set; }
 
 	//the method that will be provided to the KeyVaultClient
-	public async static Task<string> GetToken(string authority, string resource, string scope)
+	public static async Task<string> GetToken(string authority, string resource, string scope)
     {
 	    var authContext = new AuthenticationContext(authority);
 	    ClientCredential clientCred = new ClientCredential(WebConfigurationManager.AppSettings["ClientId"],


### PR DESCRIPTION
There're 2 issues in the sample code of the documentation:

1. static keyword should be put before async keyword.
2. Missing "using System.Threading.Tasks;".