### PR TITLE
'azure' instead of 'Azure' in CLI examples

### DIFF
--- a/articles/dns/dns-getstarted-create-dnszone-cli.md
+++ b/articles/dns/dns-getstarted-create-dnszone-cli.md
@@ -42,25 +42,25 @@ You can install Azure CLI for Windows, Linux, or MAC. The following steps need t
 
 All the network provider commands on CLI can be found using the following command:
 
-	Azure network
+    azure network
 
 ### 2. Switch CLI mode
 
 Azure DNS uses Azure Resource Manager. Make sure you switch CLI mode to use ARM commands.
 
-	Azure config mode arm
+	azure config mode arm
 
 ### 3. Sign in to your Azure account
 
 You will be prompted to authenticate with your credentials. Keep in mind that you can only use ORGID accounts.
 
-    Azure login -u "username"
+    azure login -u "username"
 
 ### 4. Select the subscription
 
 Choose which of your Azure subscriptions to use.
 
-    Azure account set "subscription name"
+    azure account set "subscription name"
 
 ### 5. Create a resource group
 
@@ -68,14 +68,14 @@ Azure Resource Manager requires that all resource groups specify a location. Thi
 
 You can skip this step if you are using an existing resource group. 
 
-    Azure group create -n myresourcegroup --location "West US"
+    azure group create -n myresourcegroup --location "West US"
 
 
 ### 6. Register
 
 The Azure DNS service is managed by the Microsoft.Network resource provider. Your Azure subscription needs to be registered to use this resource provider before you can use Azure DNS. This is a one-time operation for each subscription.
 
-	Azure provider register --namespace Microsoft.Network
+	azure provider register --namespace Microsoft.Network
 
 
 ## Step 2 - Create a DNS zone
@@ -91,7 +91,7 @@ The example below creates a DNS zone called *contoso.com* in the resource group 
 
 Use the example to create your DNS zone, substituting the values for your own.
 
-    Azure network dns zone create myresourcegroup contoso.com
+    azure network dns zone create myresourcegroup contoso.com
 
 ### To create a DNS zone and tags.
 
@@ -99,7 +99,7 @@ Azure DNS CLI supports tags of DNS zones specified by using the optional *-Tag* 
 
 Use the example below to create a DNS zone and tags, substituting the values for your own.
 
-	Azure network dns zone create myresourcegroup contoso.com -t "project=demo";"env=test"
+	azure network dns zone create myresourcegroup contoso.com -t "project=demo";"env=test"
 
 ## View records
 


### PR DESCRIPTION
Consider using lowercase first letter instead of Uppercase. This is common style for bash/cmd command. 
Uppercase first letter make this command look like usual sentence.