### PR TITLE
Update web-sites-configure-ssl-certificate.md

### DIFF
--- a/articles/app-service-web/web-sites-configure-ssl-certificate.md
+++ b/articles/app-service-web/web-sites-configure-ssl-certificate.md
@@ -521,7 +521,9 @@ Then, click **Upload** to upload the certificate. You should now see your upload
 If you use **SNI SSL** bindings only, skip this section. Multiple **SNI SSL** 
 bindings can work together on the existing shared IP address assigned to your app. However, if you create an 
 **IP based SSL** binding, App Service creates a dedicated IP address for the binding because the 
-**IP based SSL** requires one. Because of this dedicated IP address, you will need to configure your app
+**IP based SSL** requires one. Only one dedicated IP address can be created, therefore only one **IP based SSL** binding may be added.
+
+Because of this dedicated IP address, you will need to configure your app
 further if:
 
 - You [used an A record to map your custom domain](web-sites-custom-domain-name.md#a) to your Azure app, and


### PR DESCRIPTION
Adding clarification on multiple IP SSL bindings. Knowing this would have saved me a lot of time, and avoided this unfortunate bug: https://social.msdn.microsoft.com/Forums/en-US/8c0305ae-7f51-40c6-ae36-762c04e2030a/adding-multiple-ip-ssl-bindings?forum=windowsazurewebsitespreview

Basically the portal allows you to add multiple IP SSL bindings to an app, but it just doesn't work.