### PR TITLE
updated the decrease action in compute rules

### DIFF
--- a/includes/insights-advanced-autoscale-virtual-machine-scale-sets.md
+++ b/includes/insights-advanced-autoscale-virtual-machine-scale-sets.md
@@ -127,7 +127,7 @@ In this walkthrough, we use [Azure Resource Explorer](https://resources.azure.co
 	              "threshold": 60
 	            },
 	            "scaleAction": {
-	              "direction": "Increase",
+	              "direction": "Decrease",
 	              "type": "ChangeCount",
 	              "value": "1",
 	              "cooldown": "PT5M"


### PR DESCRIPTION
the autoscale rule had a bug, wherein both the upper and lower threshold had an action of increase instance count.
Fixing it to show decrease as the action for the lower threshold.