### PR TITLE
Moved order of sort in Dedup example

### DIFF
--- a/articles/log-analytics/log-analytics-search-reference.md
+++ b/articles/log-analytics/log-analytics-search-reference.md
@@ -600,7 +600,7 @@ Returns the first document found for every unique value of the given field.
 
 **Example**
 
-	Type=Event | sort TimeGenerated DESC | Dedup EventID
+	Type=Event | Dedup EventID | sort TimeGenerated DESC
 
 The above example returns one  event  (the latest since we use DESC on TimeGenerated) per EventID
 


### PR DESCRIPTION
This in preparation for upcoming improvements to the Dedup command, having the sort after will make more sense when using the enhanced dedup command.