### PR TITLE
minor fix (name convention and restriction) Virtual Network (vnet) name limit

### DIFF
--- a/articles/guidance/guidance-naming-conventions.md
+++ b/articles/guidance/guidance-naming-conventions.md
@@ -118,7 +118,7 @@ In general, avoid having any special characters (`-` or `_`) as the first or las
 | Storage | Queue name | Storage account | 3-63 | Lower case | Alphanumeric and dash | `<service short name>-<context>-<num>` | `awesomeservice-messages-001` |
 | Storage | Table name | Storage account | 3-63 |Case insensitive | Alphanumeric | `<service short name>-<context>` | `awesomeservice-logs` |
 | Storage | File name | Storage account | 3-63 | Lower case | Alphanumeric | `<variable based on blob usage>` | `<variable based on blob usage>` |
-| Networking | Virtual Network (VNet) | Resource Group | 2-80 | Case-insensitive | Alphanumeric, dash, underscore, and period | `<service short name>-[section]-vnet` | `profx-vnet` |
+| Networking | Virtual Network (VNet) | Resource Group | 2-64 | Case-insensitive | Alphanumeric, dash, underscore, and period | `<service short name>-[section]-vnet` | `profx-vnet` |
 | Networking | Subnet | Parent VNet | 2-80 | Case-insensitive | Alphanumeric, underscore, dash, and period | `<role>-subnet` | `gateway-subnet` |
 | Networking | Network Interface | Resource Group | 1-80 | Case-insensitive | Alphanumeric, dash, underscore, and period | `<vmname>-<num>nic` | `profx-sql1-1nic` |
 | Networking | Network Security Group | Resource Group | 1-80 | Case-insensitive | Alphanumeric, dash, underscore, and period | `<service short name>-<context>-nsg` | `profx-app-nsg` |


### PR DESCRIPTION
The documentation for Azure Virtual Network name restriction (between 2 and 80) does not match the limits on the Azure Portal ( max 64). See screenshot: 

![selection_101](https://cloud.githubusercontent.com/assets/1086433/19758950/fa4d4064-9c2a-11e6-8b2b-66afc7f2ac9d.png)
