### PR TITLE
Alternate way to get TenantId using powershell

### DIFF
--- a/articles/service-fabric/service-fabric-cluster-creation-via-arm.md
+++ b/articles/service-fabric/service-fabric-cluster-creation-via-arm.md
@@ -208,9 +208,7 @@ To simplify some of the steps involved in configuring AAD with a Service Fabric 
     .\SetupApplications.ps1 -TenantId '690ec069-8200-4068-9d01-5aaf188e557a' -ClusterName 'mycluster' -WebApplicationReplyUrl 'https://mycluster.westus.cloudapp.azure.com:19080/Explorer/index.html'
     ```
 
-    You can find your **TenantId** by looking at the URL for the tenant in the Azure classic portal. The GUID embedded in that URL is the TenantId. For example:
-
-    https://<i></i>manage.windowsazure.com/microsoft.onmicrosoft.com#Workspaces/ActiveDirectoryExtension/Directory/**690ec069-8200-4068-9d01-5aaf188e557a**/users
+    You can find your **TenantId** by executing the PowerShell command ``Get-AzureSubscription```. This will display the **TenantId** for every subscription.
 
     The **ClusterName** is used to prefix the AAD applications created by the script. It does not need to match the actual cluster name exactly as it is only intended to make it easier for you to map AAD artifacts to the Service Fabric cluster that they're being used with.
 


### PR DESCRIPTION
Using this alternative, the page width isn't exceeded by the long url pointing to the classic portal. Also, the reader is expected to be in PowerShell at the time of reading. Finally, it will display all tenant identifiers.