### PR TITLE
Adding newer way for returning a completed task

### DIFF
--- a/articles/event-hubs/event-hubs-api-overview.md
+++ b/articles/event-hubs/event-hubs-api-overview.md
@@ -150,6 +150,7 @@ public class SimpleEventProcessor : IEventProcessor
         this.partitionContext = context;
 
         return Task.FromResult<object>(null);
+        // return Task.CompletedTask; // from .Net 4.6
     }
 
     public async Task ProcessEventsAsync(PartitionContext context, IEnumerable<EventData> messages)


### PR DESCRIPTION
In OpenAsync() call of SimpleEventProcessor, an empty completed task is returned using Task.FromResult<object>(null).

It would rather be cleaner to return Task.CompletedTask, which is self-descriptive as well. But it's only available from .Net 4.6, so commenting out for the user to use as needed.