### PR TITLE
Add an F# Azure Functions developer reference

### DIFF
--- a/articles/azure-functions/functions-bindings-documentdb.md
+++ b/articles/azure-functions/functions-bindings-documentdb.md
@@ -76,7 +76,7 @@ Using the example function.json above, the DocumentDB input binding will retriev
 	let Run(myQueueItem: string, document: obj) =
 	    document?text <- "This has changed."
 
-You will need a `project.json` file that uses NuGet to reference the `FSharp.Interop.Dynamic` and `Dynamitey` assemblies, like this:
+You will need a `project.json` file that uses NuGet to specify the `FSharp.Interop.Dynamic` and `Dynamitey` packages as package dependencies, like this:
 
 	{
 	  "frameworks": {

--- a/articles/azure-functions/functions-bindings-documentdb.md
+++ b/articles/azure-functions/functions-bindings-documentdb.md
@@ -68,6 +68,27 @@ Using the example function.json above, the DocumentDB input binding will retriev
 	    document.text = "This has changed.";
 	}
 
+#### Azure DocumentDB input code example for an F# queue trigger
+
+Using the example function.json above, the DocumentDB input binding will retrieve the document with the id that matches the queue message string and pass it to the 'document' parameter. If that document is not found, the 'document' parameter will be null. The document is then updated with the new text value when the function exits.
+
+	open FSharp.Interop.Dynamic
+	let Run(myQueueItem: string, document: obj) =
+	    document?text <- "This has changed."
+
+You will need a `project.json` file that includes both `FSharp.Interop.Dynamic` and `Dynamitey`, such as this:
+
+	{
+	  "frameworks": {
+	    "net46": {
+	      "dependencies": {
+	        "Dynamitey": "1.0.2",
+	        "FSharp.Interop.Dynamic": "3.0.0"
+	      }
+	    }
+	  }
+	}
+
 #### Azure DocumentDB input code example for a Node.js queue trigger
  
 Using the example function.json above, the DocumentDB input binding will retrieve the document with the id that matches the queue message string and pass it to the `documentIn` binding property. In Node.js functions, updated documents are not sent back to the collection. However, you can pass the input binding directly to a DocumentDB output binding named `documentOut` to support updates. This code example updates the text property of the input document and sets it as the output document.
@@ -131,6 +152,12 @@ The output document:
 	}
  
 
+#### Azure DocumentDB output code example for an F# queue trigger
+
+	open FSharp.Interop.Dynamic
+	let Run(myQueueItem: string, document: obj) =
+	    document?text <- (sprintf "I'm running in an F# function! %s" myQueueItem)
+
 #### Azure DocumentDB output code example for a C# queue trigger
 
 
@@ -177,6 +204,27 @@ You could use the following C# code in a queue trigger function:
 	        address = employee.address
 	    };
 	}
+
+Or the equivalent F# code:
+
+	open FSharp.Interop.Dynamic
+	open Newtonsoft.Json
+
+	type Employee = {
+	    id: string
+	    name: string
+	    employeeId: string
+	    address: string
+	}
+
+	let Run(myQueueItem: string, employeeDocument: byref<obj>, log: TraceWriter) =
+	    log.Info(sprintf "F# Queue trigger function processed: %s" myQueueItem)
+	    let employee = JObject.Parse(myQueueItem)
+	    employeeDocument <-
+	        { id = sprintf "%s-%s" employee?name employee?employeeId
+	          name = employee?name
+	          employeeId = employee?id
+	          address = employee?address }
 
 Example output:
 

--- a/articles/azure-functions/functions-bindings-documentdb.md
+++ b/articles/azure-functions/functions-bindings-documentdb.md
@@ -76,7 +76,7 @@ Using the example function.json above, the DocumentDB input binding will retriev
 	let Run(myQueueItem: string, document: obj) =
 	    document?text <- "This has changed."
 
-You will need a `project.json` file that includes both `FSharp.Interop.Dynamic` and `Dynamitey`, such as this:
+You will need a `project.json` file that uses NuGet to reference the `FSharp.Interop.Dynamic` and `Dynamitey` assemblies, like this:
 
 	{
 	  "frameworks": {
@@ -88,6 +88,8 @@ You will need a `project.json` file that includes both `FSharp.Interop.Dynamic` 
 	    }
 	  }
 	}
+
+This will use NuGet to fetch your dependencies and will reference them in your script.
 
 #### Azure DocumentDB input code example for a Node.js queue trigger
  

--- a/articles/azure-functions/functions-bindings-event-hubs.md
+++ b/articles/azure-functions/functions-bindings-event-hubs.md
@@ -65,6 +65,13 @@ Using the example function.json above, the body of the event message will be log
 	    log.Info($"C# Event Hub trigger function processed a message: {myEventHubMessage}");
 	}
 
