### PR TITLE
Updated docs to reflect change in repo structure

### DIFF
--- a/articles/service-fabric/service-fabric-cluster-creation-via-arm.md
+++ b/articles/service-fabric/service-fabric-cluster-creation-via-arm.md
@@ -239,7 +239,7 @@ Sample Resource Manager templates are available in the [Azure quick-start templa
 
 ### Create the Resource Manager template
 
-This guide uses the [5-node secure cluster][service-fabric-secure-cluster-5-node-1-nodetype-wad] example template and template parameters. Download `azuredeploy.json` and `azuredeploy.parameters.json` to your computer and open both files in your favorite text editor.
+This guide uses the [5-node secure cluster][service-fabric-secure-cluster-5-node-1-nodetype] example template and template parameters. Download `azuredeploy.json` and `azuredeploy.parameters.json` to your computer and open both files in your favorite text editor.
 
 ### Add certificates
 


### PR DESCRIPTION
https://github.com/Azure/azure-quickstart-templates/tree/master/service-fabric-secure-cluster-5-node-1-nodetype-wad 
doesn't exist anymore. Content can now be found at:
https://github.com/Azure/azure-quickstart-templates/tree/master/service-fabric-secure-cluster-5-node-1-nodetype
, apparently.