### PR TITLE
Updatecripts in install-dotnet document

### DIFF
--- a/articles/cloud-services/cloud-services-dotnet-install-dotnet.md
+++ b/articles/cloud-services/cloud-services-dotnet-install-dotnet.md
@@ -76,7 +76,7 @@ Startup tasks allow you to perform operations before a role starts. Installing t
 	REM ***** To install .NET 4.6 set the variable netfx to "NDP46" *****
 	REM ***** To install .NET 4.6.1 set the variable netfx to "NDP461" *****
 	REM ***** To install .NET 4.6.2 set the variable netfx to "NDP462" *****
-	set netfx="NDP462"
+	set netfx="NDP461"
 	
 	REM ***** Set script start timestamp *****
 	set timehour=%time:~0,2%


### PR DESCRIPTION
The default value in the script (For .NET Fx 4.6.2) and the hyperlink
provided in the document before (.NET Fx 4.6.1) doesn't match each other,
which will lead to deploy failure unless corrected by user manually.

Update the default value in the script provided to use Fx 4.6.1 to match
the download hyperlink.