### PR TITLE
Update limit of VMs per single vNet from 2048 to 4096

### DIFF
--- a/articles/virtual-network/virtual-network-vnet-plan-design-arm.md
+++ b/articles/virtual-network/virtual-network-vnet-plan-design-arm.md
@@ -101,7 +101,7 @@ You should consider creating multiple VNets in the following scenarios:
 
 - **VMs that need to be placed in different Azure locations**. VNets in Azure are regional. They cannot span locations. Therefore you need at least one VNet for each Azure location you want to host VMs in.
 - **Workloads that need to be completely isolated from one another**. You can create separate VNets, that even use the same IP address spaces, to isolate different workloads from one another. 
-- **Avoid platform limits**. As seen in the [limits](#Limits) section, you cannot have more than 2048 VMs in a single VNet. 
+- **Avoid platform limits**. As seen in the [limits](#Limits) section, you cannot have more than 4096 VMs in a single VNet. 
 
 Keep in mind that the limits you see above are per region, per subscription. That means you can use multiple subscriptions to increase the limit of resources you can maintain in Azure. You can use a site-to-site VPN, or an ExpressRoute circuit, to connect VNets in different subscriptions.
 


### PR DESCRIPTION
Update limit of VMs per single vNet from 2048 to 4096 as outlined in the Azure limits website - Private IP Addresses per virtual network.
 https://azure.microsoft.com/en-us/documentation/articles/azure-subscription-service-limits/

Mentions of 4096:
- “Plan for no more than 4096 VMs per VNET.” - https://azure.microsoft.com/en-us/documentation/articles/virtual-machine-scale-sets-overview/

- “Private IP Addresses per virtual network             4096” - https://azure.microsoft.com/en-us/documentation/articles/azure-subscription-service-limits/#networking-limits

- Note, there is no mentioned of 2048 under the Azure Subscription Service limits aside from Job History and Request URL Size.
