### PR TITLE
Tweak language and usage (on-premises instead of on-premise, etc.) in virtual-networks-name-resolution-for-vms-and-role-instances.md

### DIFF
--- a/articles/virtual-network/virtual-networks-name-resolution-for-vms-and-role-instances.md
+++ b/articles/virtual-network/virtual-networks-name-resolution-for-vms-and-role-instances.md
@@ -1,4 +1,4 @@
-﻿<properties 
+<properties 
    pageTitle="Resolution for VMs and Role Instances"
    description="Name Resolution scenarios for Azure IaaS , hybrid solutions, between different cloud services, Active Directory and using your own DNS server "
    services="virtual-network"
@@ -33,8 +33,8 @@ The type of name resolution you use depends on how your VMs and role instances n
 |--------------|--------------|----------|
 | Name resolution between role instances or VMs located in the same cloud service or virtual network | [Azure-provided name resolution](#azure-provided-name-resolution)| hostname or FQDN |
 | Name resolution between role instances or VMs located in different virtual networks | Customer-managed DNS servers forwarding queries between vnets for resolution by Azure (DNS proxy).  see [Name resolution using your own DNS server](#name-resolution-using-your-own-dns-server)| FQDN only |
-| Resolution of on-premises computer and service names from role instances or VMs in Azure | Customer-managed DNS servers (e.g. on-premise domain controller, local read-only domain controller or a DNS secondary synced using zone transfers).  See [Name resolution using your own DNS server](#name-resolution-using-your-own-dns-server)|FQDN only |
-| Resolution of Azure hostnames from on-premise computers | Forward queries to a customer-managed DNS proxy server in the corresponding vnet, the proxy server forwards queries to Azure for resolution. See [Name resolution using your own DNS server](#name-resolution-using-your-own-dns-server)| FQDN only |
+| Resolution of on-premises computer and service names from role instances or VMs in Azure | Customer-managed DNS servers (e.g. on-premises domain controller, local read-only domain controller or a DNS secondary synced using zone transfers).  See [Name resolution using your own DNS server](#name-resolution-using-your-own-dns-server)|FQDN only |
+| Resolution of Azure hostnames from on-premises computers | Forward queries to a customer-managed DNS proxy server in the corresponding vnet, the proxy server forwards queries to Azure for resolution. See [Name resolution using your own DNS server](#name-resolution-using-your-own-dns-server)| FQDN only |
 | Reverse DNS for internal IPs | [Name resolution using your own DNS server](#name-resolution-using-your-own-dns-server) | n/a |
 | Name resolution between VMs or role instances located in different cloud services, not in a virtual network| Not applicable. Connectivity between VMs and role instances in different cloud services is not supported outside a virtual network.| n/a |
 
@@ -44,7 +44,7 @@ The type of name resolution you use depends on how your VMs and role instances n
 
 Along with resolution of public DNS names, Azure provides internal name resolution for VMs and role instances that reside within the same virtual network or cloud service.  VMs/instances in a cloud service share the same DNS suffix (so the hostname alone is sufficient) but in classic virtual networks different cloud services have different DNS suffixes so the FQDN is needed to resolve names between different cloud services.  In virtual networks in the Resource Manager deployment model, the DNS suffix is consistent across the virtual network (so the FQDN is not needed) and DNS names can be assigned to both NICs and VMs. Although Azure-provided name resolution does not require any configuration, it is not the appropriate choice for all deployment scenarios, as seen on the table above.
 
-> [AZURE.NOTE] In the case of web and worker roles, you can also access the internal IP addresses of role instances based on the role name and instance number using the Azure Service Management REST API. For more information, see [Service Management REST API Reference](https://msdn.microsoft.com/library/azure/ee460799.aspx).
+> [NOTE] In the case of web and worker roles, you can also access the internal IP addresses of role instances based on the role name and instance number using the Azure Service Management REST API. For more information, see [Service Management REST API Reference](https://msdn.microsoft.com/library/azure/ee460799.aspx).
 
 ### Features and Considerations
 
@@ -54,7 +54,7 @@ Along with resolution of public DNS names, Azure provides internal name resoluti
 
 - The Azure-provided name resolution service is highly available, saving you the need to create and manage clusters of your own DNS servers.
 
-- Can be used in conjunction with your own DNS servers to resolve both on-premise and Azure hostnames.
+- Can be used in conjunction with your own DNS servers to resolve both on-premises and Azure hostnames.
 
 - Name resolution is provided between role instances/VMs within the same cloud service without need for a FQDN.
 
@@ -84,24 +84,24 @@ Not every DNS query needs to be sent across the network.  Client-side caching he
 
 The default Windows DNS Client has a DNS cache built-in.  Some Linux distros do not include caching by default, it is recommended that one be added to each Linux VM (after checking that there isn't a local cache already).
 
-There are a number of different DNS caching packages available, e.g. dnsmasq, here are the steps to install dnsmasq on the most common distros:
+There are a number of different DNS caching packages available, such as dnsmasq, Here are the steps to install dnsmasq on the most common distros:
 
 - **Ubuntu (uses resolvconf)**:
-	- just install the dnsmasq package (“sudo apt-get install dnsmasq”).
+	- just install the dnsmasq package (<code>sudo apt-get install dnsmasq</code>).
 - **SUSE (uses netconf)**:
-	- install the dnsmasq package (“sudo zypper install dnsmasq”) 
-	- enable the dnsmasq service (“systemctl enable dnsmasq.service”) 
-	- start the dnsmasq service (“systemctl start dnsmasq.service”) 
-	- edit “/etc/sysconfig/network/config” and change NETCONFIG_DNS_FORWARDER="" to ”dnsmasq”
-	- update resolv.conf ("netconfig update") to set the cache as the local DNS resolver
+	- install the dnsmasq package (<code>sudo zypper install dnsmasq</code>) 
+	- enable the dnsmasq service (<code>systemctl enable dnsmasq.service</code>) 
+	- start the dnsmasq service (<code>systemctl start dnsmasq.service</code>) 
+	- edit <code>/etc/sysconfig/network/config</code> and change <code>NETCONFIG_DNS_FORWARDER=""</code> to <code>dnsmasq</code>
+	- update resolv.conf (<code>netconfig update</code>) to set the cache as the local DNS resolver
 - **OpenLogic (uses NetworkManager)**:
-	- install the dnsmasq package (“sudo yum install dnsmasq”)
-	- enable the dnsmasq service (“systemctl enable dnsmasq.service”)
-	- start the dnsmasq service (“systemctl start dnsmasq.service”)
-	- add “prepend domain-name-servers 127.0.0.1;” to “/etc/dhclient-eth0.conf”
-	- restart the network service (“service network restart”) to set the cache as the local DNS resolver
+	- install the dnsmasq package (<code>sudo yum install dnsmasq</code>)
+	- enable the dnsmasq service (<code>systemctl enable dnsmasq.service</code>)
+	- start the dnsmasq service (<code>systemctl start dnsmasq.service</code>)
+	- add <code>prepend domain-name-servers 127.0.0.1;</code> to <code>/etc/dhclient-eth0.conf</code>
+	- restart the network service (<code>service network restart</code>) to set the cache as the local DNS resolver
 
-> [AZURE.NOTE] The 'dnsmasq' package is only one of the many DNS caches available for Linux.  Before using it, please check its suitability for your particular needs and that no other cache is installed.
+> [NOTE] The <code>dnsmasq</code> package is only one of the many DNS caches available for Linux.  Before using it, please check its suitability for your particular needs and that no other cache is installed.
 
 **Client-side Retries:**
 
@@ -110,28 +110,28 @@ DNS is primarily a UDP protocol.  As the UDP protocol doesn't guarantee message 
  - Windows operating systems retry after 1 second and then again after another 2, 4 and another 4 seconds. 
  - The default Linux setup retries after 5 seconds.  It is recommended to change this to retry 5 times at 1 second intervals.  
 
-To check the current settings on a Linux VM, 'cat /etc/resolv.conf' and look at the 'options' line, e.g.:
+To check the current settings on a Linux VM, <code>cat /etc/resolv.conf</code> and look at the <code>options</code> line, e.g.:
 
 	options timeout:1 attempts:5
 
-The resolv.conf file is usually auto-generated and should not be edited.  The specific steps for adding the 'options' line vary by distro:
+The resolv.conf file is usually auto-generated and should not be edited.  The specific steps for adding the <code>options</code> line vary by distro:
 
-- **Ubuntu** (uses resolvconf):
-	- add the options line to '/etc/resolveconf/resolv.conf.d/head' 
-	- run 'resolvconf -u' to update
-- **SUSE** (uses netconf):
-	- add 'timeout:1 attempts:5' to the NETCONFIG_DNS_RESOLVER_OPTIONS="" parameter in '/etc/sysconfig/network/config' 
-	- run 'netconfig update' to update
-- **OpenLogic** (uses NetworkManager):
-	- add 'echo "options timeout:1 attempts:5"' to '/etc/NetworkManager/dispatcher.d/11-dhclient' 
-	- run 'service network restart' to update
+- **Ubuntu** (uses <code>resolvconf</code>):
+	- add the <code>options</code> line to <code>/etc/resolveconf/resolv.conf.d/head</code> 
+	- run <code>resolvconf -u</code> to update
+- **SUSE** (uses <code>netconf</code>):
+	- add <code>timeout:1 attempts:5</code> to the <code>NETCONFIG_DNS_RESOLVER_OPTIONS=""</code> parameter in <code>/etc/sysconfig/network/config'</code> 
+	- run <code>netconfig update</code> to update
+- **OpenLogic** (uses <code>NetworkManager</code>):
+	- add <code>echo "options timeout:1 attempts:5"</code> to <code>/etc/NetworkManager/dispatcher.d/11-dhclient</code> 
+	- run <code>service network restart</code> to update
 
 ## Name resolution using your own DNS server
 There are a number of situations where your name resolution needs may go beyond the features provided by Azure, for example when using Active Directory domains or when you require DNS resolution between virtual networks (vnets).  To cover these scenarios, Azure provides the ability for you to use your own DNS servers.  
 
-DNS servers within a virtual network can forward DNS queries to Azure's recursive resolvers to resolve hostnames within that virtual network.  For example, a Domain Controller (DC) running in Azure can respond to DNS queries for its domains and forward all other queries to Azure.  This allows VMs to see both your on-premise resources (via the DC) and Azure-provided hostnames (via the forwarder).  Access to Azure's recursive resolvers is provided via the virtual IP 168.63.129.16.
+DNS servers within a virtual network can forward DNS queries to Azure's recursive resolvers to resolve hostnames within that virtual network.  For example, a Domain Controller (DC) running in Azure can respond to DNS queries for its domains and forward all other queries to Azure.  This allows VMs to see both your on-premises resources (via the DC) and Azure-provided hostnames (via the forwarder).  Access to Azure's recursive resolvers is provided via the virtual IP 168.63.129.16.
 
-DNS forwarding also enables inter-vnet DNS resolution and allows your on-premise machines to resolve Azure-provided hostnames.  In order to resolve a VM's hostname, the DNS server VM must reside in the same virtual network and be configured to forward hostname queries to Azure.  As the DNS suffix is different in each vnet, you can use conditional forwarding rules to send DNS queries to the correct vnet for resolution.  The following image shows two vnets and an on-premise network doing inter-vnet DNS resolution using this method.  An example DNS forwarder is available in the [Azure Quickstart Templates gallery](https://azure.microsoft.com/documentation/templates/301-dns-forwarder/) and [GitHub](https://github.com/Azure/azure-quickstart-templates/tree/master/301-dns-forwarder).
+DNS forwarding also enables inter-vnet DNS resolution and allows your on-premises machines to resolve Azure-provided hostnames.  In order to resolve a VM's hostname, the DNS server VM must reside in the same virtual network and be configured to forward hostname queries to Azure.  As the DNS suffix is different in each vnet, you can use conditional forwarding rules to send DNS queries to the correct vnet for resolution.  The following image shows two vnets and an on-premises network doing inter-vnet DNS resolution using this method.  An example DNS forwarder is available in the [Azure Quickstart Templates gallery](https://azure.microsoft.com/documentation/templates/301-dns-forwarder/) and [GitHub](https://github.com/Azure/azure-quickstart-templates/tree/master/301-dns-forwarder).
 
 ![Inter-vnet DNS](./media/virtual-networks-name-resolution-for-vms-and-role-instances/inter-vnet-dns.png)
 
@@ -145,26 +145,26 @@ If needed, the Internal DNS suffix can be determined using PowerShell or the API
 
 If forwarding queries to Azure doesn't suit your needs, you will need to provide your own DNS solution.  Your DNS solution will need to:
 
--  Provide appropriate hostname resolution, e.g. via [DDNS](virtual-networks-name-resolution-ddns.md).  Note, if using DDNS you may need to disable DNS record scavenging as Azure's DHCP leases are very long and scavenging may remove DNS records prematurely. 
+-  Provide appropriate hostname resolution, e.g. via Dynamic DNS ([DDNS](virtual-networks-name-resolution-ddns.md)).  Note, if using DDNS you may need to disable DNS record scavenging as Azure's DHCP leases are very long and scavenging may remove DNS records prematurely. 
 -  Provide appropriate recursive resolution to allow resolution of external domain names.
 -  Be accessible (TCP and UDP on port 53) from the clients it serves and be able to access the internet.
 -  Be secured against access from the internet, to mitigate threats posed by external agents.
 
-> [AZURE.NOTE] For best performance, when using Azure VMs as DNS servers, IPv6 should be disabled and an [Instance-Level Public IP](virtual-networks-instance-level-public-ip.md) should be assigned to each DNS server VM.  If you choose to use Windows Server as your DNS server, [this article](http://blogs.technet.com/b/networking/archive/2015/08/19/name-resolution-performance-of-a-recursive-windows-dns-server-2012-r2.aspx) provides additional performance analysis and optimizations.
+> [NOTE] For best performance, when using Azure VMs as DNS servers, IPv6 should be disabled and an [Instance-Level Public IP](virtual-networks-instance-level-public-ip.md) should be assigned to each DNS server VM.  If you choose to use Windows Server as your DNS server, [this article](http://blogs.technet.com/b/networking/archive/2015/08/19/name-resolution-performance-of-a-recursive-windows-dns-server-2012-r2.aspx) provides additional performance analysis and optimizations.
 
 
 ### Specifying DNS servers
 
 When using your own DNS servers, Azure provides the ability to specify multiple DNS servers per virtual network or per network interface (Resource Manager) / cloud service (classic).  DNS servers specified for a cloud service/network interface get precedence over those specified for the virtual network.
 
-> [AZURE.NOTE] Network connection properties, such as DNS server IPs, should not be edited directly within Windows VMs as they may get erased during service heal when the virtual network adaptor gets replaced. 
+> [NOTE] Network connection properties, such as DNS server IPs, should not be edited directly within Windows VMs as they may get erased during service heal when the virtual network adaptor gets replaced. 
 
 
 When using the Resource Manager deployment model, DNS servers can be specified in the Portal, API/Templates ([vnet](https://msdn.microsoft.com/library/azure/mt163661.aspx), [nic](https://msdn.microsoft.com/library/azure/mt163668.aspx)) or PowerShell ([vnet](https://msdn.microsoft.com/library/mt603657.aspx), [nic](https://msdn.microsoft.com/library/mt619370.aspx)).
 
 When using the classic deployment model, DNS servers for the virtual network can be specified in the Portal or [the *Network Configuration* file](https://msdn.microsoft.com/library/azure/jj157100).  For cloud services, the DNS servers are specified via [the *Service Configuration* file](https://msdn.microsoft.com/library/azure/ee758710) or in PowerShell ([New-AzureVM](https://msdn.microsoft.com/library/azure/dn495254.aspx)).
 
-> [AZURE.NOTE] If you change the DNS settings for a virtual network/virtual machine that is already deployed, you need to restart each affected VM for the changes to take effect.
+> [NOTE] If you change the DNS settings for a virtual network/virtual machine that is already deployed, you need to restart each affected VM for the changes to take effect.
 
 
 ## Next steps


### PR DESCRIPTION
Besides the on-premise bit (an admitted pet peeve of mine; I feel it reduces Microsoft's credibility when its cloud service documentation uses incorrect terminology), I also made some simply formatting tweaks to make the article easier to digest. That's what I hope, anyway. :) Thanks, Tim
