### PR TITLE
Tenant id in URL is incorrect

### DIFF
--- a/articles/resource-manager-rest-api.md
+++ b/articles/resource-manager-rest-api.md
@@ -56,7 +56,7 @@ In the below HTTP request make sure to replace "Azure AD Tenant ID", "Applicatio
 **Generic HTTP Request:**
 
 ```HTTP
-POST /<Azure AD Tenant ID>.onmicrosoft.com/oauth2/token?api-version=1.0 HTTP/1.1 HTTP/1.1
+POST /<Azure AD Tenant ID>/oauth2/token?api-version=1.0 HTTP/1.1 HTTP/1.1
 Host: login.microsoftonline.com
 Cache-Control: no-cache
 Content-Type: application/x-www-form-urlencoded
@@ -81,13 +81,13 @@ grant_type=client_credentials&resource=https%3A%2F%2Fmanagement.core.windows.net
 **Generating access token using Bash:**
 
 ```console
-curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "grant_type=client_credentials&resource=https://management.core.windows.net&client_id=<application id>&client_secret=<password you selected for authentication>" https://login.microsoftonline.com/microsoft.onmicrosoft.com/oauth2/token?api-version=1.0
+curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "grant_type=client_credentials&resource=https://management.core.windows.net&client_id=<application id>&client_secret=<password you selected for authentication>" https://login.microsoftonline.com/<Azure AD Tenant ID>/oauth2/token?api-version=1.0
 ```
 
 **Generating access token using PowerShell:**
 
 ```powershell
-Invoke-RestMethod -Uri https://login.microsoftonline.com/microsoft.onmicrosoft.com/oauth2/token?api-version=1.0 -Method Post
+Invoke-RestMethod -Uri https://login.microsoftonline.com/<Azure AD Tenant ID>/oauth2/token?api-version=1.0 -Method Post
  -Body @{"grant_type" = "client_credentials"; "resource" = "https://management.core.windows.net/"; "client_id" = "<application id>"; "client_secret" = "<password you selected for authentication>" }
 ```
 


### PR DESCRIPTION
The post sample shows the tenant id, but whith `.onmicrosoft.com` appended. 
The Bash and PowerShell sample don't even show the tenant ID 