### PR TITLE
Update virtual-machines-linux-ssh-from-windows.md

### DIFF
--- a/articles/virtual-machines/virtual-machines-linux-ssh-from-windows.md
+++ b/articles/virtual-machines/virtual-machines-linux-ssh-from-windows.md
@@ -163,7 +163,7 @@ The easiest way to resolve this is to set the `OPENSSL_CONF` environment variabl
 
 	![linuxputtyconfig](./media/virtual-machines-linux-ssh-from-windows/linuxputtyconfig.png)
 
-4.	Before selecting **Open**, click the Connection > SSH > Auth tab to choose your key. See the screenshot below for the field to fill in:
+4.	Before selecting **Open**, click the Connection > SSH > Auth tab to choose your private key. See the screenshot below for the field to fill in:
 
 	![linuxputtyprivatekey](./media/virtual-machines-linux-ssh-from-windows/linuxputtyprivatekey.png)
 


### PR DESCRIPTION
Explicitly mentioned private key in the Connection > SSH > Auth tab of PuTTY. For users really new with Public/Private Keys the ambiguity can be unhelpful.