### PR TITLE
Remove "PM>" prefix

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-devquickstarts-web-dotnet.md
+++ b/articles/active-directory-b2c/active-directory-b2c-devquickstarts-web-dotnet.md
@@ -70,9 +70,9 @@ Your app communicates with Azure AD B2C by sending authentication messages that 
 To begin, add the OWIN middleware NuGet packages to the project by using the Visual Studio Package Manager Console.
 
 ```
-PM> Install-Package Microsoft.Owin.Security.OpenIdConnect
-PM> Install-Package Microsoft.Owin.Security.Cookies
-PM> Install-Package Microsoft.Owin.Host.SystemWeb
+Install-Package Microsoft.Owin.Security.OpenIdConnect
+Install-Package Microsoft.Owin.Security.Cookies
+Install-Package Microsoft.Owin.Host.SystemWeb
 ```
 
 Next, open the `web.config` file in the root of the project and enter your app's configuration values in the `<appSettings>` section, replacing the existing values.


### PR DESCRIPTION
Copying the text to your clipboard and pasting it to the package manager console forces the NuGet installation process to fail.