+#### Azure Event Hub trigger F# example
+
+Using the example function.json above, the body of the event message will be logged using the F# function code below:
+
+	let Run(myEventHubMessage: string, log: TraceWriter) =
+	    log.Info(sprintf "F# eventhub trigger function processed work item: %s" myEventHubMessage)
+
 #### Azure Event Hub trigger Node.js example
  
 Using the example function.json above, the body of the event message will be logged using the Node.js function code below:
@@ -112,6 +119,15 @@ The following C# example function code demonstrates writing a event to an Event 
 	    
 	    outputEventHubMessage = msg;
 	}
+
+#### Azure Event Hub F# code example for output binding
+
+The following F# example function code demonstrates writing a event to an Event Hub event stream. This example represents the Event Hub output binding shown above applied to a C# timer trigger.
+
+	let Run(myTimer: TimerInfo, outputEventHubMessage: byref<string>, log: TraceWriter) =
+	    let msg = sprintf "TimerTriggerFSharp1 executed at: %s" DateTime.Now.ToString()
+	    log.Verbose(msg);
+	    outputEventHubMessage <- msg;
 
 #### Azure Event Hub Node.js code example for output binding
  

--- a/articles/azure-functions/functions-bindings-event-hubs.md
+++ b/articles/azure-functions/functions-bindings-event-hubs.md
@@ -107,7 +107,7 @@ The *function.json* file for an Azure Event Hub output binding specifies the fol
 
 #### Azure Event Hub C# code example for output binding
  
-The following C# example function code demonstrates writing a event to an Event Hub event stream. This example represents the Event Hub output binding shown above applied to a C# timer trigger.  
+The following C# example function code demonstrates writing an event to an Event Hub event stream. This example represents the Event Hub output binding shown above applied to a C# timer trigger.  
  
 	using System;
 	
@@ -122,7 +122,7 @@ The following C# example function code demonstrates writing a event to an Event 
 
 #### Azure Event Hub F# code example for output binding
 
-The following F# example function code demonstrates writing a event to an Event Hub event stream. This example represents the Event Hub output binding shown above applied to a C# timer trigger.
+The following F# example function code demonstrates writing an event to an Event Hub event stream. This example represents the Event Hub output binding shown above applied to a C# timer trigger.
 
 	let Run(myTimer: TimerInfo, outputEventHubMessage: byref<string>, log: TraceWriter) =
 	    let msg = sprintf "TimerTriggerFSharp1 executed at: %s" DateTime.Now.ToString()

--- a/articles/azure-functions/functions-bindings-http-webhook.md
+++ b/articles/azure-functions/functions-bindings-http-webhook.md
@@ -160,11 +160,11 @@ let Run(req: HttpRequestMessage) =
             try
                 return req.CreateResponse(HttpStatusCode.OK, "Hello " + data?name)
             with e ->
-            return req.CreateErrorResponse(HttpStatusCode.BadRequest, "Please pass a name on the query string or in the request body")
+                return req.CreateErrorResponse(HttpStatusCode.BadRequest, "Please pass a name on the query string or in the request body")
     } |> Async.StartAsTask
 ```
 
-You will need a `project.json` file that includes both `FSharp.Interop.Dynamic` and `Dynamitey`, such as this:
+You will need a `project.json` file that uses NuGet to reference the `FSharp.Interop.Dynamic` and `Dynamitey` assemblies, like this:
 
 ```json
 {
@@ -178,6 +178,8 @@ You will need a `project.json` file that includes both `FSharp.Interop.Dynamic` 
   }
 }
 ```
+
+This will use NuGet to fetch your dependencies and will reference them in your script.
 
 ## Example Node.js code for an HTTP trigger function 
 

--- a/articles/azure-functions/functions-bindings-http-webhook.md
+++ b/articles/azure-functions/functions-bindings-http-webhook.md
@@ -242,10 +242,11 @@ type Response = {
     body: string
 }
 
-let Run(req: HttpRequestMessage) =
+let Run(req: HttpRequestMessage, log: TraceWriter) =
     async {
         let! content = req.Content.ReadAsStringAsync() |> Async.AwaitTask
         let data = content |> JsonConvert.DeserializeObject
+        log.Info(sprintf "GitHub WebHook triggered! %s" data?comment?body)
         return req.CreateResponse(
             HttpStatusCode.OK,
             { body = sprintf "New GitHub comment: %s" data?comment?body })

--- a/articles/azure-functions/functions-bindings-http-webhook.md
+++ b/articles/azure-functions/functions-bindings-http-webhook.md
@@ -138,6 +138,47 @@ public static async Task<HttpResponseMessage> Run(HttpRequestMessage req, TraceW
 }
 ```
 
