### PR TITLE
Make clear that developers must use default Redirect URI

### DIFF
--- a/articles/active-directory/active-directory-v2-devquickstarts-android.md
+++ b/articles/active-directory/active-directory-v2-devquickstarts-android.md
@@ -49,7 +49,8 @@ Create a new app at the [Application registration portal](https://apps.dev.micro
 
 - Copy the **Application Id** that's assigned to your app because you'll need it soon.
 - Add the **Mobile** platform for your app.
-- Copy the **Redirect URI** from the portal. You must use the default value of `https://login.microsoftonline.com/common/oauth2/nativeclient`.
+
+> Note: The Application registration portal provides a **Redirect URI** value. However, in this example you must use the default value of `https://login.microsoftonline.com/common/oauth2/nativeclient`.
 
 
 ## Download the NXOAuth2 third-party library and create a workspace


### PR DESCRIPTION
Make clear that developers won't be using the portal provided redirect URI. They must use the default value of `https://login.microsoftonline.com/common/oauth2/nativeclient`.

Previous text instructed developers to copy the portal provided value, which is not used afterwards.