### PR TITLE
Typo inside the code sample Catch exception in line 374 from Ex to ex.

### DIFF
--- a/articles/batch/batch-visual-studio-templates.md
+++ b/articles/batch/batch-visual-studio-templates.md
@@ -371,7 +371,7 @@ public async Task<int> Run()
     {
         throw new TaskProcessorException(
         $"{ex.GetType().Name} exception in run task processor: {ex.Message}",
-        Ex
+        ex
         );
     }
 }


### PR DESCRIPTION
Hiya @mmacy 

A quick typo change, in line 374 where instead of Ex it should be 'ex' I have checked with Felipe and he is cool with it. I am the dev who worked on this.  :shipit: 

Thanks,
^Tats