### PR TITLE
Step 2 line 60 and Line 74

### DIFF
--- a/articles/app-service-api/app-service-api-nodejs-api-app.md
+++ b/articles/app-service-api/app-service-api-nodejs-api-app.md
@@ -57,7 +57,7 @@ While App Service supports many ways to deploy your code to an API app, this tut
 
 	Swaggerize is a tool that generates server code for an API described by a Swagger metadata file. The Swagger file that you'll use is named *api.json* and is located in the *start* folder of the repository you cloned.
 
-2. Navigate to the *start* folder, and then execute the `yo swaggerize` command. Swaggerize will ask a series of questions.  For **what to call this project**, enter "contactlist", for **path to swagger document**, enter "api.json", and for **Express, Hapi, or Restify**, enter "express".
+2. Navigate to the *start* folder, and then execute the `yo swaggerize` command. Swaggerize will ask a series of questions.  For **what to call this project**, enter "ContactList", for **path to swagger document**, enter "api.json", and for **Express, Hapi, or Restify**, enter "express".
 
 		yo swaggerize
 
@@ -71,7 +71,7 @@ While App Service supports many ways to deploy your code to an API app, this tut
 
  		"regenerate": "yo swaggerize --only=handlers,models,tests --framework express --apiPath config/api.json"
 
-1. Navigate to the folder that contains the scaffolded code (in this case, the *ContactList* subfolder).
+1. Navigate to the folder that contains the scaffolded code (in this case, the */start/ContactList* subfolder).
 
 1. Run `npm install`.
 	


### PR DESCRIPTION
In swaggerize steps, docs say to enter project name "contactlist", all lower case. In the code screenshot, "ContactList" with caps rather than all lowercase is entered. In the next steps docs say to cd to "ContactList". The git clone has a "ContactList" folder so that is what you would be cd'ing to, as I did. I also changed line 74 to give the path to the subfolder, just to be clear as possible. Hope this helps.