### PR TITLE
Update Lessonly company name

### DIFF
--- a/articles/active-directory/active-directory-saas-lessonly-tutorial.md
+++ b/articles/active-directory/active-directory-saas-lessonly-tutorial.md
@@ -1,6 +1,6 @@
 <properties
-	pageTitle="Tutorial: Azure Active Directory integration with Lesson.ly | Microsoft Azure"
-	description="Learn how to configure single sign-on between Azure Active Directory and Lesson.ly."
+	pageTitle="Tutorial: Azure Active Directory integration with Lessonly | Microsoft Azure"
+	description="Learn how to configure single sign-on between Azure Active Directory and Lessonly."
 	services="active-directory"
 	documentationCenter=""
 	authors="jeevansd"
@@ -17,24 +17,24 @@
 	ms.author="jeedes"/>
 
 
-# Tutorial: Azure Active Directory integration with Lesson.ly
+# Tutorial: Azure Active Directory integration with Lessonly
 
-The objective of this tutorial is to show you how to integrate Lesson.ly with Azure Active Directory (Azure AD).
+The objective of this tutorial is to show you how to integrate Lessonly with Azure Active Directory (Azure AD).
 
-Integrating Lesson.ly with Azure AD provides you with the following benefits:
+Integrating Lessonly with Azure AD provides you with the following benefits:
 
-- You can control in Azure AD who has access to Lesson.ly
-- You can enable your users to automatically get signed-on to Lesson.ly (Single Sign-On) with their Azure AD accounts
+- You can control in Azure AD who has access to Lessonly
+- You can enable your users to automatically get signed-on to Lessonly (Single Sign-On) with their Azure AD accounts
 - You can manage your accounts in one central location - the Azure classic portal
 
 If you want to know more details about SaaS app integration with Azure AD, see [What is application access and single sign-on with Azure Active Directory](active-directory-appssoaccess-whatis.md).
 
 ## Prerequisites
 
-To configure Azure AD integration with Lesson.ly, you need the following items:
+To configure Azure AD integration with Lessonly, you need the following items:
 
 - An Azure AD subscription
-- A Lesson.ly single-sign on enabled subscription
+- A Lessonly single-sign on enabled subscription
 
 
 > [AZURE.NOTE] To test the steps in this tutorial, we do not recommend using a production environment.
@@ -51,14 +51,14 @@ The objective of this tutorial is to enable you to test Azure AD single sign-on 
 
 The scenario outlined in this tutorial consists of two main building blocks:
 
-1. Adding Lesson.ly from the gallery
+1. Adding Lessonly from the gallery
 2. Configuring and testing Azure AD single sign-on
 
 
-## Adding Lesson.ly from the gallery
-To configure the integration of Lesson.ly into Azure AD, you need to add Lesson.ly from the gallery to your list of managed SaaS apps.
+## Adding Lessonly from the gallery
+To configure the integration of Lessonly into Azure AD, you need to add Lessonly from the gallery to your list of managed SaaS apps.
 
-**To add Lesson.ly from the gallery, perform the following steps:**
+**To add Lessonly from the gallery, perform the following steps:**
 
 1. In the **Azure classic portal**, on the left navigation pane, click **Active Directory**. 
 
@@ -78,42 +78,42 @@ To configure the integration of Lesson.ly into Azure AD, you need to add Lesson.
  
 	![Applications][4]
 
-6. In the search box, type **Lesson.ly**.
+6. In the search box, type **Lessonly**.
  
 	![Creating an Azure AD test user](./media/active-directory-saas-lessonly-tutorial/tutorial_lessonly_01.png)
 
-7. In the results pane, select **Lesson.ly**, and then click **Complete** to add the application.
+7. In the results pane, select **Lessonly**, and then click **Complete** to add the application.
 
 
 ![Creating an Azure AD test user](./media/active-directory-saas-lessonly-tutorial/tutorial_lessonly_02.png)
 
 ##  Configuring and testing Azure AD single sign-on
