### PR TITLE
Added option 'nofail' to fstab

### DIFF
--- a/articles/virtual-machines/virtual-machines-linux-classic-attach-disk.md
+++ b/articles/virtual-machines/virtual-machines-linux-classic-attach-disk.md
@@ -142,11 +142,13 @@ You can attach both empty disks and disks that contain data to your Azure VMs. B
 
 	In this example, we use the UUID value for the new **/dev/sdc1** device that was created in the previous steps, and the mountpoint **/datadrive**. Add the following line to the end of the **/etc/fstab** file:
 
-		UUID=33333333-3b3b-3c3c-3d3d-3e3e3e3e3e3e   /datadrive   ext4   defaults   1   2
+		UUID=33333333-3b3b-3c3c-3d3d-3e3e3e3e3e3e   /datadrive   ext4   defaults,nofail   1   2
 
 	Or, on systems based on SuSE Linux you may need to use a slightly different format:
 
-		/dev/disk/by-uuid/33333333-3b3b-3c3c-3d3d-3e3e3e3e3e3e   /datadrive   ext3   defaults   1   2
+		/dev/disk/by-uuid/33333333-3b3b-3c3c-3d3d-3e3e3e3e3e3e   /datadrive   ext3   defaults,nofail   1   2
+	
+	>[AZURE.NOTE] The option **nofail** ensures that the VM does start even in the case that the filesystem is corrupt or the disk does not exist at boot time. So a manuall intervention may be avoided like described in [Cannot SSH to Linux VM due to FSTAB errors](https://blogs.msdn.microsoft.com/linuxonazure/2016/07/21/cannot-ssh-to-linux-vm-after-adding-data-disk-to-etcfstab-and-rebooting/)
 
 	You can now test that the file system is mounted properly by unmounting and then remounting the file system, i.e. using the example mount point `/datadrive` created in the earlier steps:
 


### PR DESCRIPTION
I added the option 'nofail' to the fstab configuration. This option may help to prevent that a VM gets not started in the case the filesystem is corrupt or the disk is not available at boot time. So this avoids a lot of SR's we see in CSS and the customer is in a better position to repair the disk then. Otherwise it is required to follow a process liek described in this blog https://blogs.msdn.microsoft.com/linuxonazure/2016/07/21/cannot-ssh-to-linux-vm-after-adding-data-disk-to-etcfstab-and-rebooting/