### PR TITLE
Update active-directory-passwords-set-expiration-policy.md

### DIFF
--- a/articles/active-directory/active-directory-passwords-set-expiration-policy.md
+++ b/articles/active-directory/active-directory-passwords-set-expiration-policy.md
@@ -51,9 +51,9 @@ To use Windows PowerShell cmdlets, you first must install them.
 
 2.  Do one of the following:
 
-	- To set the password of one user so that the password will expire, run the following cmdlet by using the user principal name (UPN) or the user ID of the user: `Set-MsolUser -UserPrincipalName <user ID> -PasswordNeverExpires \$false`
+	- To set the password of one user so that the password will expire, run the following cmdlet by using the user principal name (UPN) or the user ID of the user: `Set-MsolUser -UserPrincipalName <user ID> -PasswordNeverExpires $false`
 
-	- To set the passwords of all users in the organization so that they will expire, use the following cmdlet: `Get-MSOLUser | Set-MsolUser -PasswordNeverExpires \$false`
+	- To set the passwords of all users in the organization so that they will expire, use the following cmdlet: `Get-MSOLUser | Set-MsolUser -PasswordNeverExpires $false`
 
 ## Set a password to never expire
 
@@ -61,9 +61,9 @@ To use Windows PowerShell cmdlets, you first must install them.
 
 2.  Do one of the following:
 
-	- To set the password of one user to never expire, run the following cmdlet by using the user principal name (UPN) or the user ID of the user: `Set-MsolUser -UserPrincipalName <user ID> -PasswordNeverExpires \$true`
+	- To set the password of one user to never expire, run the following cmdlet by using the user principal name (UPN) or the user ID of the user: `Set-MsolUser -UserPrincipalName <user ID> -PasswordNeverExpires $true`
 
-	- To set the passwords of all the users in an organization to never expire, run the following cmdlet: `Get-MSOLUser | Set-MsolUser -PasswordNeverExpires \$true`
+	- To set the passwords of all the users in an organization to never expire, run the following cmdlet: `Get-MSOLUser | Set-MsolUser -PasswordNeverExpires $true`
 
 ## Next steps
 


### PR DESCRIPTION
Removed the preceding slash in front of the $true or $false values in the PowerShell script. Their presence made no sense, and when I copied and used the scripts they did not work unless I removed them.