### PR TITLE
Update tag expression limit in documentation

### DIFF
--- a/articles/notification-hubs/notification-hubs-tags-segment-push-message.md
+++ b/articles/notification-hubs/notification-hubs-tags-segment-push-message.md
@@ -94,7 +94,7 @@ Consider a sports application that sends a reminder to everyone in Boston about 
 
 ![](./media/notification-hubs-routing-tag-expressions/notification-hubs-tags4.png)
 
-Tag expressions can contain all Boolean operators, such as AND (&&), OR (||), and NOT (!). They can also contain parentheses. Tag expressions are limited to 20 tags if they contain only ORs; otherwise they are limited to 6 tags.
+Tag expressions can contain all Boolean operators, such as AND (&&), OR (||), and NOT (!). They can also contain parentheses. Tag expressions are limited to 20 tags if they contain only ORs; otherwise they are limited to 10 tags.
 
 Here's an example for sending notifications with tag expressions using the SDK.
 


### PR DESCRIPTION
According to this: https://feedback.azure.com/forums/218849-notification-hubs/suggestions/12880704-increase-tag-limit-expression
I think that limit is now 10, right?