### PR TITLE
Updating ADLS Java SDK article to reflect current Maven packages

### DIFF
--- a/articles/data-lake-store/data-lake-store-get-started-java-sdk.md
+++ b/articles/data-lake-store/data-lake-store-get-started-java-sdk.md
@@ -13,7 +13,7 @@
    ms.topic="get-started-article"
    ms.tgt_pltfrm="na"
    ms.workload="big-data"
-   ms.date="05/12/2016"
+   ms.date="08/18/2016"
    ms.author="nitinme"/>
 
 # Get started with Azure Data Lake Store using Java
@@ -31,7 +31,7 @@ Learn how to use the Azure Data Lake Store Java SDK to create an Azure Data Lake
 
 ## Azure Data Lake Store Java SDK
 
-Following links provide you the download location for the Java SDK for Data Lake Store and the Java SDK reference. For this tutorial you do not need to download the SDK or follow the reference document. These links are for your information only.
+Following links provide you the download location for the Java SDK for Data Lake Store and the Java SDK reference. For this tutorial, you do not need to download the SDK or follow the reference document. These links are for your information only.
 
 * The source code for the Java SDK for Data Lake Store is available on [GitHub](https://github.com/Azure/azure-sdk-for-java).
 * Java SDK Reference for Data Lake Store is available at [https://azure.github.io/azure-sdk-for-java/](https://azure.github.io/azure-sdk-for-java/).
@@ -58,158 +58,110 @@ Following links provide you the download location for the Java SDK for Data Lake
 
 The code snippet below provides code for **non-interactive** authentication, where the application provides its own credentials.
 
-You will need to give your application permission to create resources in Azure for this tutorial to work. It is **highly recommended** that you only give this application Contributor permissions to a new, unusued, and empty resource group in your Azure subscription for the purposes of this tutorial.
+You will need to give your application permission to create resources in Azure for this tutorial to work. It is **highly recommended** that you only give this application Contributor permissions to a new, unused, and empty resource group in your Azure subscription for the purposes of this tutorial.
 
 ## Create a Java aplication
 
 1. Open IntelliJ and create a new Java project using the **Command Line App** template. Complete the wizard to create the project.
 
-2. Right-click on the project on the left-hand side of your screen and click **Add Framework Support**. Choose **Maven** and click **OK**.
+2. Open **File** -> **Project Structure** -> **Modules** (under Project Settings) -> **Dependencies** -> **+** -> **Library** -> **From Maven**.
 
-3. Open the newly created **"pom.xml"** file and add the following snippet of text between the **\</version>** tag and the **\</project>** tag:
+3. Search for the following Maven packages and add them your project:
 
-    >[AZURE.NOTE] This step is temporary until the Azure Data Lake Store SDK is available in Maven. This article will be updated once the SDK is available in Maven. All future updates to this SDK will be availble through Maven.
+    * com.microsoft.azure:azure-mgmt-datalake-store:1.0.0-beta1.2
+    * com.microsoft.azure:azure-mgmt-datalake-store-uploader:1.0.0-beta1.2
+    * com.microsoft.azure:azure-client-authentication:1.0.0-beta2
 
-        <repositories>
-        	<repository>
-	            <id>adx-snapshots</id>
-	            <name>Azure ADX Snapshots</name>
-	            <url>http://adxsnapshots.azurewebsites.net/</url>
-	            <layout>default</layout>
-	            <snapshots>
-                	<enabled>true</enabled>
-            	</snapshots>
-        	</repository>
-        	<repository>
-	            <id>oss-snapshots</id>
-	            <name>Open Source Snapshots</name>
-	            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-	            <layout>default</layout>
-	            <snapshots>
-	                <enabled>true</enabled>
-	                <updatePolicy>always</updatePolicy>
-	            </snapshots>
-        	</repository>
-    	</repositories>
-    	<dependencies>
-	        <dependency>
-	            <groupId>com.microsoft.azure</groupId>
-	            <artifactId>azure-client-authentication</artifactId>
-	            <version>1.0.0-20160513.000802-24</version>
-	        </dependency>
-	        <dependency>
-	            <groupId>com.microsoft.azure</groupId>
-	            <artifactId>azure-client-runtime</artifactId>
-	            <version>1.0.0-20160513.000812-28</version>
-	        </dependency>
-	        <dependency>
-	            <groupId>com.microsoft.rest</groupId>
-	            <artifactId>client-runtime</artifactId>
-	            <version>1.0.0-20160513.000825-29</version>
-	        </dependency>
-	        <dependency>
-	            <groupId>com.microsoft.azure</groupId>
-	            <artifactId>azure-mgmt-datalake-store</artifactId>
-	            <version>1.0.0-SNAPSHOT</version>
-	        </dependency>
-    	</dependencies>
-
-
-4. Go to **File**, then **Settings**, then **Build, Execution, and Deployment**. Expand **Build Tools**, **Maven**, and then expand **Importing**. Select the check box for **Import Maven projects automatically**. Click **Apply** and then click **OK**.
-
-5. From the left pane, navigate to **src**, **main**, **java**, **\<package name>**, and then open **Main.java** and replace the existing code block with the following code. Also, provide the values for parameters called out in the code snippet, such as **localFolderPath**, **_adlsAccountName**, **_resourceGroupName** and replace placeholders for **CLIENT-ID**, **CLIENT-SECRET**, **TENANT-ID**, and **SUBSCRIPTION-ID**.
+4. From the left pane, navigate to **src**, **main**, **java**, **\<package name>**, and then open **Main.java** and replace the existing code block with the following code. Also, provide the values for parameters called out in the code snippet, such as **localFolderPath**, **DATA-LAKE-STORE-NAME**, **RESOURCE-GROUP-NAME** and replace placeholders for **CLIENT-ID**, **CLIENT-SECRET**, **TENANT-ID**, and **SUBSCRIPTION-ID** with information about your subscription and its Azure Active Directory. For information on how to find this information, see [the Azure guide to creating service principals](https://azure.microsoft.com/documentation/articles/resource-group-authenticate-service-principal/).
 
     This code goes through the process of creating a Data Lake Store account, creating files in the store, concatenating files, downloading a file, and finally deleting the account.
-
+    
         package com.company;
-        
+
         import com.microsoft.azure.CloudException;
         import com.microsoft.azure.credentials.ApplicationTokenCredentials;
-        import com.microsoft.azure.management.datalake.store.*;
+        import com.microsoft.azure.management.datalake.store.implementation.DataLakeStoreAccountManagementClientImpl;
+        import com.microsoft.azure.management.datalake.store.implementation.DataLakeStoreFileSystemManagementClientImpl;
         import com.microsoft.azure.management.datalake.store.models.*;
+        import com.microsoft.azure.management.datalake.store.uploader.*;
         import com.microsoft.rest.credentials.ServiceClientCredentials;
         import java.io.*;
         import java.nio.charset.Charset;
         import java.util.ArrayList;
         import java.util.List;
-        
+
         public class Main {
-            private static String _adlsAccountName;
-            private static String _resourceGroupName;
-            private static String _location;
-        
-            private static String _tenantId;
-            private static String _subId;
-            private static String _clientId;
-            private static String _clientSecret;
-        
-            private static DataLakeStoreAccountManagementClient _adlsClient;
-            private static DataLakeStoreFileSystemManagementClient _adlsFileSystemClient;
-        
+            final static String ADLS_ACCOUNT_NAME = <DATA-LAKE-STORE-NAME>;
+            final static String RESOURCE_GROUP_NAME = "<RESOURCE-GROUP-NAME>";
+            final static String LOCATION = "East US 2";
+            final static String TENANT_ID = "<TENANT-ID>";
+            final static String SUBSCRIPTION_ID =  "<SUBSCRIPTION-ID>";
+            final static String CLIENT_ID = "<CLIENT-ID>";
+            final static String CLIENT_SECRET = "<CLIENT-SECRET>"; // TODO: For production scenarios, we recommend that you replace this line with a more secure way of acquiring the application client secret, rather than hard-coding it in the source code.
+
+            private static DataLakeStoreAccountManagementClientImpl _adlsClient;
+            private static DataLakeStoreFileSystemManagementClientImpl _adlsFileSystemClient;
+
             public static void main(String[] args) throws Exception {
-                _adlsAccountName = "<DATA-LAKE-STORE-NAME>";
-                _resourceGroupName = "<RESOURCE-GROUP-NAME>";
-                _location = "East US 2";
-        
-                _tenantId = "<TENANT-ID>";
-                _subId =  "<SUBSCRIPTION-ID>";
-                _clientId = "<CLIENT-ID>";
-        
-                _clientSecret = "<CLIENT-SECRET>"; // TODO: For production scenarios, we recommend that you replace this line with a more secure way of acquiring the application client secret, rather than hard-coding it in the source code.
-        
                 String localFolderPath = "C:\\local_path\\"; // TODO: Change this to any unused, new, empty folder on your local machine.
-        
+
                 // Authenticate
-                ApplicationTokenCredentials creds = new ApplicationTokenCredentials(_clientId, _tenantId, _clientSecret, null);
+                ApplicationTokenCredentials creds = new ApplicationTokenCredentials(CLIENT_ID, TENANT_ID, CLIENT_SECRET, null);
                 SetupClients(creds);
-        
+
                 // Create Data Lake Store account
                 WaitForNewline("Authenticated.", "Creating NEW account.");
                 CreateAccount();
                 WaitForNewline("Account created.", "Displaying account(s).");
-        
+
                 // List Data Lake Store accounts that this app can access
-                System.out.println(String.format("All ADL Store accounts that this app can access in subscription %s:", _subId));
-                List<DataLakeStoreAccount> adlsListResult = _adlsClient.getAccountOperations().list().getBody();
+                System.out.println(String.format("All ADL Store accounts that this app can access in subscription %s:", SUBSCRIPTION_ID));
+                List<DataLakeStoreAccount> adlsListResult = _adlsClient.accounts().list().getBody();
                 for (DataLakeStoreAccount acct : adlsListResult) {
-                    System.out.println(acct.getName());
+                    System.out.println(acct.name());
                 }
-                WaitForNewline("Account(s) displayed.", "Creating files.");
-        
-                // Create two files in Data Lake Store: file1.csv and file2.csv
-                CreateFile("/file1.csv", "123,abc", true);
+                WaitForNewline("Account(s) displayed.", "Uploading file.");
+
+                // Upload a file to Data Lake Store: file1.csv
+                UploadFile(localFolderPath + "file1.csv", "/file1.csv");
+                WaitForNewline("File uploaded.", "Appending newline.");
+
+                // Append newline to file1.csv
+                AppendToFile("/file1.csv", "\r\n");
+                WaitForNewline("Newline appended.", "Creating file.");
+
+                // Create a new file in Data Lake Store: file2.csv
                 CreateFile("/file2.csv", "456,def", true);
-                WaitForNewline("Files created.", "Concatenating files.");
-        
+                WaitForNewline("File created.", "Concatenating files.");
+
                 // Concatenate two files in Data Lake Store
                 List<String> srcFilePaths = new ArrayList<String>();
                 srcFilePaths.add("/file1.csv");
                 srcFilePaths.add("/file2.csv");
                 ConcatenateFiles(srcFilePaths, "/input.csv");
                 WaitForNewline("Files concatenated.", "Downloading file.");
-        
+
                 // Download file from Data Lake Store
                 DownloadFile("/input.csv", localFolderPath + "input.csv");
                 WaitForNewline("File downloaded.", "Deleting file.");
-        
+
                 // Delete file from Data Lake Store
                 DeleteFile("/input.csv");
                 WaitForNewline("File deleted.", "Deleting account.");
-        
+
                 // Delete account
                 DeleteAccount();
                 WaitForNewline("Account deleted.", "DONE.");
             }
-        
+
             //Set up clients
             public static void SetupClients(ServiceClientCredentials creds)
             {
                 _adlsClient = new DataLakeStoreAccountManagementClientImpl(creds);
                 _adlsFileSystemClient = new DataLakeStoreFileSystemManagementClientImpl(creds);
-        
-                _adlsClient.setSubscriptionId(_subId);
+                _adlsClient.withSubscriptionId(SUBSCRIPTION_ID);
             }
-        
+
             // Helper function to show status and wait for user input
             public static void WaitForNewline(String reason, String nextAction)
             {
@@ -229,64 +181,72 @@ You will need to give your application permission to create resources in Azure f
                     catch(Exception e){}
                 }
             }
-        
+
             // Create Data Lake Store account
             public static void CreateAccount() throws InterruptedException, CloudException, IOException {
                 DataLakeStoreAccount adlsParameters = new DataLakeStoreAccount();
-                adlsParameters.setLocation(_location);
-        
-                _adlsClient.getAccountOperations().create(_resourceGroupName, _adlsAccountName, adlsParameters);
+                adlsParameters.withLocation(LOCATION);
+
+                _adlsClient.accounts().create(RESOURCE_GROUP_NAME, ADLS_ACCOUNT_NAME, adlsParameters);
             }
-        
+
             // Create file
-            public static void CreateFile(String path) throws IOException, CloudException {
-                _adlsFileSystemClient.getFileSystemOperations().create(_adlsAccountName, path);
+            public static void CreateFile(String path) throws IOException, AdlsErrorException {
+                _adlsFileSystemClient.fileSystems().create(ADLS_ACCOUNT_NAME, path);
             }
-        
+
             // Create file with contents
-            public static void CreateFile(String path, String contents, boolean force) throws IOException, CloudException {
+            public static void CreateFile(String path, String contents, boolean force) throws IOException, AdlsErrorException {
                 byte[] bytesContents = contents.getBytes();
-        
-                _adlsFileSystemClient.getFileSystemOperations().create(_adlsAccountName, path, bytesContents, force);
+
+                _adlsFileSystemClient.fileSystems().create(ADLS_ACCOUNT_NAME, path, bytesContents, force);
             }
-        
+
             // Append to file
-            public static void AppendToFile(String path, String contents) throws IOException, CloudException {
+            public static void AppendToFile(String path, String contents) throws IOException, AdlsErrorException {
                 byte[] bytesContents = contents.getBytes();
-        
-                _adlsFileSystemClient.getFileSystemOperations().append(_adlsAccountName, path, bytesContents);
+
+                _adlsFileSystemClient.fileSystems().append(ADLS_ACCOUNT_NAME, path, bytesContents);
             }
-        
+
             // Concatenate files
-            public static void ConcatenateFiles(List<String> srcFilePaths, String destFilePath) throws IOException, CloudException {
-                _adlsFileSystemClient.getFileSystemOperations().concat(_adlsAccountName, destFilePath, srcFilePaths);
+            public static void ConcatenateFiles(List<String> srcFilePaths, String destFilePath) throws IOException, AdlsErrorException {
+                _adlsFileSystemClient.fileSystems().concat(ADLS_ACCOUNT_NAME, destFilePath, srcFilePaths);
             }
-        
+
             // Delete concatenated file
-            public static void DeleteFile(String filePath) throws IOException, CloudException {
-                _adlsFileSystemClient.getFileSystemOperations().delete(_adlsAccountName, filePath);
+            public static void DeleteFile(String filePath) throws IOException, AdlsErrorException {
+                _adlsFileSystemClient.fileSystems().delete(ADLS_ACCOUNT_NAME, filePath);
             }
-        
+
             // Get file or directory info
-            public static FileStatusProperties GetItemInfo(String path) throws IOException, CloudException {
-                return _adlsFileSystemClient.getFileSystemOperations().getFileStatus(_adlsAccountName, path).getBody().getFileStatus();
+            public static FileStatusProperties GetItemInfo(String path) throws IOException, AdlsErrorException {
+                return _adlsFileSystemClient.fileSystems().getFileStatus(ADLS_ACCOUNT_NAME, path).getBody().fileStatus();
             }
-        
+
             // List files and directories
-            public static List<FileStatusProperties> ListItems(String directoryPath) throws IOException, CloudException {
-                return _adlsFileSystemClient.getFileSystemOperations().listFileStatus(_adlsAccountName, directoryPath).getBody().getFileStatuses().getFileStatus();
+            public static List<FileStatusProperties> ListItems(String directoryPath) throws IOException, AdlsErrorException {
+                return _adlsFileSystemClient.fileSystems().listFileStatus(ADLS_ACCOUNT_NAME, directoryPath).getBody().fileStatuses().fileStatus();
             }
-        
+
+            // Upload file
+            public static void UploadFile(String srcPath, String destPath) throws Exception {
+                UploadParameters parameters = new UploadParameters(srcPath, destPath, ADLS_ACCOUNT_NAME);
+                FrontEndAdapter frontend = new DataLakeStoreFrontEndAdapterImpl(ADLS_ACCOUNT_NAME, _adlsFileSystemClient);
+                DataLakeStoreUploader uploader = new DataLakeStoreUploader(parameters, frontend);
+                uploader.execute();
+            }
+
             // Download file
-            public static void DownloadFile(String srcPath, String destPath) throws IOException, CloudException {
-                InputStream stream = _adlsFileSystemClient.getFileSystemOperations().open(_adlsAccountName, srcPath).getBody();
-        
+            public static void DownloadFile(String srcPath, String destPath) throws IOException, AdlsErrorException {
+                InputStream stream = _adlsFileSystemClient.fileSystems().open(ADLS_ACCOUNT_NAME, srcPath).getBody();
+
                 PrintWriter pWriter = new PrintWriter(destPath, Charset.defaultCharset().name());
-        
+
                 String fileContents = "";
                 if (stream != null) {
                     Writer writer = new StringWriter();
-        
+
                     char[] buffer = new char[1024];
                     try {
                         Reader reader = new BufferedReader(
@@ -300,14 +260,14 @@ You will need to give your application permission to create resources in Azure f
                     }
                     fileContents =  writer.toString();
                 }
-        
+
                 pWriter.println(fileContents);
                 pWriter.close();
             }
-        
+
             // Delete account
             public static void DeleteAccount() throws InterruptedException, CloudException, IOException {
-                _adlsClient.getAccountOperations().delete(_resourceGroupName, _adlsAccountName);
+                _adlsClient.accounts().delete(RESOURCE_GROUP_NAME, ADLS_ACCOUNT_NAME);
             }
         }
 


### PR DESCRIPTION
Updating ADLS Java SDK article to reflect current Maven packages.

The new code and steps in this PR have been tested, and they work. The core changes include: updated steps for project creation so that it doesn't deal with POM.xml creation, the use of Maven instead of ADX Snapshot packages, and the refactorings required to use the new packages.

@begoldsm, could you ACK please?

@nitinme, @mumian, could one of your sign off on this, please?