+## Example F# code for an HTTP trigger function
+
+The example code looks for a `name` parameter either in the query string or the body of the HTTP request.
+
+```fsharp
+open System.Net
+open System.Net.Http
+open FSharp.Interop.Dynamic
+
+let Run(req: HttpRequestMessage) =
+    async {
+        let q =
+            req.GetQueryNameValuePairs()
+                |> Seq.tryFind (fun kv -> kv.Key = "name")
+        match q with
+        | Some kv ->
+            return req.CreateResponse(HttpStatusCode.OK, "Hello " + kv.Value)
+        | None ->
+            let! data = Async.AwaitTask(req.Content.ReadAsAsync<obj>())
+            try
+                return req.CreateResponse(HttpStatusCode.OK, "Hello " + data?name)
+            with e ->
+            return req.CreateErrorResponse(HttpStatusCode.BadRequest, "Please pass a name on the query string or in the request body")
+    } |> Async.StartAsTask
+```
+
+You will need a `project.json` file that includes both `FSharp.Interop.Dynamic` and `Dynamitey`, such as this:
+
+```json
+{
+  "frameworks": {
+    "net46": {
+      "dependencies": {
+        "Dynamitey": "1.0.2",
+        "FSharp.Interop.Dynamic": "3.0.0"
+      }
+    }
+  }
+}
+```
+
 ## Example Node.js code for an HTTP trigger function 
 
 This example code looks for a `name` parameter either in the query string or the body of the HTTP request.
@@ -185,6 +226,30 @@ public static async Task<object> Run(HttpRequestMessage req, TraceWriter log)
         body = $"New GitHub comment: {data.comment.body}"
     });
 }
+```
+
+## Example F# code for a GitHub WebHook function
+
+This example code logs GitHub issue comments.
+
+```fsharp
+open System.Net
+open System.Net.Http
+open FSharp.Interop.Dynamic
+open Newtonsoft.Json
+
+type Response = {
+    body: string
+}
+
+let Run(req: HttpRequestMessage) =
+    async {
+        let! content = req.Content.ReadAsStringAsync() |> Async.AwaitTask
+        let data = content |> JsonConvert.DeserializeObject
+        return req.CreateResponse(
+            HttpStatusCode.OK,
+            { body = sprintf "New GitHub comment: %s" data?comment?body })
+    } |> Async.StartAsTask
 ```
 
 ## Example Node.js code for a GitHub WebHook function 

--- a/articles/azure-functions/functions-bindings-notification-hubs.md
+++ b/articles/azure-functions/functions-bindings-notification-hubs.md
@@ -87,6 +87,13 @@ This example sends a notification for a [template registration](../notification-
 	    context.done();
 	};
 
+## Azure Notification Hub code example for a F# timer trigger
+
+This example sends a notification for a [template registration](../notification-hubs/notification-hubs-templates-cross-platform-push-messages.md) that contains `location` and `message`.
+
+	let Run(myTimer: TimerInfo, notification: byref<IDictionary<string, string>>) =
+	    notification = dict [("location", "Redmond"); ("message", "Hello from F#!")]
+
 ## Azure Notification Hub code example for a C# queue trigger
 
 This example sends a notification for a [template registration](../notification-hubs/notification-hubs-templates-cross-platform-push-messages.md) that contains `message`.

--- a/articles/azure-functions/functions-bindings-service-bus.md
+++ b/articles/azure-functions/functions-bindings-service-bus.md
@@ -67,6 +67,13 @@ public static void Run(string myQueueItem, TraceWriter log)
 }
 ```
 
+#### F# code example that processes a Service Bus queue message
+
+```fsharp
+let Run(myQueueItem: string, log: TraceWriter) =
+    log.Info(sprintf "F# ServiceBus queue trigger function processed message: %s" myQueueItem)
+```
+
 #### Node.js code example that processes a Service Bus queue message
 
 ```javascript
@@ -166,6 +173,15 @@ public static void Run(TimerInfo myTimer, TraceWriter log, ICollector<string> ou
     outputSbQueue.Add("1 " + message);
     outputSbQueue.Add("2 " + message);
 }
+```
+
+#### F# code example that creates a Service Bus queue message
+
+```fsharp
+let Run(myTimer: TimerInfo, log: TraceWriter, outputSbQueue: byref<string>) =
+    let message = sprintf "Service Bus queue message created at: %s" (DateTime.Now.ToString())
+    log.Info(message)
+    outputSbQueue = message
 ```
 
 #### Node.js code example that creates a Service Bus queue message

--- a/articles/azure-functions/functions-bindings-storage.md
+++ b/articles/azure-functions/functions-bindings-storage.md
@@ -461,6 +461,21 @@ public class Person
 }
 ```
 
+The following F# code example also works with the preceding *function.json* file to read a single table entity.
+
+```fsharp
+[<CLIMutable>]
+type Person = {
+  PartitionKey: string
+  RowKey: string
+  Name: string
+}
+
+let Run(myQueueItem: string, personEntity: Person) =
+    log.Info(sprintf "F# Queue trigger function processed: %s" myQueueItem)
+    log.Info(sprintf "Name in Person entity: %s" personEntity.Name)
+```
+
 The following Node code example also works with the preceding *function.json* file to read a single table entity.
 
 ```javascript
