### PR TITLE
Ensure WindowsFeature Web-IP-Security Is On

### DIFF
--- a/articles/cloud-services/cloud-services-startup-tasks-common.md
+++ b/articles/cloud-services/cloud-services-startup-tasks-common.md
@@ -175,6 +175,10 @@ Add the following startup task to the [ServiceDefinition.csdef] file.
 
 Add this command to the **startup.cmd** file:
 
+    @echo off
+    @echo Installing "IPv4 Address and Domain Restrictions" feature 
+    powershell -ExecutionPolicy Unrestricted -command "Install-WindowsFeature Web-IP-Security"
+    @echo Unlocking configuration for "IPv4 Address and Domain Restrictions" feature 
     %windir%\system32\inetsrv\AppCmd.exe unlock config -section:system.webServer/security/ipSecurity
 
 This causes the **startup.cmd** batch file to be run every time the web role is initialized, ensuring that the required **ipSecurity** section is unlocked.


### PR DESCRIPTION
We have found that unlocking the section is not enough and that the IP security feature is not switched on by default. Caused a bit of a delay to getting IP sec up and running.

Got the above script from Satya Ramani at azure support and feel it would have been really helpful if it had been here, which was the first place we looked.