### PR TITLE
bringing back unsupported features

### DIFF
--- a/articles/service-bus/service-bus-dotnet-advanced-message-queuing.md
+++ b/articles/service-bus/service-bus-dotnet-advanced-message-queuing.md
@@ -291,6 +291,13 @@ Received message with JMSMessageID = ID:acbca67f03c346de9b7893026f97ddeb
 exit
 ```
 
+## Unsupported features and restrictions
+
+The following features of the .NET Service Bus API are not currently supported when using AMQP:
+
+ * Transactions
+ * Send via transfer destination
+
 ## Summary
 
 This article showed how to access the Service Bus brokered messaging features (queues and publish/subscribe topics) from .NET using AMQP 1.0 and the Service Bus .NET API.


### PR DESCRIPTION
While it would be great to have feature parity, `transactions `and `sendvia` do not work.
Additionally, there's an [additional document](https://azure.microsoft.com/en-us/documentation/articles/service-bus-amqp-dotnet/#unsupported-features-restrictions-and-behavioral-differences) that lists `transactions`, `sendvia`, and `Scaled-out receive` as unsupported.

@jtaubensee @sethmanheim please review