### PR TITLE
Fixed the comments in createContainerIfNotExists sample code

### DIFF
--- a/articles/storage/storage-nodejs-how-to-use-blob-storage.md
+++ b/articles/storage/storage-nodejs-how-to-use-blob-storage.md
@@ -85,9 +85,7 @@ To create a new container, use **createContainerIfNotExists**. The following cod
 
 	blobSvc.createContainerIfNotExists('mycontainer', function(error, result, response){
 	    if(!error){
-	      // Container exists and allows
-	      // anonymous read access to blob
-	      // content and metadata within this container
+	      // Container exists and is private
 	    }
 	});
 
@@ -105,7 +103,9 @@ The following code example demonstrates setting the access level to **blob**:
 
 	blobSvc.createContainerIfNotExists('mycontainer', {publicAccessLevel : 'blob'}, function(error, result, response){
 	    if(!error){
-	      // Container exists and is private
+	      // Container exists and allows
+	      // anonymous read access to blob
+	      // content and metadata within this container
 	    }
 	});
 


### PR DESCRIPTION
The one without ACL had the comment saying "anonymous read access to blob", whereas the one with the explicit 'blob' ACL had the comment "container is private". Switched.