### PR TITLE
Fix Set-AzureLoadBalancedEndpoint syntax

### DIFF
--- a/articles/load-balancer/load-balancer-distribution-mode.md
+++ b/articles/load-balancer/load-balancer-distribution-mode.md
@@ -77,7 +77,7 @@ If the LoadBalancerDistribution element is not present then the Azure Load balan
 
 If endpoints are part of a load balanced endpoint set, the distribution mode must be set on the load balanced endpoint set:
 
-    Set-AzureLoadBalancedEndpoint -ServiceName MyService -LBSetName LBSet1 -Protocol TCP -LocalPort 80 -ProbeProtocol TCP -ProbePort 8080 –LoadBalancerDistribution sourceIP
+    Set-AzureLoadBalancedEndpoint -ServiceName MyService -LBSetName LBSet1 -Protocol TCP -LocalPort 80 -ProbeProtocolTCP -ProbePort 8080 –LoadBalancerDistribution sourceIP
 
 ### Cloud Service configuration to change distribution mode
 


### PR DESCRIPTION
The correct parameter is ProbeProtocolTCP, according to https://msdn.microsoft.com/en-us/library/azure/dn495126.aspx