### PR TITLE
For clarity - NIC requires existing VNet

### DIFF
--- a/articles/virtual-network/virtual-network-multiple-ip-addresses-powershell.md
+++ b/articles/virtual-network/virtual-network-multiple-ip-addresses-powershell.md
@@ -45,7 +45,7 @@ To register for the preview, send an email to [Multiple IPs](mailto:MultipleIPsP
 		Get-AzureRmLocation 	 | Format-Table Location
 		Get-AzureRmResourceGroup | Format-Table ResourceGroupName	
  
-3. <a name="subnet"></a>The NIC must be connected to a subnet within an existing Azure Virtual Network (VNet) in the same location and [subscription](../azure-glossary-cloud-terminology.md#subscription) as the NIC. If you're not familiar with VNets, read the [Virtual network overview](virtual-networks-overview.md) article to learn more about them or read the [Create a VNet](virtual-networks-create-vnet-arm-ps.md) article to learn how to create one. Change the following "values" of the $Variables to the name of the VNet and Subnet you want to connect the NIC to, and the name of the resource group the VNet is in.
+3. <a name="subnet"></a>The NIC must be connected to a subnet within an existing Azure Virtual Network (VNet). The three components: NIC, subnet, and VNet, must all exist in the same region and [subscription](../azure-glossary-cloud-terminology.md#subscription).  If you're not familiar with VNets, read the [Virtual network overview](virtual-networks-overview.md) article to learn more about them or read the [Create a VNet](virtual-networks-create-vnet-arm-ps.md) article to learn how to create one. Change the following "values" of the $Variables to the name of the VNet and Subnet you want to connect the NIC to, and the name of the resource group the VNet is in.
 
 		$VNetName   = "VNet1"
 		$SubnetName = "Subnet1"


### PR DESCRIPTION
When reading this I thought it would be clearer to break into 2 sentences. With the 1st indicating the hig-level operation that a NIC must be associated with a subnet. Then the 2nd that all of the related components must exist in the same Region + Subscription.

From:
The NIC must be connected to a subnet within an existing Azure Virtual Network (VNet) in the same location and [subscription](../azure-glossary-cloud-terminology.md#subscription) as the NIC. 

To:
The NIC must be connected to a subnet within an existing Azure Virtual Network (VNet). The three components: NIC, subnet, and VNet, must all exist in the same region and [subscription](../azure-glossary-cloud-terminology.md#subscription).