### PR TITLE
Remove [Azure.Note]

### DIFF
--- a/articles/active-directory/active-directory-add-company-branding.md
+++ b/articles/active-directory/active-directory-add-company-branding.md
@@ -27,10 +27,7 @@ To avoid confusion, many companies want to apply a consistent look and feel acro
 
 This topic explains how you can customize the sign-in page and the access panel page.
 
-> [AZURE.NOTE]
->
-- Company branding is a feature that is available only if you upgraded to the Premium or Basic edition of Azure Active Directory. For more information, see [Azure Active Directory editions](active-directory-editions.md).
-- Azure Active Directory Premium and Basic editions are available for customers in China using the worldwide instance of Azure Active Directory. Azure Active Directory Premium and Basic editions are not currently supported in the Microsoft Azure service operated by 21Vianet in China. For more information, contact us at the [Azure Active Directory Forum](https://feedback.azure.com/forums/169401-azure-active-directory/).
+
 
 
 


### PR DESCRIPTION
As of 2-17-15 there is no longer a requirement for Azure AD Premium or Basic to add company branding per this blog: https://blogs.office.com/2015/02/17/sign-page-branding-cloud-user-self-service-password-reset-office-365/

Can you please update this page as it caused us confusion with a client since we read it on the Azure documentation site and assumed it was correct?