### PR TITLE
Stop further role initialization when restart is needed

### DIFF
--- a/articles/cloud-services/cloud-services-dotnet-install-dotnet.md
+++ b/articles/cloud-services/cloud-services-dotnet-install-dotnet.md
@@ -141,7 +141,7 @@ Startup tasks allow you to perform operations before a role starts. Installing t
 	
 	:restart
 	echo Restarting to complete .NET (%netfx%) installation >> %startuptasklog%
-	goto end
+	EXIT /B %ERRORLEVEL%
 	
 	:installed
 	echo .NET (%netfx%) is installed >> %startuptasklog%


### PR DESCRIPTION
When a role needs to restart after installing a new .NET, `install.cmd` should exit with a non-zero value to prevent further role initialization.

Example:
* A role with with .NET 4.5 installed
* Code in RoleEntryPoint.OnStart() that relies on .NET 4.6, e.g. [`System.Array.Empty()`](https://msdn.microsoft.com/en-us/library/dn906179(v=vs.110).aspx)

* As the installation is executed without the /norestart switch it initiates a reboot after installation.
* Install.cmd exits with 0
* All startup tasks returns 0, so [initialization continues](https://azure.microsoft.com/en-us/documentation/articles/cloud-services-startup-tasks/) by executing RoleEntryPoint.OnStart()
* A `System.MissingMethodException` is thrown, as `System.Array.Empty()` is not available in .NET 4.5
* The role reboots
* After rebooting no exceptions are thrown, as .NET 4.6 is now fully installed.
 
If `install.cmd` is placed as the first startup task and all tasks are executed synchronously, this should have *no* side-effects.

Anyways startup tasks must be written with [precautions for multiple executions between reboots](https://azure.microsoft.com/da-dk/documentation/articles/cloud-services-startup-tasks-common/#detect-that-your-task-has-already-run).

I have tested this change in `install.cmd` as a working solution to the example shown above.