### PR TITLE
Az Auto typo correction

### DIFF
--- a/articles/automation/automation-runbook-execution.md
+++ b/articles/automation/automation-runbook-execution.md
@@ -84,14 +84,17 @@ You can use the following steps to view the jobs for a runbook.
 
 ## Retrieving job status using Windows PowerShell
 
-You can use the [Get-AzureAutomationJob](http://msdn.microsoft.com/library/azure/dn690263.aspx) to retrieve the jobs created for a runbook and the details of a particular job. If you start a runbook with Windows PowerShell using [Start-AzureAutomationRunbook](http://msdn.microsoft.com/library/azure/dn690259.aspx), then it will return the resulting job. Use [Get-AzureAutomationJob](http://msdn.microsoft.com/library/azure/dn690263.aspx)Output to get a job’s output.
+You can use the [Get-AzureAutomationJob](http://msdn.microsoft.com/library/azure/dn690263.aspx) to retrieve the jobs created for a runbook and the details of a particular job. If you start a runbook with Windows PowerShell using [Start-AzureAutomationRunbook](http://msdn.microsoft.com/library/azure/dn690259.aspx), then it will return the resulting job. Use [Get-AzureAutomationJobOutput](https://msdn.microsoft.com/en-us/library/azure/dn690268.aspx) to get a summary of a job’s output. The full output can be obtained with [Get-AzureAutomationJobOutputRecord](https://msdn.microsoft.com/en-us/library/mt643911.aspx) in the Value property of the response.
 
-The following sample commands retrieves the last job for a sample runbook and displays it’s status, the values provide for the runbook parameters, and the output from the job.
+The following sample commands retrieves the last job for a sample runbook and displays its status, the values provided for the runbook parameters, and the output from the job.
 
 	$job = (Get-AzureAutomationJob –AutomationAccountName "MyAutomationAccount" –Name "Test-Runbook" | sort LastModifiedDate –desc)[0]
 	$job.Status
 	$job.JobParameters
-	Get-AzureAutomationJobOutput –AutomationAccountName "MyAutomationAccount" -Id $job.Id –Stream Output
+	$output = Get-AzureAutomationJobOutput –AutomationAccountName "MyAutomationAccount" -Id $job.Id –Stream Output
+	#output summary
+	$output
+	$output | Get-AzureAutomationJobOutputRecord | Select-Object -ExpandProperty Value
 
 ## Fair share
 


### PR DESCRIPTION
- Corrects some typos
- Corrects the link to `Get-AzureAutomationJobOutput` docs
- Adds link to `Get-AzureAutomationJobOutputRecord` docs and example