### PR TITLE
Default to v4.6.1 in script

### DIFF
--- a/articles/cloud-services/cloud-services-dotnet-install-dotnet.md
+++ b/articles/cloud-services/cloud-services-dotnet-install-dotnet.md
@@ -76,7 +76,7 @@ Startup tasks allow you to perform operations before a role starts. Installing t
 	REM ***** To install .NET 4.6 set the variable netfx to "NDP46" *****
 	REM ***** To install .NET 4.6.1 set the variable netfx to "NDP461" *****
 	REM ***** To install .NET 4.6.2 set the variable netfx to "NDP462" *****
-	set netfx="NDP462"
+	set netfx="NDP461"
 	
 	REM ***** Set script start timestamp *****
 	set timehour=%time:~0,2%


### PR DESCRIPTION
Default to v4.6.1 in script to align with the example in the article.

If this isn't done and you forget to update it the worker will run for hours without finishing.