### PR TITLE
Fix code that generates SAS URL

### DIFF
--- a/articles/app-service/app-service-powershell-backup.md
+++ b/articles/app-service/app-service-powershell-backup.md
@@ -40,8 +40,7 @@ A SAS URL can be generated with PowerShell. Here is an example of how to generat
 		$context = New-AzureStorageContext -StorageAccountName $storageAccountName -StorageAccountKey $storageAccountKey[0].Value
 
 		$blobContainerName = "<name of blob container for app backups>"
-		$token = New-AzureStorageContainerSASToken -Name $blobContainerName -Permission rwdl -Context $context -ExpiryTime (Get-Date).AddMonths(1)
-		$sasUrl = $context.BlobEndPoint + $blobContainerName + $token
+		$sasUrl = New-AzureStorageContainerSASToken -Name $blobContainerName -Permission rwdl -Context $context -ExpiryTime (Get-Date).AddMonths(1)
 
 ## Install Azure PowerShell 1.3.2 or greater
 

--- a/articles/app-service/app-service-powershell-backup.md
+++ b/articles/app-service/app-service-powershell-backup.md
@@ -40,7 +40,7 @@ A SAS URL can be generated with PowerShell. Here is an example of how to generat
 		$context = New-AzureStorageContext -StorageAccountName $storageAccountName -StorageAccountKey $storageAccountKey[0].Value
 
 		$blobContainerName = "<name of blob container for app backups>"
-		$sasUrl = New-AzureStorageContainerSASToken -Name $blobContainerName -Permission rwdl -Context $context -ExpiryTime (Get-Date).AddMonths(1)
+		$sasUrl = New-AzureStorageContainerSASToken -Name $blobContainerName -Permission rwdl -Context $context -ExpiryTime (Get-Date).AddMonths(1) -FullUri
 
 ## Install Azure PowerShell 1.3.2 or greater
 


### PR DESCRIPTION
The New-AzureStorageContainerSASToken cmdlet already returns an URL that includes the account endpoint and container name.