### PR TITLE
Update app-service-mobile-android-how-to-use-client-library.md

### DIFF
--- a/articles/app-service-mobile/app-service-mobile-android-how-to-use-client-library.md
+++ b/articles/app-service-mobile/app-service-mobile-android-how-to-use-client-library.md
@@ -608,7 +608,7 @@ When you try to use an expired token you will get a *401 unauthorized* response.
 
 ## <a name="adal"></a>How to: Authenticate users with the Active Directory Authentication Library
 
-You can use the Active Directory Authentication Library (ADAL) to sign users into your application using Azure Active Directory. This is often preferable to using the `loginAsync()` methods, as it provides a more native UX feel and allows for additional customization.
+You can use the Active Directory Authentication Library (ADAL) to sign users into your application using Azure Active Directory. This is often preferable to using the `login()` methods, as it provides a more native UX feel and allows for additional customization.
 
 1. Configure your mobile app backend for AAD sign-in by followin the [How to configure App Service for Active Directory login](app-service-mobile-how-to-configure-active-directory-authentication.md) tutorial. Make sure to complete the optional step of registering a native client application.
 


### PR DESCRIPTION
loginAsync() method should be login() for Android, this could be a copy-and-paste error from .NET client