### PR TITLE
Added mention for log_errors = on

### DIFF
--- a/articles/app-service-web/web-sites-php-configure.md
+++ b/articles/app-service-web/web-sites-php-configure.md
@@ -86,6 +86,10 @@ For any built-in PHP runtime, you can change any of the configuration options by
 		; Example Settings
 		display_errors=On
 		upload_max_filesize=10M
+		
+		; Turn this on to write PHP errors
+		; to d:\home\LogFiles\php_errors.log
+		log_errors=On
 
 3. Deploy your web app.
 4. Restart the web app. (Restarting is necessary because the frequency with which PHP reads `.user.ini` files is governed by the `user_ini.cache_ttl` setting, which is a system level setting and is 300 seconds (5 minutes) by default. Restarting the web app forces PHP to read the new settings in the `.user.ini` file.)

--- a/articles/app-service-web/web-sites-php-configure.md
+++ b/articles/app-service-web/web-sites-php-configure.md
@@ -87,10 +87,8 @@ For any built-in PHP runtime, you can change any of the configuration options by
 		display_errors=On
 		upload_max_filesize=10M
 		
-		; OPTIONAL:
-		; Turn this on to write PHP errors
-		; to d:\home\LogFiles\php_errors.log
-		log_errors=On
+		; OPTIONAL: Turn this on to write errors to d:\home\LogFiles\php_errors.log
+		; log_errors=On
 
 3. Deploy your web app.
 4. Restart the web app. (Restarting is necessary because the frequency with which PHP reads `.user.ini` files is governed by the `user_ini.cache_ttl` setting, which is a system level setting and is 300 seconds (5 minutes) by default. Restarting the web app forces PHP to read the new settings in the `.user.ini` file.)

--- a/articles/app-service-web/web-sites-php-configure.md
+++ b/articles/app-service-web/web-sites-php-configure.md
@@ -87,6 +87,7 @@ For any built-in PHP runtime, you can change any of the configuration options by
 		display_errors=On
 		upload_max_filesize=10M
 		
+		; OPTIONAL:
 		; Turn this on to write PHP errors
 		; to d:\home\LogFiles\php_errors.log
 		log_errors=On


### PR DESCRIPTION
Without `log_errors = on` nothing gets written to `d:\home\LogFiles\php_errors.log`