### PR TITLE
Change Write-Host to Write-Output

### DIFF
--- a/articles/cloud-services/cloud-services-python-ptvs.md
+++ b/articles/cloud-services/cloud-services-python-ptvs.md
@@ -173,7 +173,7 @@ $is_python2 = $env:PYTHON2 -eq "on"
 $nl = [Environment]::NewLine
 
 if (-not $is_emulated){
-	Write-Host "Checking if python is installed...$nl"
+	Write-Output "Checking if python is installed...$nl"
 	if ($is_python2) {
 		& "${env:SystemDrive}\Python27\python.exe"  -V | Out-Null
 	}
@@ -191,9 +191,9 @@ if (-not $is_emulated){
 			$outFile = "${env:TEMP}\python-2.7.12.amd64.msi"
 		}
 		
-		Write-Host "Not found, downloading $url to $outFile$nl"
+		Write-Output "Not found, downloading $url to $outFile$nl"
 		Invoke-WebRequest $url -OutFile $outFile
-		Write-Host "Installing$nl"
+		Write-Output "Installing$nl"
 
 		if ($is_python2) {
 			Start-Process msiexec.exe -ArgumentList "/q", "/i", "$outFile", "ALLUSERS=1" -Wait
@@ -202,10 +202,10 @@ if (-not $is_emulated){
 			Start-Process "$outFile" -ArgumentList "/quiet", "InstallAllUsers=1" -Wait
 		}
 
-		Write-Host "Done$nl"
+		Write-Output "Done$nl"
 	}
 	else {
-		Write-Host "Already installed"
+		Write-Output "Already installed"
 	}
 }
 ```
@@ -220,9 +220,9 @@ $is_python2 = $env:PYTHON2 -eq "on"
 $nl = [Environment]::NewLine
 
 if (-not $is_emulated){
-	Write-Host "Checking if requirements.txt exists$nl"
+	Write-Output "Checking if requirements.txt exists$nl"
 	if (Test-Path ..\requirements.txt) {
-		Write-Host "Found. Processing pip$nl"
+		Write-Output "Found. Processing pip$nl"
 
 		if ($is_python2) {
 			& "${env:SystemDrive}\Python27\python.exe" -m pip install -r ..\requirements.txt
@@ -231,10 +231,10 @@ if (-not $is_emulated){
 			py -m pip install -r ..\requirements.txt
 		}
 
-		Write-Host "Done$nl"
+		Write-Output "Done$nl"
 	}
 	else {
-		Write-Host "Not found$nl"
+		Write-Output "Not found$nl"
 	}
 }
 ```
@@ -252,7 +252,7 @@ $nl = [Environment]::NewLine
 
 if (-not $is_emulated)
 {
-	Write-Host "Running worker.py$nl"
+	Write-Output "Running worker.py$nl"
 
 	if ($is_python2) {
 		cd..
@@ -265,7 +265,7 @@ if (-not $is_emulated)
 }
 else
 {
-	Write-Host "Running (EMULATED) worker.py$nl"
+	Write-Output "Running (EMULATED) worker.py$nl"
 
 	# Customize to your local dev environment
 


### PR DESCRIPTION
"Script definition uses Write-Host. Avoid using Write-Host because it might not work in all hosts, does not work when there is no host, and (prior to PS 5.0) cannot be suppressed, captured, or redirected." Source: http://www.jsnover.com/blog/2013/12/07/write-host-considered-harmful/