-The objective of this section is to show you how to configure and test Azure AD single sign-on with Lesson.ly based on a test user called "Britta Simon".
+The objective of this section is to show you how to configure and test Azure AD single sign-on with Lessonly based on a test user called "Britta Simon".
 
-For single sign-on to work, Azure AD needs to know what the counterpart user in Lesson.ly to an user in Azure AD is. In other words, a link relationship between an Azure AD user and the related user in Lesson.ly needs to be established.
+For single sign-on to work, Azure AD needs to know what the counterpart user in Lessonly to an user in Azure AD is. In other words, a link relationship between an Azure AD user and the related user in Lessonly needs to be established.
 
-This link relationship is established by assigning the value of the **user name** in Azure AD as the value of the **Username** in Lesson.ly.
+This link relationship is established by assigning the value of the **user name** in Azure AD as the value of the **Username** in Lessonly.
 
-To configure and test Azure AD single sign-on with Lesson.ly, you need to complete the following building blocks:
+To configure and test Azure AD single sign-on with Lessonly, you need to complete the following building blocks:
 
 1. **[Configuring Azure AD Single Sign-On](#configuring-azure-ad-single-single-sign-on)** - to enable your users to use this feature.
 2. **[Creating an Azure AD test user](#creating-an-azure-ad-test-user)** - to test Azure AD single sign-on with Britta Simon.
-4. **[Creating a Lesson.ly test user](#creating-a-Lessonly-test-user)** - to have a counterpart of Britta Simon in Lesson.ly that is linked to the Azure AD representation of her.
+4. **[Creating a Lessonly test user](#creating-a-Lessonly-test-user)** - to have a counterpart of Britta Simon in Lessonly that is linked to the Azure AD representation of her.
 5. **[Assigning the Azure AD test user](#assigning-the-azure-ad-test-user)** - to enable Britta Simon to use Azure AD single sign-on.
 5. **[Testing Single Sign-On](#testing-single-sign-on)** - to verify whether the configuration works.
 
 ### Configuring Azure AD Single Sign-On
 
-The objective of this section is to outline how to enable users to authenticate to Lesson.ly with their account in Azure AD using federation based on the SAML protocol.
+The objective of this section is to outline how to enable users to authenticate to Lessonly with their account in Azure AD using federation based on the SAML protocol.
 
-Your Lesson.ly application expects the SAML assertions in a specific format, which requires you to add custom attribute mappings to your **saml token attributes** configuration.
+Your Lessonly application expects the SAML assertions in a specific format, which requires you to add custom attribute mappings to your **saml token attributes** configuration.
 The following screenshot shows an example for this.
 
 ![Configure Single Sign-On](./media/active-directory-saas-lessonly-tutorial/tutorial_lessonly_06.png) 
 
-**To configure Azure AD single sign-on with Lesson.ly, perform the following steps:**
+**To configure Azure AD single sign-on with Lessonly, perform the following steps:**
 
-1. In the Azure classic portal, on the Lesson.ly application integration page, in the menu on the top, click **Attributes** to open the **SAML Token Attributes** dialog.
+1. In the Azure classic portal, on the Lessonly application integration page, in the menu on the top, click **Attributes** to open the **SAML Token Attributes** dialog.
 
 	![Configure Single Sign-On](./media/active-directory-saas-lessonly-tutorial/tutorial_lessonly_07.png) 
 
@@ -137,7 +137,7 @@ The following screenshot shows an example for this.
 
 	![Configure Single Sign-On][6] 
 
-6. On the **How would you like users to sign on to Lesson.ly** page, select **Azure AD Single Sign-On**, and then click **Next**.
+6. On the **How would you like users to sign on to Lessonly** page, select **Azure AD Single Sign-On**, and then click **Next**.
 
 	![Configure Single Sign-On](./media/active-directory-saas-lessonly-tutorial/tutorial_lessonly_03.png) 
 
@@ -146,10 +146,10 @@ The following screenshot shows an example for this.
 	![Configure Single Sign-On](./media/active-directory-saas-lessonly-tutorial/tutorial_lessonly_04.png) 
 
 
-    a. In the Sign On URL textbox, type the URL used by your users to sign-on to your Lesson.ly application using the following pattern: **“https://companyname.Lesson.ly/signin”**. When referencing a generic name that **companyname** needs to be replaced by an actual name.
+    a. In the Sign On URL textbox, type the URL used by your users to sign-on to your Lessonly application using the following pattern: **“https://companyname.lesson.ly/signin”**. When referencing a generic name that **companyname** needs to be replaced by an actual name.
 
 
-8. On the **Configure single sign-on at Lesson.ly** page, perform the following steps:
+8. On the **Configure single sign-on at Lessonly** page, perform the following steps:
 
 	![Configure Single Sign-On](./media/active-directory-saas-lessonly-tutorial/tutorial_lessonly_05.png) 
 
@@ -158,7 +158,7 @@ The following screenshot shows an example for this.
     b. Click **Next**.
 
 
-9. To get SSO configured for your application, contact your Lesson.ly support team via dev@lesson.ly. Attach the downloaded certificate file to your mail and share the metadata urls (Entity ID, SSO Sign in URL and Sign Out URL) with Lesson.ly team to set up SSO on their side.
+9. To get SSO configured for your application, contact your Lessonly support team via dev@lessonly.com. Attach the downloaded certificate file to your mail and share the metadata urls (Entity ID, SSO Sign in URL and Sign Out URL) with Lessonly team to set up SSO on their side.
 
 
 10. In the Azure classic portal, select the single sign-on configuration confirmation, and then click **Next**.
@@ -232,28 +232,28 @@ The objective of this section is to create a test user in the Azure classic port
 
 
 
-### Creating a Lesson.ly test user
+### Creating a Lessonly test user
 
-The objective of this section is to create a user called Britta Simon in Lesson.ly. Lesson.ly supports just-in-time provisioning, which is by default enabled.
+The objective of this section is to create a user called Britta Simon in Lessonly. Lessonly supports just-in-time provisioning, which is by default enabled.
 
-There is no action item for you in this section. A new user will be created during an attempt to access Lesson.ly if it doesn't exist yet. [Configuring Azure AD Single Sign-On](#configuring-azure-ad-single-single-sign-on).
+There is no action item for you in this section. A new user will be created during an attempt to access Lessonly if it doesn't exist yet. [Configuring Azure AD Single Sign-On](#configuring-azure-ad-single-single-sign-on).
 
-> [AZURE.NOTE] If you need to create an user manually, you need to contact the Lesson.ly support team.
+> [AZURE.NOTE] If you need to create an user manually, you need to contact the Lessonly support team.
 
 
 ### Assigning the Azure AD test user
 
-The objective of this section is to enabling Britta Simon to use Azure single sign-on by granting her access to Lesson.ly.
+The objective of this section is to enabling Britta Simon to use Azure single sign-on by granting her access to Lessonly.
 
 ![Assign User][200] 
 
-**To assign Britta Simon to Lesson.ly, perform the following steps:**
+**To assign Britta Simon to Lessonly, perform the following steps:**
 
 1. On the Azure classic portal, to open the applications view, in the directory view, click **Applications** in the top menu.
 
 	![Assign User][201] 
 
-2. In the applications list, select **Lesson.ly**.
+2. In the applications list, select **Lessonly**.
 
 	![Configure Single Sign-On](./media/active-directory-saas-lessonly-tutorial/tutorial_lessonly_50.png) 
 
@@ -273,7 +273,7 @@ The objective of this section is to enabling Britta Simon to use Azure single si
 
 The objective of this section is to test your Azure AD single sign-on configuration using the Access Panel.
 
-When you click the Lesson.ly tile in the Access Panel, you should get automatically signed-on to your Lesson.ly application.
+When you click the Lessonly tile in the Access Panel, you should get automatically signed-on to your Lessonly application.
 
 
 ## Additional Resources


### PR DESCRIPTION
Lessonly has recently removed the dot from their name, going from "Lesson.ly" to "Lessonly".

Also, updated support email address.