@@ -565,6 +580,47 @@ public class Person
     public string Name { get; set; }
 }
 
+```
+
+#### Storage tables example: Create table entities in F#
+
+The following *function.json* and *run.csx* example shows how to write table entities in F#.
+
+```json
+{
+  "bindings": [
+    {
+      "name": "input",
+      "type": "manualTrigger",
+      "direction": "in"
+    },
+    {
+      "tableName": "Person",
+      "connection": "MyStorageConnection",
+      "name": "tableBinding",
+      "type": "table",
+      "direction": "out"
+    }
+  ],
+  "disabled": false
+}
+```
+
+```fsharp
+[<CLIMutable>]
+type Person = {
+  PartitionKey: string
+  RowKey: string
+  Name: string
+}
+
+let Run(input: string, tableBinding: ICollector<Person>, log: TraceWriter) =
+    for i = 1 to 10 do
+        log.Info(sprintf "Adding Person entity %d" i)
+        tableBinding.Add(
+            { PartitionKey = "Test"
+              RowKey = i.ToString()
+              Name = "Name" + i.ToString() })
 ```
 
 #### Storage tables example: Create a table entity in Node

--- a/articles/azure-functions/functions-bindings-storage.md
+++ b/articles/azure-functions/functions-bindings-storage.md
@@ -584,7 +584,7 @@ public class Person
 
 #### Storage tables example: Create table entities in F#
 
-The following *function.json* and *run.csx* example shows how to write table entities in F#.
+The following *function.json* and *run.fsx* example shows how to write table entities in F#.
 
 ```json
 {

--- a/articles/azure-functions/functions-overview.md
+++ b/articles/azure-functions/functions-overview.md
@@ -21,7 +21,7 @@
    
 # Azure Functions Overview
 
-Azure Functions is a solution for easily running small pieces of code, or "functions," in the cloud. You can write just the code you need for the problem at hand, without worrying about a whole application or the infrastructure to run it. This can make development even more productive, and you can use your development language of choice, such as C#, Node.js, Python or PHP. Pay only for the time your code runs and trust Azure to scale as needed.
+Azure Functions is a solution for easily running small pieces of code, or "functions," in the cloud. You can write just the code you need for the problem at hand, without worrying about a whole application or the infrastructure to run it. This can make development even more productive, and you can use your development language of choice, such as C#, F#, Node.js, Python or PHP. Pay only for the time your code runs and trust Azure to scale as needed.
 
 This topic provides a high-level overview of Azure Functions. If you want to jump right in and get started with Azure Functions, start with [Create your first Azure Function](functions-create-first-azure-function.md). If you are looking for more technical information about Functions, see the [developer reference](functions-reference.md).
 
@@ -29,7 +29,7 @@ This topic provides a high-level overview of Azure Functions. If you want to jum
 
 Here are some key features of Azure Functions:
     
-* **Choice of language** - Write functions using C#, Node.js, Python, F#, PHP, batch, bash, Java, or any executable.  
+* **Choice of language** - Write functions using C#, F#, Node.js, Python, PHP, batch, bash, Java, or any executable.
 * **Pay-per-use pricing model** - Pay only for the time spent running your code. See the Dynamic App Service Plan option in the [pricing section](#pricing) below.  
 * **Bring your own dependencies** - Functions supports NuGet and NPM, so you can use your favorite libraries.  
 * **Integrated security** - Protect HTTP-triggered functions with OAuth providers such as Azure Active Directory, Facebook, Google, Twitter, and Microsoft Account.  

--- a/articles/azure-functions/functions-reference-csharp.md
+++ b/articles/azure-functions/functions-reference-csharp.md
@@ -22,6 +22,7 @@
 
 > [AZURE.SELECTOR]
 - [C# script](../articles/azure-functions/functions-reference-csharp.md)
+- [F# script](../articles/azure-functions/functions-reference-fsharp.md)
 - [Node.js](../articles/azure-functions/functions-reference-node.md)
  
 The C# experience for Azure Functions is based on the Azure WebJobs SDK. Data flows into your C# function via method arguments. Argument names are specified in `function.json`, and there are predefined names for accessing things like the function logger and cancellation tokens.
@@ -255,6 +256,7 @@ The `#load` directive works only with *.csx* (C# script) files, not with *.cs* f
 For more information, see the following resources:
 
 * [Azure Functions developer reference](functions-reference.md)
+* [Azure Functions NodeJS developer reference](functions-reference-fsharp.md)
 * [Azure Functions NodeJS developer reference](functions-reference-node.md)
 * [Azure Functions triggers and bindings](functions-triggers-bindings.md)
 

--- a/articles/azure-functions/functions-reference-fsharp.md
+++ b/articles/azure-functions/functions-reference-fsharp.md
@@ -1,0 +1,288 @@
+<properties
+	pageTitle="Azure Functions F# developer reference | Microsoft Azure"
+	description="Understand how to develop Azure Functions using F#."
+	services="functions"
+	documentationCenter="fsharp"
+	authors="sylvanc"
+	manager="jbronsk"
+	editor=""
+	tags=""
+	keywords="azure functions, functions, event processing, webhooks, dynamic compute, serverless architecture, F#"/>
+
+<tags
+	ms.service="functions"
+	ms.devlang="fsharp"
+	ms.topic="reference"
+	ms.tgt_pltfrm="multiple"
+	ms.workload="na"
+	ms.date="09/09/2016"
+	ms.author="syclebsc"/>
+
+# Azure Functions F# Developer Reference
+
+> [AZURE.SELECTOR]
+- [C# script](../articles/azure-functions/functions-reference-csharp.md)
+- [F# script](../articles/azure-functions/functions-reference-fsharp.md)
+- [Node.js](../articles/azure-functions/functions-reference-node.md)
+
+F# for Azure Functions is a solution for easily running small pieces of code, or "functions," in the cloud. Data flows into your F# function via function arguments. Argument names are specified in `function.json`, and there are predefined names for accessing things like the function logger and cancellation tokens.
+
+This article assumes that you've already read the [Azure Functions developer reference](functions-reference.md).
+
+## How .fsx works
+
+An `.fsx` file is an F# script. It can be thought of as an F# project that's contained in a single file. The file contains both the code for your program (in this case, your Azure Function) and directives for managing dependencies.
+
+When you use an `.fsx` for an Azure Function, commonly required assemblies are automatically included for you, allowing you to focus on the function rather than "boilerplate" code.
+
+## Binding to arguments
+
+Each binding supports some set of arguments, as detailed in the [Azure Functions triggers and bindings developer reference](functions-triggers-bindings.md). For example, one of the argument bindings a blob trigger supports is a POCO, which can be expressed using an F# record. For example:
+
+```fsharp
+type Item = { Id: string }
+
+let Run(blob: string, output: byref<Item>) =
+    let item = { Id = "Some ID" }
+    output <- item
+```
+
+Notice that `byref<>` is used for output arguments. There is no need to add the `[<Out>]` annotation.
+
+When an F# record is used as an input type, the record definition must be marked with `[<CLIMutable>]` in order to allow the Azure Functions framework to set the fields appropriately before passing the record to your function. Under the hood, `[<CLIMutable>]` generates setters for the record properties. For example:
+
+```fsharp
+[<CLIMutable>]
+type TestObject =
+    { SenderName : string
+      Greeting : string }
+
+let Run(req: TestObject, log: TraceWriter) =
+    { req with Greeting = sprintf "Hello, %s" req.SenderName }
+```
+
+An F# class can also be used for both in and out arguments. For a class, properties will usually need getters and setters. For example:
+
+```fsharp
+type Item() =
+    member val Id = "" with get,set
+    member val Text = "" with get,set
+
+let Run(input: string, item: byref<Item>) =
+    let result = Item(Id = input, Text = "Hello from F#!")
+    item <- result
+```
+
+## Logging
+
+To log output to your [streaming logs](../app-service-web/web-sites-streaming-logs-and-console.md) in F#, your function should take an argument of type `TraceWriter`. For consistency, we recommend this argument is named `log`. For example:
+
+```fsharp
+let Run(blob: string, output: byref<string>, log: TraceWriter) =
+    log.Verbose(sprintf "F# Azure Function processed a blob: %s" blob)
+    output <- input
+```
+
+## Async
+
+The `async` workflow can be used, but the result needs to return a `Task`. This can be done with `Async.StartAsTask`, for example:
+
+```fsharp
+let Run(req: HttpRequestMessage) =
+    async {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+    } |> Async.StartAsTask
+```
+
+## Cancellation Token
+
+If your function needs to handle shutdown gracefully, you can give it a [`CancellationToken`](https://msdn.microsoft.com/library/system.threading.cancellationtoken.aspx) argument. This can be combined with `async`, for example:
+
+```fsharp
+let Run(req: HttpRequestMessage, token: CancellationToken)
+    let f = async {
+        do! Async.Sleep(10)
+        return new HttpResponseMessage(HttpStatusCode.OK)
+    }
+    Async.StartAsTask(f, token)
+```
+
+## Importing namespaces
+
+Namespaces can be opened in the usual way:
+
+```fsharp
+open System.Net
+open System.Threading.Tasks
+
+let Run(req: HttpRequestMessage, log: TraceWriter) =
+    ...
+```
+
+The following namespaces are automatically opened:
+
+* `System`
+* `System.Collections.Generic`
+* `System.IO`
+* `System.Linq`
+* `System.Net.Http`
+* `System.Threading.Tasks`
+* `Microsoft.Azure.WebJobs`
+* `Microsoft.Azure.WebJobs.Host`.
+
+## Referencing External Assemblies
+
+Similarly, framework assembly references be added with the `#r "AssemblyName"` directive.
+
+```fsharp
+#r "System.Web.Http"
+
+open System.Net
+open System.Net.Http
+open System.Threading.Tasks
+
+let Run(req: HttpRequestMessage, log: TraceWriter) =
+    ...
+```
+
+The following assemblies are automatically added by the Azure Functions hosting environment:
+
+* `mscorlib`,
+* `System`
+* `System.Core`
+* `System.Xml`
+* `System.Net.Http`
+* `Microsoft.Azure.WebJobs`
+* `Microsoft.Azure.WebJobs.Host`
+* `Microsoft.Azure.WebJobs.Extensions`
+* `System.Web.Http`
+* `System.Net.Http.Formatting`.
+
+In addition, the following assemblies are special cased and may be referenced by simplename (e.g. `#r "AssemblyName"`):
+
+* `Newtonsoft.Json`
+* `Microsoft.WindowsAzure.Storage`
+* `Microsoft.ServiceBus`
+* `Microsoft.AspNet.WebHooks.Receivers`
+* `Microsoft.AspNEt.WebHooks.Common`.
+
+If you need to reference a private assembly, you can upload the assembly file into a `bin` folder relative to your function and reference it by using the file name (e.g.  `#r "MyAssembly.dll"`). For information on how to upload files to your function folder, see the following section on package management.
+
+## Editor Prelude
+
+An editor that supports F# Compiler Services will not be aware of the namespaces and assemblies that Azure Functions automatically includes. As such, it can be useful to include a prelude that helps the editor find the assemblies you are using, and to explicitly open namespaces. For example:
+
+```fsharp
+#if !COMPILED
+#I "../../bin/Binaries/WebJobs.Script.Host"
+#r "Microsoft.Azure.WebJobs.Host.dll"
+#endif
+
+open Sytem
+open Microsoft.Azure.WebJobs.Host
+
+let Run(blob: string, output: byref<string>, log: TraceWriter) =
+    ...
+```
+
+When Azure Functions executes your code, it processes the source with `COMPILED` defined, so the editor prelude will be ignored.
+
+## Package management
+
+To use NuGet packages in an F# function, add a `project.json` file to the the function's folder in the function app's file system. Here is an example `project.json` file that adds a reference to `Microsoft.ProjectOxford.Face` version 1.1.0:
+
+```json
+{
+  "frameworks": {
+    "net46":{
+      "dependencies": {
+        "Microsoft.ProjectOxford.Face": "1.1.0"
+      }
+    }
+   }
+}
+```
+
+Only the .NET Framework 4.6 is supported, so make sure that your `project.json` file specifies `net46` as shown here.
+
+When you upload a `project.json` file, the runtime gets the packages and automatically adds references to the package assemblies. You don't need to add `#r "AssemblyName"` directives. Just add the required `open` statements to your `.fsx` file.
+
+You may wish to put automatically references assemblies in your editor prelude, to improve your editor's interaction with F# Compile Services.
+
+### How to add a `project.json` file to your Azure Function
+
+1. Begin by making sure your function app is running, which you can do by opening your function in the Azure portal. This also gives access to the streaming logs where package installation output will be displayed.
+
+2. To upload a `project.json` file, use one of the methods described in [how to update function app files](functions-reference.md#fileupdate). If you are using [Continuous Deployment for Azure Functions](functions-continuous-deployment.md), you can add a `project.json` file to your staging branch in order to experiment with it before adding it to your deployment branch.
+
+3. After the `project.json` file is added, you will see output similar to the following example in your function's streaming log:
+
+```
+2016-04-04T19:02:48.745 Restoring packages.
+2016-04-04T19:02:48.745 Starting NuGet restore
+2016-04-04T19:02:50.183 MSBuild auto-detection: using msbuild version '14.0' from 'D:\Program Files (x86)\MSBuild\14.0\bin'.
+2016-04-04T19:02:50.261 Feeds used:
+2016-04-04T19:02:50.261 C:\DWASFiles\Sites\facavalfunctest\LocalAppData\NuGet\Cache
+2016-04-04T19:02:50.261 https://api.nuget.org/v3/index.json
+2016-04-04T19:02:50.261
+2016-04-04T19:02:50.511 Restoring packages for D:\home\site\wwwroot\HttpTriggerCSharp1\Project.json...
+2016-04-04T19:02:52.800 Installing Newtonsoft.Json 6.0.8.
+2016-04-04T19:02:52.800 Installing Microsoft.ProjectOxford.Face 1.1.0.
+2016-04-04T19:02:57.095 All packages are compatible with .NETFramework,Version=v4.6.
+2016-04-04T19:02:57.189
+2016-04-04T19:02:57.189
+2016-04-04T19:02:57.455 Packages restored.
+```
+
+## Environment variables
+
+To get an environment variable or an app setting value, use `System.Environment.GetEnvironmentVariable`, for example:
+
+```fsharp
+open System.Environment
+
+let Run(timer: TimerInfo, log: TraceWriter) =
+    log.Info("Storage = " + GetEnvironmentVariable("AzureWebJobsStorage"))
+    log.Info("Site = " + GetEnvironmentVariable("WEBSITE_SITE_NAME"))
+```
+
+## Reusing .fsx code
+
+You can use code from other `.fsx` files by using a `#load` directive. For example:
+
+`run.fsx`
+
+```fsharp
+#load "logger.fsx"
+
+let Run(timer: TimerInfo, log: TraceWriter) =
+    mylog log (sprintf "Timer: %s" DateTime.Now.ToString())
+```
+
+`logger.fsx`
+
+```fsharp
+let mylog(log: TraceWriter, text: string) =
+    log.Verbose(text);
+```
+
+Paths provides to the `#load` directive are relative to the location of your `.fsx` file.
+
+* `#load "logger.fsx"` loads a file located in the function folder.
+
+* `#load "package\logger.fsx"` loads a file located in the `package` folder in the function folder.
+
+* `#load "..\shared\mylogger.fsx"` loads a file located in the `shared` folder at the same level as the function folder, that is, directly under `wwwroot`.
+
+The `#load` directive only works with `.fsx` (F# script) files, and not with `.fs` files.
+
+## Next steps
+
+For more information, see the following resources:
+
+* [Azure Functions developer reference](functions-reference.md)
+* [Azure Functions C# developer reference](functions-reference-csharp.md)
+* [Azure Functions NodeJS developer reference](functions-reference-node.md)
+* [Azure Functions triggers and bindings](functions-triggers-bindings.md)
+* [Azure Functions testing](functions-test-a-function.md)
+* [Azure Functions scaling](functions-scale.md)

--- a/articles/azure-functions/functions-reference-fsharp.md
+++ b/articles/azure-functions/functions-reference-fsharp.md
@@ -47,7 +47,9 @@ let Run(blob: string, output: byref<Item>) =
     output <- item
 ```
 
-Notice that `byref<>` is used for output arguments. There is no need to add the `[<Out>]` annotation.
+Your F# Azure Function will take one or more arguments. When we talk about Azure Functions arguments, we refer to _input_ arguments and _output_ arguments. An input argument is exactly what it sounds like: input to your F# Azure Function. An _output_ argument is mutable data or a `byref<>` argument that serves as a way to pass data back _out_ of your function.
+
+In the example above, `blob` is an input argument, and `output` is an output argument. Notice that we used `byref<>` for `output` (there's no need to add the `[<Out>]` annotation). Using a `byref<>` type allows your function to change which record or object the argument refers to.
 
 When an F# record is used as an input type, the record definition must be marked with `[<CLIMutable>]` in order to allow the Azure Functions framework to set the fields appropriately before passing the record to your function. Under the hood, `[<CLIMutable>]` generates setters for the record properties. For example:
 
@@ -189,7 +191,7 @@ When Azure Functions executes your code, it processes the source with `COMPILED`
 
 ## Package management
 
-To use NuGet packages in an F# function, add a `project.json` file to the the function's folder in the function app's file system. Here is an example `project.json` file that adds a reference to `Microsoft.ProjectOxford.Face` version 1.1.0:
+To use NuGet packages in an F# function, add a `project.json` file to the the function's folder in the function app's file system. Here is an example `project.json` file that adds a NuGet package reference to `Microsoft.ProjectOxford.Face` version 1.1.0:
 
 ```json
 {
@@ -280,6 +282,7 @@ The `#load` directive only works with `.fsx` (F# script) files, and not with `.f
 
 For more information, see the following resources:
 
+* [F# Guide](https://docs.microsoft.com/en-us/dotnet/articles/fsharp/index)
 * [Azure Functions developer reference](functions-reference.md)
 * [Azure Functions C# developer reference](functions-reference-csharp.md)
 * [Azure Functions NodeJS developer reference](functions-reference-node.md)

--- a/articles/azure-functions/functions-reference-node.md
+++ b/articles/azure-functions/functions-reference-node.md
@@ -22,6 +22,7 @@
 
 > [AZURE.SELECTOR]
 - [C# script](../articles/azure-functions/functions-reference-csharp.md)
+- [F# script](../articles/azure-functions/functions-reference-fsharp.md)
 - [Node.js](../articles/azure-functions/functions-reference-node.md)
 
 The Node/JavaScript experience for Azure Functions makes it easy to export a function which is passed a `context` object for communicating with the runtime, and for receiving and sending data via bindings.
@@ -199,4 +200,5 @@ For more information, see the following resources:
 
 * [Azure Functions developer reference](functions-reference.md)
 * [Azure Functions C# developer reference](functions-reference-csharp.md)
+* [Azure Functions F# developer reference](functions-reference-fsharp.md)
 * [Azure Functions triggers and bindings](functions-triggers-bindings.md)

--- a/articles/azure-functions/functions-reference.md
+++ b/articles/azure-functions/functions-reference.md
@@ -145,6 +145,7 @@ Here is a table of all supported bindings.
 For more information, see the following resources:
 
 * [Azure Functions C# developer reference](functions-reference-csharp.md)
+* [Azure Functions F# developer reference](functions-reference-fsharp.md)
 * [Azure Functions NodeJS developer reference](functions-reference-node.md)
 * [Azure Functions triggers and bindings](functions-triggers-bindings.md)
 * [Azure Functions: The Journey](https://blogs.msdn.microsoft.com/appserviceteam/2016/04/27/azure-functions-the-journey/) on the Azure App Service team blog. A history of how Azure Functions was developed.

--- a/articles/azure-functions/functions-run-local.md
+++ b/articles/azure-functions/functions-run-local.md
@@ -219,5 +219,6 @@ For more information, see the following resources:
 
 * [Azure Functions developer reference](functions-reference.md)
 * [Azure Functions C# developer reference](functions-reference-csharp.md)
+* [Azure Functions F# developer reference](functions-reference-fsharp.md)
 * [Azure Functions NodeJS developer reference](functions-reference-node.md)
 * [Azure Functions triggers and bindings](functions-triggers-bindings.md)

--- a/articles/azure-functions/functions-test-a-function.md
+++ b/articles/azure-functions/functions-test-a-function.md
@@ -172,7 +172,7 @@ In the portal **Logs** window, output similar to the following is logged while e
 
 You can test a blob trigger function using [Microsoft Azure Storage Explorer](http://storageexplorer.com/).
 
-1. In the [Azure Portal] for your Functions app, create a new C# or Node blob trigger function. Set the path to monitor to the name of your blob container. For example:
+1. In the [Azure Portal] for your Functions app, create a new C#, F# or Node blob trigger function. Set the path to monitor to the name of your blob container. For example:
 
 		files
 

--- a/articles/azure-functions/functions-triggers-bindings.md
+++ b/articles/azure-functions/functions-triggers-bindings.md
@@ -20,7 +20,7 @@
 
 # Azure Functions triggers and bindings developer reference
 
-The following articles explain how to configure and code triggers and bindings in Azure Functions. The articles assume that you've read the [Azure Functions developer reference](functions-reference.md), and the [C#](functions-reference-csharp.md) or [Node.js](functions-reference-node.md) developer reference articles.
+The following articles explain how to configure and code triggers and bindings in Azure Functions. The articles assume that you've read the [Azure Functions developer reference](functions-reference.md), and the [C#](functions-reference-csharp.md), [F#](functions-reference-fsharp.md), or [Node.js](functions-reference-node.md) developer reference articles.
 
 ## Triggers and bindings articles
 

--- a/articles/stream-analytics/stream-analytics-functions-redis.md
+++ b/articles/stream-analytics/stream-analytics-functions-redis.md
@@ -206,6 +206,7 @@ You can also see the following resources:
 
 - [Azure Functions developer reference](../azure-functions/functions-reference.md)
 - [Azure Functions C# developer reference](../azure-functions/functions-reference-csharp.md)
+- [Azure Functions F# developer reference](../azure-functions/functions-reference-fsharp.md)
 - [Azure Functions NodeJS developer reference](../azure-functions/functions-reference.md)
 - [Azure Functions triggers and bindings](../azure-functions/functions-triggers-bindings.md)
 - [How to monitor Azure Redis Cache](../redis-cache/cache-how-to-monitor.md)

--- a/includes/functions-bindings-intro.md
+++ b/includes/functions-bindings-intro.md
@@ -2,4 +2,4 @@ This is reference information for Azure Functions developers. If you're new to A
 
 * [Create your first Azure Function](../articles/azure-functions/functions-create-first-azure-function.md)
 * [Azure Functions developer reference](../articles/azure-functions/functions-reference.md)
-* [C#](../articles/azure-functions/functions-reference-csharp.md) or [Node](../articles/azure-functions/functions-reference-node.md) developer reference
+* [C#](../articles/azure-functions/functions-reference-csharp.md), [F#](../articles/azure-functions/functions-reference-fsharp.md), or [Node](../articles/azure-functions/functions-reference-node.md) developer reference


### PR DESCRIPTION
This adds an F# developer reference with roughly the same layout as the C#
developer reference. Anywhere the C# or node.js developer reference is
linked to, an additional link to the F# developer reference has been
added.

Additional F# examples have been added where C# and node.js examples existed.
